### PR TITLE
build: add clang x86_64 Windows toolchain file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache/
 .vs/
+.xwin-cache/
 build/
 install/
 megalinter-reports/

--- a/cmake/toolchain-x86_64-pc-windows-msvc.cmake
+++ b/cmake/toolchain-x86_64-pc-windows-msvc.cmake
@@ -4,7 +4,7 @@
 # The recommended way of installing the SDK and CRT is by using xwin (https://github.com/Jake-Shadle/xwin):
 # $ xwin --accept-license splat --preserve-ms-arch-notation
 #
-# xwin patches the SDK and CRT for case-sensitive filesystems; the --presere-ms-arch-notation is
+# xwin patches the SDK and CRT for case-sensitive filesystems; the --preserve-ms-arch-notation is
 # necessary to make the /winsdkdir and /vctoolsdir options of clang work.
 
 set(CMAKE_SYSTEM_NAME Windows)

--- a/cmake/toolchain-x86_64-pc-windows-msvc.cmake
+++ b/cmake/toolchain-x86_64-pc-windows-msvc.cmake
@@ -1,0 +1,22 @@
+# This toolchain file enables cross-compilation from non-Windows hosts to Windows hosts.
+# It assumes the Windows SDK and CRT are installed at a path specified by WINDOWS_SDK_ROOT.
+#
+# The recommended way of installing the SDK and CRT is by using xwin (https://github.com/Jake-Shadle/xwin):
+# $ xwin --accept-license splat --preserve-ms-arch-notation
+#
+# xwin patches the SDK and CRT for case-sensitive filesystems; the --presere-ms-arch-notation is
+# necessary to make the /winsdkdir and /vctoolsdir options of clang work.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
+
+set(WINDOWS_SDK_ROOT "/winsdk" CACHE PATH "Path to a Windows SDK and CRT installation")
+
+find_program(CMAKE_C_COMPILER NAMES clang-cl REQUIRED)
+find_program(CMAKE_CXX_COMPILER NAMES clang-cl REQUIRED)
+find_program(CMAKE_AR NAMES llvm-lib REQUIRED)
+
+add_compile_options(--target=x86_64-pc-windows-msvc -Wno-error -fuse-ld=lld /winsdkdir ${WINDOWS_SDK_ROOT}/sdk /vctoolsdir ${WINDOWS_SDK_ROOT}/crt)
+add_link_options(/manifest:no -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/um/x64 -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/ucrt/x64 -libpath:${WINDOWS_SDK_ROOT}/crt/lib/x64)


### PR DESCRIPTION
This PR adds support for cross-compilation from non-Windows hosts to Windows hosts.
It assumes the Windows SDK and CRT are installed at a path specified by WINDOWS_SDK_ROOT.

The recommended way of installing the SDK and CRT is by using xwin (https://github.com/Jake-Shadle/xwin):
`$ xwin --accept-license splat --preserve-ms-arch-notation`

xwin patches the SDK and CRT for case-sensitive filesystems; the --presere-ms-arch-notation is
necessary to make the /winsdkdir and /vctoolsdir options of clang work.