### PR TITLE
build(cmake/emil_xsltproc.cmake): download dependencies of xsltproc

### DIFF
--- a/cmake/emil_xsltproc.cmake
+++ b/cmake/emil_xsltproc.cmake
@@ -1,12 +1,17 @@
 function(emil_fetch_xsltproc)
-    if (CMAKE_HOST_WIN32 AND NOT EMIL_XSLTPROC_PATH)
-        FetchContent_Declare(xsltproc
-            URL https://www.zlatkovic.com/pub/libxml/libxslt-1.1.26.win32.zip
-        )
-
-        FetchContent_MakeAvailable(xsltproc)
+    if (CMAKE_HOST_WIN32)
+        FetchContent_Declare(xsltproc URL https://www.zlatkovic.com/pub/libxml/libxslt-1.1.26.win32.zip)
+        FetchContent_Declare(libxml2 URL https://www.zlatkovic.com/pub/libxml/libxml2-2.7.8.win32.zip)
+        FetchContent_Declare(iconv URL https://www.zlatkovic.com/pub/libxml/iconv-1.9.2.win32.zip)
+        FetchContent_Declare(zlib URL https://www.zlatkovic.com/pub/libxml/zlib-1.2.5.win32.zip)
+        FetchContent_MakeAvailable(xsltproc libxml2 iconv zlib)
 
         set(EMIL_XSLTPROC_PATH "${xsltproc_SOURCE_DIR}/bin/" CACHE INTERNAL "")
+
+        set(path "$ENV{PATH}")
+        list(APPEND path "${libxml2_SOURCE_DIR}/bin" "${iconv_SOURCE_DIR}/bin" "${zlib_SOURCE_DIR}/bin")
+        string(REPLACE ";" "\\;" path "${path}")
+        set(EMIL_PATH_FOR_XSLTPROC "${path}" CACHE INTERNAL "")
     endif()
 endfunction()
 
@@ -44,12 +49,21 @@ function(generate_xslt target output)
         HINTS ${EMIL_XSLTPROC_PATH}
     )
 
-    add_custom_command(
-        OUTPUT ${absolute_output}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${absolute_directory}
-        COMMAND ${xsltproc_program} ${xslt_params} --output "${absolute_output}" ${absolute_inputs}
-        DEPENDS ${absolute_inputs}
-    )
+    if (EMIL_PATH_FOR_XSLTPROC)
+        add_custom_command(
+            OUTPUT ${absolute_output}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${absolute_directory}
+            COMMAND ${CMAKE_COMMAND} -E env PATH=${EMIL_PATH_FOR_XSLTPROC} ${xsltproc_program} ${xslt_params} --output "${absolute_output}" ${absolute_inputs}
+            DEPENDS ${absolute_inputs}
+        )
+    else()
+        add_custom_command(
+            OUTPUT ${absolute_output}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${absolute_directory}
+            COMMAND ${xsltproc_program} ${xslt_params} --output "${absolute_output}" ${absolute_inputs}
+            DEPENDS ${absolute_inputs}
+        )
+    endif()
 
     target_sources(${target} PRIVATE ${absolute_inputs})
 endfunction()


### PR DESCRIPTION
Download dependencies of xsltproc (libxml2, iconv and zlib) for Windows hosts and add to PATH if necessary.