### PR TITLE
ci: add workflow to check PR conventions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,5 +57,6 @@ jobs:
           buildPreset: "Package"
           configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
       - run: gh release upload ${{ needs.release_please.outputs.tag_name }} Build/**/emil-*.zip --clobber
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,16 @@
+---
+name: Validate Pull-Request
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  conventional_commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Namchee/conventional-pr@d5139479d879132c4b7a97cf56b5aae285b80d77 # v0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: Namchee/conventional-pr@d5139479d879132c4b7a97cf56b5aae285b80d77 # v0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
+          body: false
+          issue: false


### PR DESCRIPTION
Add a workflow that validates if pull-requests adhere to conventional commits. This is necessary for correct operation of the automated release workflow.