### PR TITLE
ci: update Sonar scanning procedure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel: false
+  AfterCaseLabel: true
   AfterClass: true
   AfterControlStatement: Always
   AfterEnum: true
@@ -33,7 +33,7 @@ BraceWrapping:
   AfterNamespace: true
   AfterObjCDeclaration: true
   AfterStruct: true
-  AfterUnion: false
+  AfterUnion: true
   AfterExternBlock: true
   BeforeCatch: true
   BeforeElse: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ matrix.gcc }}-${{ matrix.configuration }}
       - run: |
           echo "::add-matcher::.github/matchers/gcc-problem-matcher.json"
-          cmake --preset Host -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --preset Host -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset Host-${{ matrix.configuration }}
-          cmake --preset Embedded -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --preset Embedded -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset Embedded-${{ matrix.configuration }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,12 +34,10 @@ jobs:
           echo "${PWD}/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> "$GITHUB_PATH"
       - uses: hendrikmuhs/ccache-action@621a41397ed83711c72862638d9ff6e63fca3041
       - name: Build & Collect Coverage
-        env:
-          GTEST_OUTPUT: "xml:${PWD}/testresults/"
         run: |
           cmake --preset Coverage -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset Coverage
-          ctest --preset Coverage
+          GTEST_OUTPUT="xml:${PWD}/testresults/" ctest --preset Coverage
           gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j 2 --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
       - name: Convert Results
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       SONAR_SCANNER_VERSION: 4.7.0.2747
       SONAR_SERVER_URL: "https://sonarcloud.io"
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
@@ -29,26 +28,25 @@ jobs:
         with:
           packages: gcovr==5.0
       - name: Install Sonar Scanner
-        env:
-          SONAR_SCANNER_URL: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip
-          SONAR_WRAPPER_URL: ${{ env.SONAR_SERVER_URL }}/static/cpp/build-wrapper-linux-x86.zip
         run: |
-          wget -qN "${{ env.SONAR_WRAPPER_URL }}"
-          wget -qN "${{ env.SONAR_SCANNER_URL }}"
-          unzip -qqo build-wrapper-linux-x86.zip
+          wget -qN "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip"
           unzip -qqo "sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip"
-          echo "${PWD}/build-wrapper-linux-x86" >> "$GITHUB_PATH"
           echo "${PWD}/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> "$GITHUB_PATH"
       - uses: hendrikmuhs/ccache-action@621a41397ed83711c72862638d9ff6e63fca3041
-      - name: Build
+      - name: Build & Collect Coverage
+        env:
+          GTEST_OUTPUT: "xml:${PWD}/testresults/"
         run: |
-          sudo apt-get update && sudo apt-get install --no-install-recommends -y xsltproc
-          cmake --preset Coverage -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build --preset Coverage
-          GTEST_OUTPUT="xml:${PWD}/testresults/" ctest --preset Coverage
-          { echo '<testExecutions version="1">'; xsltproc .github/formatters/gtest-to-generic-execution.xslt testresults/*.xml; echo '</testExecutions>'; } | tee execution.xml > /dev/null
+          cmake --preset Coverage -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build --preset Coverage
+          ctest --preset Coverage
           gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j 2 --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
-      - name: Analysis
+      - name: Convert Results
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -y xsltproc jq
+          { echo '<testExecutions version="1">'; xsltproc .github/formatters/gtest-to-generic-execution.xslt testresults/*.xml; echo '</testExecutions>'; } | tee execution.xml > /dev/null
+          cp Build/Coverage/compile_commands.json compile_commands.json
+      - name: Run Analysis
         # skip the analysis step for dependabot PRs since dependabot does not have access to secrets
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:
@@ -58,7 +56,7 @@ jobs:
         run: |
           SONAR_PROJECT_VERSION=$(grep -m 1 -o '".*"' Build/Coverage/*/generated/[Vv]ersion.h | tr -d '"')
           export SONAR_PROJECT_VERSION
-          sonar-scanner -D sonar.host.url="${{ env.SONAR_SERVER_URL }}" -D sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner -D sonar.host.url="${{ env.SONAR_SERVER_URL }}"
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
@@ -75,7 +73,7 @@ jobs:
         with:
           languages: cpp
       - run: |
-          cmake --preset ContinuousIntegration -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --preset ContinuousIntegration -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset ContinuousIntegration
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cc7986c02bac29104a72998e67239bb5ee2ee110

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "cmake.copyCompileCommands": "${workspaceFolder}/Build/compile_commands.json",
-  "sonarlint.pathToCompileCommands": "${workspaceFolder}/Build/compile_commands.json"
+  "sonarlint.pathToCompileCommands": "${workspaceFolder}/Build/compile_commands.json",
+  "C_Cpp.autoAddFileAssociations": false
 }

--- a/infra/syntax/Json.cpp
+++ b/infra/syntax/Json.cpp
@@ -52,7 +52,8 @@ namespace infra
                     return '\r';
                 case 't':
                     return '\t';
-                case 'u': {
+                case 'u':
+                {
                     char result = 0;
 
                     for (int skipCode = 0; skipCode != 4 && next != end; ++skipCode, ++next)

--- a/services/network/NameResolverCache.cpp
+++ b/services/network/NameResolverCache.cpp
@@ -60,7 +60,8 @@ namespace services
 
     std::array<uint8_t, 16> NameResolverCache::Hash(infra::BoundedConstString name) const
     {
-        union {
+        union
+        {
             struct
             {
                 std::array<uint8_t, 16> first;

--- a/services/tracer/TracerAdapterPrintf.cpp
+++ b/services/tracer/TracerAdapterPrintf.cpp
@@ -82,7 +82,8 @@ namespace services
             case 'c':
                 tracer.Continue() << static_cast<const char>(va_arg(*args, int32_t));
                 break;
-            case 's': {
+            case 's':
+            {
                 auto* s = va_arg(*args, char*);
                 tracer.Continue() << (s != nullptr ? s : "(null)");
                 break;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,15 +4,16 @@ sonar.organization=philips-software
 sonar.projectName=embeddedinfralib
 sonar.projectVersion=${env.SONAR_PROJECT_VERSION}
 
-sonar.links.homepage=https://github.com/philips-software/embeddedinfralib
-sonar.links.ci=https://github.com/philips-software/embeddedinfralib/actions
-sonar.links.issue=https://github.com/philips-software/embeddedinfralib/issues
-sonar.links.scm=https://github.com/philips-software/embeddedinfralib.git
+sonar.links.homepage=https://github.com/philips-software/amp-embedded-infra-lib
+sonar.links.ci=https://github.com/philips-software/amp-embedded-infra-lib/actions
+sonar.links.issue=https://github.com/philips-software/amp-embedded-infra-lib/issues
+sonar.links.scm=https://github.com/philips-software/amp-embedded-infra-lib.git
 
 sonar.sources=hal,infra,lwip/lwip_cpp,protobuf,services,upgrade
 sonar.tests=hal,infra,protobuf,services,upgrade
 sonar.test.inclusions=**/test/*,**/test_doubles/*
 
+sonar.cfamily.compile-commands=compile_commands.json
 sonar.cfamily.cache.enabled=false
 sonar.cfamily.threads=2
 


### PR DESCRIPTION
* Don't use build-wrapper but use the compilation database as scanner input
* Separate out the step to convert from different sources to Sonar input