### PR TITLE
ci!: Replaced mull-ir-frontend-12 with mull-ir-frontend

### DIFF
--- a/cmake/emil_test_helpers.cmake
+++ b/cmake/emil_test_helpers.cmake
@@ -34,10 +34,19 @@ function(emil_enable_testing)
 
     if (EMIL_ENABLE_MUTATION_TESTING)
         if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-            add_compile_options(
-                -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
-                -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend-12
-            )
+            execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
+
+            if(CLANG_VERSION VERSION_GREATER 15.0 OR CLANG_VERSION VERSION_EQUAL 15.0)
+                add_compile_options(
+                    -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
+                    -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend
+                )
+            else()
+                add_compile_options(
+                    -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
+                    -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend-12
+                )
+            endif()
 
             add_link_options(-fprofile-instr-generate)
         else()


### PR DESCRIPTION
amp-devcontainer has been updated to only supply clang-15. The mutation test function in embedded infra lib still relies on clang-12.

This update resolves this issue by dropping the `-12` when clang-15 is detected