### PR TITLE
fix: pin version of base image to sha of ubuntu:20.04

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu@sha256:4b1d0c4a2d2aaf63b37111f34eb9fa89fa1bf53dd6e4ca954d47caebca4005c2
+FROM ubuntu@sha256:450e066588f42ebe1551f3b1a535034b6aa46cd936fe7f2c6b0d72997ec61dbd
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This change restores compatibility between the base image and the packages being nstalled. The list of packages is compatible with the base image of 20.04 but the modified sha256 is for ubuntu:latest.

This leads to incompatibilities that prevent the image from being built.