### PR TITLE
ci: add Docker package ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Our repository contains Dockefiles; make sure that they are kept up-to-date automatically.