### PR TITLE
ci: enable sonarcloud server-side cache

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.tests=hal,infra,protobuf,services,upgrade
 sonar.test.inclusions=**/test/*,**/test_doubles/*
 
 sonar.cfamily.compile-commands=compile_commands.json
-sonar.cfamily.cache.enabled=false
 sonar.cfamily.threads=2
 
 sonar.externalIssuesReportPaths=mutation-sonar.json


### PR DESCRIPTION
As per https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache the server-side cache is now supported on SonarCloud. This change enables that cache by-default and removes an analysis warning in the web-ui.