### PR TITLE
ci: reduce duplicate workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,6 @@
 name: Build & Publish Documentation
 
 on:
-  push:
   merge_group:
 
 permissions:

--- a/.github/workflows/fuzzing-pr.yml
+++ b/.github/workflows/fuzzing-pr.yml
@@ -4,7 +4,6 @@ name: Pull-Request Fuzzing
 on:
   workflow_dispatch:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/linting-formatting.yml
+++ b/.github/workflows/linting-formatting.yml
@@ -2,8 +2,6 @@
 name: Linting & Formatting
 
 on:
-  push:
-    branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,7 +6,6 @@ on:
     branches: [develop, modern-cmake]
   pull_request:
     types: [opened, synchronize, reopened]
-  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Now that we use the merge queue, workflow events are sometimes ran multiple times. One for the merge event and one for the push event. This PR tries to address that by running on either push or merge events.