### PR TITLE
ci: enable merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 permissions:
   contents: read
@@ -55,7 +56,7 @@ jobs:
           ]
         configuration: ["RelWithDebInfo", "Release"]
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           persist-credentials: false
       - name: Install GNU Arm Embedded Toolchain ${{ matrix.gcc }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,7 @@ name: Build & Publish Documentation
 
 on:
   push:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/fuzzing-pr.yml
+++ b/.github/workflows/fuzzing-pr.yml
@@ -4,6 +4,7 @@ name: Pull-Request Fuzzing
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/linting-formatting.yml
+++ b/.github/workflows/linting-formatting.yml
@@ -6,6 +6,7 @@ on:
     branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,6 +6,7 @@ on:
     branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR enables the merge_group trigger for relevant ci-tasks necessary to enable the merge queue feature.