### PR TITLE
refactor: improve how PATH is set in custom commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(EMIL_STANDALONE On)
 endif()
 
+if (MINGW)
+    # When compiling with MINGW, dynamically linking to the standard C++ library results in linking to libstdc++-6.dll.
+    # The libstdc++-6.dll found during runtime is often different than the one with which the application is compiled with,
+    # so instead of linking dynamically, we statically link to the standard C++ library.
+    add_link_options("-static-libstdc++")
+endif()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(EMIL_BUILD_WIN On)
     set(EMIL_HOST_BUILD On)

--- a/cmake/emil_xsltproc.cmake
+++ b/cmake/emil_xsltproc.cmake
@@ -7,11 +7,7 @@ function(emil_fetch_xsltproc)
         FetchContent_MakeAvailable(xsltproc libxml2 iconv zlib)
 
         set(EMIL_XSLTPROC_PATH "${xsltproc_SOURCE_DIR}/bin/" CACHE INTERNAL "")
-
-        set(path "$ENV{PATH}")
-        list(APPEND path "${libxml2_SOURCE_DIR}/bin" "${iconv_SOURCE_DIR}/bin" "${zlib_SOURCE_DIR}/bin")
-        string(REPLACE ";" "\\;" path "${path}")
-        set(EMIL_PATH_FOR_XSLTPROC "${path}" CACHE INTERNAL "")
+        set(EMIL_PATH_FOR_XSLTPROC "${libxml2_SOURCE_DIR}/bin;${iconv_SOURCE_DIR}/bin;${zlib_SOURCE_DIR}/bin" CACHE INTERNAL "")
     endif()
 endfunction()
 
@@ -53,7 +49,7 @@ function(generate_xslt target output)
         add_custom_command(
             OUTPUT ${absolute_output}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${absolute_directory}
-            COMMAND ${CMAKE_COMMAND} -E env PATH=${EMIL_PATH_FOR_XSLTPROC} ${xsltproc_program} ${xslt_params} --output "${absolute_output}" ${absolute_inputs}
+            COMMAND ${CMAKE_COMMAND} -E env "PATH=$<SHELL_PATH:$ENV{PATH};${EMIL_PATH_FOR_XSLTPROC}>>" ${xsltproc_program} ${xslt_params} --output "${absolute_output}" ${absolute_inputs}
             DEPENDS ${absolute_inputs}
         )
     else()


### PR DESCRIPTION
The hacky way that PATH is extended with library has now been improved. There were still issues when building with Embedded Infralib as a dependency of other projects, which have now been solved.