### PR TITLE
ci: fix SonarQube finding cpp:S1044

### DIFF
--- a/protobuf/echo_console/Main.cpp
+++ b/protobuf/echo_console/Main.cpp
@@ -135,7 +135,7 @@ void ConsoleClientConnection::DataReceived()
             services::ConnectionObserver::Subject().AckReceived();
         }
     }
-    catch (application::Console::IncompletePacket)
+    catch (application::Console::IncompletePacket&)
     {}
 }
 


### PR DESCRIPTION
cpp:S1044 Exception classes should be caught by reference