### PR TITLE
build: refactor CMakeLists files to use emil_build_for

### DIFF
--- a/hal/generic/CMakeLists.txt
+++ b/hal/generic/CMakeLists.txt
@@ -1,22 +1,21 @@
-if (EMIL_HOST_BUILD)
-    add_library(hal.generic ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(hal.generic STATIC)
+emil_build_for(hal.generic HOST Windows PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_link_libraries(hal.generic PUBLIC
-        hal.interfaces
-        hal.synchronous_interfaces
-        $<$<OR:$<BOOL:${EMIL_BUILD_UNIX}>,$<BOOL:${EMIL_BUILD_DARWIN}>>:pthread>
-    )
+target_link_libraries(hal.generic PUBLIC
+    hal.interfaces
+    hal.synchronous_interfaces
+    $<$<OR:$<BOOL:${EMIL_BUILD_UNIX}>,$<BOOL:${EMIL_BUILD_DARWIN}>>:pthread>
+)
 
-    target_sources(hal.generic PRIVATE
-        FileSystemGeneric.cpp
-        FileSystemGeneric.hpp
-        SerialCommunicationConsole.cpp
-        SerialCommunicationConsole.hpp
-        SynchronousRandomDataGeneratorGeneric.cpp
-        SynchronousRandomDataGeneratorGeneric.hpp
-        TimeKeeperGeneric.cpp
-        TimeKeeperGeneric.hpp
-        TimerServiceGeneric.cpp
-        TimerServiceGeneric.hpp
-    )
-endif()
+target_sources(hal.generic PRIVATE
+    FileSystemGeneric.cpp
+    FileSystemGeneric.hpp
+    SerialCommunicationConsole.cpp
+    SerialCommunicationConsole.hpp
+    SynchronousRandomDataGeneratorGeneric.cpp
+    SynchronousRandomDataGeneratorGeneric.hpp
+    TimeKeeperGeneric.cpp
+    TimeKeeperGeneric.hpp
+    TimerServiceGeneric.cpp
+    TimerServiceGeneric.hpp
+)

--- a/hal/interfaces/CMakeLists.txt
+++ b/hal/interfaces/CMakeLists.txt
@@ -47,10 +47,5 @@ target_sources(hal.interfaces PRIVATE
     $<$<BOOL:${EMIL_HOST_BUILD}>:FileSystem.hpp>
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/hal/interfaces/test/CMakeLists.txt
+++ b/hal/interfaces/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(hal.interfaces_test)
-emil_build_for(hal.interfaces_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(hal.interfaces_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.interfaces_test)
 
 target_link_libraries(hal.interfaces_test PUBLIC

--- a/hal/interfaces/test/CMakeLists.txt
+++ b/hal/interfaces/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(hal.interfaces_test)
+emil_build_for(hal.interfaces_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.interfaces_test)
 
 target_link_libraries(hal.interfaces_test PUBLIC

--- a/hal/interfaces/test_doubles/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(hal.interfaces_test_doubles STATIC)
-emil_build_for(hal.interfaces_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(hal.interfaces_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(hal.interfaces_test_doubles PRIVATE
     hal.interfaces

--- a/hal/interfaces/test_doubles/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(hal.interfaces_test_doubles ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(hal.interfaces_test_doubles STATIC)
+emil_build_for(hal.interfaces_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(hal.interfaces_test_doubles PRIVATE
     hal.interfaces
@@ -36,6 +37,4 @@ target_sources(hal.interfaces_test_doubles PRIVATE
     SpiMock.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/hal/interfaces/test_doubles/test/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(hal.interfaces_test_doubles_test)
+emil_build_for(hal.interfaces_test_doubles_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.interfaces_test_doubles_test)
 
 target_link_libraries(hal.interfaces_test_doubles_test PUBLIC

--- a/hal/interfaces/test_doubles/test/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(hal.interfaces_test_doubles_test)
-emil_build_for(hal.interfaces_test_doubles_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(hal.interfaces_test_doubles_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.interfaces_test_doubles_test)
 
 target_link_libraries(hal.interfaces_test_doubles_test PUBLIC

--- a/hal/synchronous_interfaces/CMakeLists.txt
+++ b/hal/synchronous_interfaces/CMakeLists.txt
@@ -27,6 +27,4 @@ target_sources(hal.synchronous_interfaces PRIVATE
     TimeService.hpp
 )
 
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test_doubles)

--- a/hal/synchronous_interfaces/test_doubles/CMakeLists.txt
+++ b/hal/synchronous_interfaces/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(hal.synchronous_interfaces_test_doubles STATIC)
-emil_build_for(hal.synchronous_interfaces_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(hal.synchronous_interfaces_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(hal.synchronous_interfaces_test_doubles PUBLIC
     hal.synchronous_interfaces

--- a/hal/synchronous_interfaces/test_doubles/CMakeLists.txt
+++ b/hal/synchronous_interfaces/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(hal.synchronous_interfaces_test_doubles ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(hal.synchronous_interfaces_test_doubles STATIC)
+emil_build_for(hal.synchronous_interfaces_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(hal.synchronous_interfaces_test_doubles PUBLIC
     hal.synchronous_interfaces
@@ -19,6 +20,4 @@ target_sources(hal.synchronous_interfaces_test_doubles PRIVATE
     TimeKeeperMock.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/hal/synchronous_interfaces/test_doubles/test/CMakeLists.txt
+++ b/hal/synchronous_interfaces/test_doubles/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(hal.synchronous_interfaces_test_doubles_test)
-emil_build_for(hal.synchronous_interfaces_test_doubles_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(hal.synchronous_interfaces_test_doubles_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.synchronous_interfaces_test_doubles_test)
 
 target_link_libraries(hal.synchronous_interfaces_test_doubles_test PUBLIC

--- a/hal/synchronous_interfaces/test_doubles/test/CMakeLists.txt
+++ b/hal/synchronous_interfaces/test_doubles/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(hal.synchronous_interfaces_test_doubles_test)
+emil_build_for(hal.synchronous_interfaces_test_doubles_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(hal.synchronous_interfaces_test_doubles_test)
 
 target_link_libraries(hal.synchronous_interfaces_test_doubles_test PUBLIC

--- a/hal/unix/CMakeLists.txt
+++ b/hal/unix/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(hal.unix STATIC)
-emil_build_for(hal.generic HOST Linux Darwin PREREQUISITE_BOOL EMIL_STANDALONE)
+emil_build_for(hal.unix HOST Linux Darwin PREREQUISITE_BOOL EMIL_STANDALONE)
 
 target_link_libraries(hal.unix PUBLIC
     hal.interfaces

--- a/hal/unix/CMakeLists.txt
+++ b/hal/unix/CMakeLists.txt
@@ -1,22 +1,21 @@
-if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
-    add_library(hal.unix ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(hal.unix STATIC)
+emil_build_for(hal.generic HOST Linux Darwin PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_link_libraries(hal.unix PUBLIC
-        hal.interfaces
-    )
+target_link_libraries(hal.unix PUBLIC
+    hal.interfaces
+)
 
-    target_compile_definitions(hal.unix PUBLIC
-        EMIL_HAL_UNIX
-    )
+target_compile_definitions(hal.unix PUBLIC
+    EMIL_HAL_UNIX
+)
 
-    if (EMIL_BUILD_DARWIN)
-        target_compile_definitions(hal.unix PRIVATE
-            EMIL_OS_DARWIN
-        )
-    endif()
-
-    target_sources(hal.unix PRIVATE
-        UartUnix.cpp
-        UartUnix.hpp
+if (EMIL_BUILD_DARWIN)
+    target_compile_definitions(hal.unix PRIVATE
+        EMIL_OS_DARWIN
     )
 endif()
+
+target_sources(hal.unix PRIVATE
+    UartUnix.cpp
+    UartUnix.hpp
+)

--- a/hal/windows/CMakeLists.txt
+++ b/hal/windows/CMakeLists.txt
@@ -1,23 +1,22 @@
-if (EMIL_BUILD_WIN)
-    add_library(hal.windows ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(hal.windows STATIC)
+emil_build_for(hal.windows HOST Windows PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_link_libraries(hal.windows PUBLIC
-        hal.interfaces
-        setupapi.lib
-    )
+target_link_libraries(hal.windows PUBLIC
+    hal.interfaces
+    setupapi.lib
+)
 
-    target_compile_definitions(hal.windows PUBLIC
-        _SETUPAPI_VER=_WIN32_WINNT_LONGHORN
-        EMIL_HAL_WINDOWS
-        NOMINMAX
-    )
+target_compile_definitions(hal.windows PUBLIC
+    _SETUPAPI_VER=_WIN32_WINNT_LONGHORN
+    EMIL_HAL_WINDOWS
+    NOMINMAX
+)
 
-    target_sources(hal.windows PRIVATE
-        SynchronousUartWindows.cpp
-        SynchronousUartWindows.hpp
-        UartPortFinder.cpp
-        UartPortFinder.hpp
-        UartWindows.cpp
-        UartWindows.hpp
-    )
-endif()
+target_sources(hal.windows PRIVATE
+    SynchronousUartWindows.cpp
+    SynchronousUartWindows.hpp
+    UartPortFinder.cpp
+    UartPortFinder.hpp
+    UartWindows.cpp
+    UartWindows.hpp
+)

--- a/infra/event/CMakeLists.txt
+++ b/infra/event/CMakeLists.txt
@@ -19,10 +19,5 @@ target_sources(infra.event PRIVATE
     SystemStateManager.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_helper)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_helper)

--- a/infra/event/test/CMakeLists.txt
+++ b/infra/event/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(infra.event_test)
+emil_build_for(infra.event_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.event_test)
 
 target_link_libraries(infra.event_test PUBLIC

--- a/infra/event/test/CMakeLists.txt
+++ b/infra/event/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(infra.event_test)
-emil_build_for(infra.event_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(infra.event_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.event_test)
 
 target_link_libraries(infra.event_test PUBLIC

--- a/infra/event/test_helper/CMakeLists.txt
+++ b/infra/event/test_helper/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(infra.event_test_helper INTERFACE)
-emil_build_for(infra.event_test_helper PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(infra.event_test_helper BOOL BUILD_TESTING)
 
 target_link_libraries(infra.event_test_helper INTERFACE
     gmock

--- a/infra/event/test_helper/CMakeLists.txt
+++ b/infra/event/test_helper/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(infra.event_test_helper ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(infra.event_test_helper INTERFACE)
+emil_build_for(infra.event_test_helper PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(infra.event_test_helper INTERFACE
     gmock

--- a/infra/stream/CMakeLists.txt
+++ b/infra/stream/CMakeLists.txt
@@ -61,6 +61,4 @@ target_sources(infra.stream PRIVATE
     StringOutputStream.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/infra/stream/test/CMakeLists.txt
+++ b/infra/stream/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(infra.stream_test)
-emil_build_for(infra.stream_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(infra.stream_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.stream_test)
 
 target_link_libraries(infra.stream_test PUBLIC

--- a/infra/stream/test/CMakeLists.txt
+++ b/infra/stream/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(infra.stream_test)
+emil_build_for(infra.stream_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.stream_test)
 
 target_link_libraries(infra.stream_test PUBLIC

--- a/infra/syntax/CMakeLists.txt
+++ b/infra/syntax/CMakeLists.txt
@@ -40,10 +40,5 @@ if (EMIL_ENABLE_FUZZING)
     add_subdirectory(fuzz)
 endif()
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/infra/syntax/test/CMakeLists.txt
+++ b/infra/syntax/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(infra.syntax_test)
-emil_build_for(infra.syntax_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(infra.syntax_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.syntax_test)
 
 target_link_libraries(infra.syntax_test PUBLIC

--- a/infra/syntax/test/CMakeLists.txt
+++ b/infra/syntax/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(infra.syntax_test)
+emil_build_for(infra.syntax_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.syntax_test)
 
 target_link_libraries(infra.syntax_test PUBLIC

--- a/infra/syntax/test_doubles/CMakeLists.txt
+++ b/infra/syntax/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(infra.syntax_test_doubles ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(infra.syntax_test_doubles INTERFACE)
+emil_build_for(infra.syntax_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(infra.syntax_test_doubles INTERFACE
     infra.syntax

--- a/infra/syntax/test_doubles/CMakeLists.txt
+++ b/infra/syntax/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(infra.syntax_test_doubles INTERFACE)
-emil_build_for(infra.syntax_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(infra.syntax_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(infra.syntax_test_doubles INTERFACE
     infra.syntax

--- a/infra/timer/CMakeLists.txt
+++ b/infra/timer/CMakeLists.txt
@@ -30,10 +30,5 @@ target_sources(infra.timer PRIVATE
     TimerService.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_helper)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_helper)

--- a/infra/timer/test/CMakeLists.txt
+++ b/infra/timer/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(infra.timer_test)
-emil_build_for(infra.timer_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(infra.timer_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.timer_test)
 
 target_link_libraries(infra.timer_test PUBLIC

--- a/infra/timer/test/CMakeLists.txt
+++ b/infra/timer/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(infra.timer_test)
+emil_build_for(infra.timer_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.timer_test)
 
 target_link_libraries(infra.timer_test PUBLIC

--- a/infra/timer/test_helper/CMakeLists.txt
+++ b/infra/timer/test_helper/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(infra.timer_test_helper ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(infra.timer_test_helper STATIC)
+emil_build_for(infra.timer_test_helper PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(infra.timer_test_helper PRIVATE
     infra.timer

--- a/infra/timer/test_helper/CMakeLists.txt
+++ b/infra/timer/test_helper/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(infra.timer_test_helper STATIC)
-emil_build_for(infra.timer_test_helper PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(infra.timer_test_helper BOOL BUILD_TESTING)
 
 target_link_libraries(infra.timer_test_helper PRIVATE
     infra.timer

--- a/infra/util/CMakeLists.txt
+++ b/infra/util/CMakeLists.txt
@@ -90,13 +90,8 @@ if (EMIL_HOST_BUILD)
     target_compile_definitions(infra.util PUBLIC EMIL_HOST_BUILD)
 endif()
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_helper)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_helper)
 
 function(emil_transform_file_to_string input name namespace output)
 

--- a/infra/util/test/CMakeLists.txt
+++ b/infra/util/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(infra.util_test)
-emil_build_for(infra.util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(infra.util_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.util_test)
 
 target_link_libraries(infra.util_test PUBLIC

--- a/infra/util/test/CMakeLists.txt
+++ b/infra/util/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(infra.util_test)
+emil_build_for(infra.util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(infra.util_test)
 
 target_link_libraries(infra.util_test PUBLIC

--- a/infra/util/test_helper/CMakeLists.txt
+++ b/infra/util/test_helper/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(infra.util_test_helper ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(infra.util_test_helper INTERFACE)
+emil_build_for(infra.util_test_helper PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(infra.util_test_helper INTERFACE
     gmock

--- a/infra/util/test_helper/CMakeLists.txt
+++ b/infra/util/test_helper/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(infra.util_test_helper INTERFACE)
-emil_build_for(infra.util_test_helper PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(infra.util_test_helper BOOL BUILD_TESTING)
 
 target_link_libraries(infra.util_test_helper INTERFACE
     gmock

--- a/lwip/lwip_config/CMakeLists.txt
+++ b/lwip/lwip_config/CMakeLists.txt
@@ -1,14 +1,11 @@
-if (TARGET_CORTEX)
-    add_library(lwip.lwip_conf ${EMIL_EXCLUDE_FROM_ALL} STATIC)
-
-    target_sources(lwip.lwip_conf PRIVATE
-        sys_now.cpp
-    )
-else()
-    add_library(lwip.lwip_conf ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
-endif()
+add_library(lwip.lwip_conf STATIC)
+emil_build_for(lwip.lwip_conf PREREQUISITE_BOOL TARGET_CORTEX EMIL_STANDALONE)
 
 target_include_directories(lwip.lwip_conf INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+target_sources(lwip.lwip_conf PRIVATE
+    sys_now.cpp
 )

--- a/lwip/lwip_config/CMakeLists.txt
+++ b/lwip/lwip_config/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(lwip.lwip_conf STATIC)
-emil_build_for(lwip.lwip_conf PREREQUISITE_BOOL TARGET_CORTEX EMIL_STANDALONE)
+emil_build_for(lwip.lwip_conf BOOL TARGET_CORTEX PREREQUISITE_BOOL EMIL_STANDALONE)
 
 target_include_directories(lwip.lwip_conf INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"

--- a/osal/freertos_std_thread/CMakeLists.txt
+++ b/osal/freertos_std_thread/CMakeLists.txt
@@ -20,6 +20,4 @@ target_sources(osal.freertos_std_thread PRIVATE
     thread
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/osal/freertos_std_thread/test/CMakeLists.txt
+++ b/osal/freertos_std_thread/test/CMakeLists.txt
@@ -1,14 +1,14 @@
-ccola_component(freertos_std_thread_test gmock_test)
-    ccola_inheritable_include_directories(..)
-	ccola_sources(
-		FreeRTOS.h
-		semphr.cpp
-		semphr.h
-		test_condition_variable.cpp
-	)
+add_executable(osal.freertos_std_thread_test)
+emil_build_for(osal.freertos_std_thread_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_add_test(osal.freertos_std_thread_test)
 
-	ccola_dependencies(
-		freertos_std_thread
-	)
+target_link_libraries(osal.freertos_std_thread_test PUBLIC
+    osal.freertos_std_thread
+)
 
-ccola_end_component()
+target_sources(osal.freertos_std_thread_test PRIVATE
+    FreeRTOS.h
+    semphr.cpp
+    semphr.h
+    test_condition_variable.cpp
+)

--- a/osal/freertos_std_thread/test/CMakeLists.txt
+++ b/osal/freertos_std_thread/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(osal.freertos_std_thread_test)
-emil_build_for(osal.freertos_std_thread_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(osal.freertos_std_thread_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(osal.freertos_std_thread_test)
 
 target_link_libraries(osal.freertos_std_thread_test PUBLIC

--- a/protobuf/echo/CMakeLists.txt
+++ b/protobuf/echo/CMakeLists.txt
@@ -15,12 +15,8 @@ target_sources(protobuf.echo PRIVATE
     TracingEcho.hpp
 )
 
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test_doubles)
 
 include(protocol_buffer_echo.cmake)
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/protobuf/echo/test/CMakeLists.txt
+++ b/protobuf/echo/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(protobuf.echo_test)
+emil_build_for(protobuf.echo_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(protobuf.echo_test)
 
 target_sources(protobuf.echo_test PRIVATE

--- a/protobuf/echo/test/CMakeLists.txt
+++ b/protobuf/echo/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(protobuf.echo_test)
-emil_build_for(protobuf.echo_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(protobuf.echo_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(protobuf.echo_test)
 
 target_sources(protobuf.echo_test PRIVATE

--- a/protobuf/echo/test_doubles/CMakeLists.txt
+++ b/protobuf/echo/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(protobuf.test_doubles ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(protobuf.test_doubles STATIC)
+emil_build_for(protobuf.test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(protobuf.test_doubles PUBLIC
     protobuf.echo

--- a/protobuf/echo/test_doubles/CMakeLists.txt
+++ b/protobuf/echo/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(protobuf.test_doubles STATIC)
-emil_build_for(protobuf.test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(protobuf.test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(protobuf.test_doubles PUBLIC
     protobuf.echo

--- a/protobuf/echo_console/CMakeLists.txt
+++ b/protobuf/echo_console/CMakeLists.txt
@@ -1,27 +1,26 @@
-if (EMIL_HOST_BUILD)
-    add_executable(protobuf.echo_console)
-    install(TARGETS protobuf.echo_console EXPORT emilProtobufTargets DESTINATION bin)
+add_executable(protobuf.echo_console)
+emil_build_for(protobuf.echo_console HOST All)
+install(TARGETS protobuf.echo_console EXPORT emilProtobufTargets DESTINATION bin)
 
-    target_link_libraries(protobuf.echo_console PUBLIC
-        args
-        hal.generic
-        protobuf.protoc_echo_plugin_lib
-        protobuf.echo
-        services.network_instantiations
-        services.util
-    )
+target_link_libraries(protobuf.echo_console PUBLIC
+    args
+    hal.generic
+    protobuf.protoc_echo_plugin_lib
+    protobuf.echo
+    services.network_instantiations
+    services.util
+)
 
-    if (EMIL_BUILD_WIN)
-        target_link_libraries(protobuf.echo_console PRIVATE hal.windows)
-    endif()
-
-    if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
-        target_link_libraries(protobuf.echo_console PRIVATE hal.unix)
-    endif()
-
-    target_sources(protobuf.echo_console PRIVATE
-        Console.cpp
-        Console.hpp
-        Main.cpp
-    )
+if (EMIL_BUILD_WIN)
+    target_link_libraries(protobuf.echo_console PRIVATE hal.windows)
 endif()
+
+if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
+    target_link_libraries(protobuf.echo_console PRIVATE hal.unix)
+endif()
+
+target_sources(protobuf.echo_console PRIVATE
+    Console.cpp
+    Console.hpp
+    Main.cpp
+)

--- a/protobuf/protoc_echo_plugin/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin/CMakeLists.txt
@@ -1,37 +1,38 @@
-add_library(protobuf.protoc_echo_plugin_lib STATIC)
-emil_build_for(protobuf.protoc_echo_plugin_lib HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
+if (EMIL_HOST_BUILD)
+    add_library(protobuf.protoc_echo_plugin_lib ${EMIL_EXCLUDE_FROM_ALL} STATIC)
 
-target_compile_definitions(protobuf.protoc_echo_plugin_lib PRIVATE
-    LIBPROTOC_EXPORTS
-)
+    target_compile_definitions(protobuf.protoc_echo_plugin_lib PRIVATE
+        LIBPROTOC_EXPORTS
+    )
 
-target_link_libraries(protobuf.protoc_echo_plugin_lib PUBLIC
-    protobuf.echo_attributes
-)
+    target_link_libraries(protobuf.protoc_echo_plugin_lib PUBLIC
+        protobuf.echo_attributes
+    )
 
-target_include_directories(protobuf.protoc_echo_plugin_lib PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../>"
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-)
+    target_include_directories(protobuf.protoc_echo_plugin_lib PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    )
 
-target_sources(protobuf.protoc_echo_plugin_lib PRIVATE
-    CppFormatter.cpp
-    CppFormatter.hpp
-    EchoObjects.cpp
-    EchoObjects.hpp
-    ProtoCEchoPlugin.cpp
-    ProtoCEchoPlugin.hpp
-)
+    target_sources(protobuf.protoc_echo_plugin_lib PRIVATE
+        CppFormatter.cpp
+        CppFormatter.hpp
+        EchoObjects.cpp
+        EchoObjects.hpp
+        ProtoCEchoPlugin.cpp
+        ProtoCEchoPlugin.hpp
+    )
 
-add_executable(protobuf.protoc_echo_plugin)
-install(TARGETS protobuf.protoc_echo_plugin EXPORT emilProtobufTargets DESTINATION bin)
+    add_executable(protobuf.protoc_echo_plugin)
+    install(TARGETS protobuf.protoc_echo_plugin EXPORT emilProtobufTargets DESTINATION bin)
 
-target_link_libraries(protobuf.protoc_echo_plugin PUBLIC
-    protobuf.protoc_echo_plugin_lib
-)
+    target_link_libraries(protobuf.protoc_echo_plugin PUBLIC
+        protobuf.protoc_echo_plugin_lib
+    )
 
-target_sources(protobuf.protoc_echo_plugin PRIVATE
-    Main.cpp
-)
+    target_sources(protobuf.protoc_echo_plugin PRIVATE
+        Main.cpp
+    )
+endif()
 
 add_subdirectory(test)

--- a/protobuf/protoc_echo_plugin/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin/CMakeLists.txt
@@ -1,40 +1,37 @@
-if (EMIL_HOST_BUILD)
-    add_library(protobuf.protoc_echo_plugin_lib ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(protobuf.protoc_echo_plugin_lib STATIC)
+emil_build_for(protobuf.protoc_echo_plugin_lib HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_compile_definitions(protobuf.protoc_echo_plugin_lib PRIVATE
-        LIBPROTOC_EXPORTS
-    )
+target_compile_definitions(protobuf.protoc_echo_plugin_lib PRIVATE
+    LIBPROTOC_EXPORTS
+)
 
-    target_link_libraries(protobuf.protoc_echo_plugin_lib PUBLIC
-        protobuf.echo_attributes
-    )
+target_link_libraries(protobuf.protoc_echo_plugin_lib PUBLIC
+    protobuf.echo_attributes
+)
 
-    target_include_directories(protobuf.protoc_echo_plugin_lib PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    )
+target_include_directories(protobuf.protoc_echo_plugin_lib PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
-    target_sources(protobuf.protoc_echo_plugin_lib PRIVATE
-        CppFormatter.cpp
-        CppFormatter.hpp
-        EchoObjects.cpp
-        EchoObjects.hpp
-        ProtoCEchoPlugin.cpp
-        ProtoCEchoPlugin.hpp
-    )
+target_sources(protobuf.protoc_echo_plugin_lib PRIVATE
+    CppFormatter.cpp
+    CppFormatter.hpp
+    EchoObjects.cpp
+    EchoObjects.hpp
+    ProtoCEchoPlugin.cpp
+    ProtoCEchoPlugin.hpp
+)
 
-    add_executable(protobuf.protoc_echo_plugin)
-    install(TARGETS protobuf.protoc_echo_plugin EXPORT emilProtobufTargets DESTINATION bin)
+add_executable(protobuf.protoc_echo_plugin)
+install(TARGETS protobuf.protoc_echo_plugin EXPORT emilProtobufTargets DESTINATION bin)
 
-    target_link_libraries(protobuf.protoc_echo_plugin PUBLIC
-        protobuf.protoc_echo_plugin_lib
-    )
+target_link_libraries(protobuf.protoc_echo_plugin PUBLIC
+    protobuf.protoc_echo_plugin_lib
+)
 
-    target_sources(protobuf.protoc_echo_plugin PRIVATE
-        Main.cpp
-    )
+target_sources(protobuf.protoc_echo_plugin PRIVATE
+    Main.cpp
+)
 
-    if (EMIL_BUILD_TESTS)
-        add_subdirectory(test)
-    endif()
-endif()
+add_subdirectory(test)

--- a/protobuf/protoc_echo_plugin/test/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(protobuf.protoc_echo_plugin_test)
+emil_build_for(protobuf.protoc_echo_plugin_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(protobuf.protoc_echo_plugin_test)
 
 protocol_buffer_echo_cpp(protobuf.protoc_echo_plugin_test TestMessages.proto)

--- a/protobuf/protoc_echo_plugin/test/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(protobuf.protoc_echo_plugin_test)
-emil_build_for(protobuf.protoc_echo_plugin_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(protobuf.protoc_echo_plugin_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(protobuf.protoc_echo_plugin_test)
 
 protocol_buffer_echo_cpp(protobuf.protoc_echo_plugin_test TestMessages.proto)

--- a/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
@@ -1,14 +1,13 @@
-if (EMIL_HOST_BUILD)
-    add_executable(protobuf.protoc_echo_plugin_csharp)
-    install(TARGETS protobuf.protoc_echo_plugin_csharp EXPORT emilProtobufTargets DESTINATION bin)
+add_executable(protobuf.protoc_echo_plugin_csharp)
+emil_build_for(protobuf.protoc_echo_plugin_csharp HOST All)
+install(TARGETS protobuf.protoc_echo_plugin_csharp EXPORT emilProtobufTargets DESTINATION bin)
 
-    target_link_libraries(protobuf.protoc_echo_plugin_csharp PUBLIC
-        protobuf.protoc_echo_plugin_lib
-    )
+target_link_libraries(protobuf.protoc_echo_plugin_csharp PUBLIC
+    protobuf.protoc_echo_plugin_lib
+)
 
-    target_sources(protobuf.protoc_echo_plugin_csharp PRIVATE
-        Main.cpp
-        ProtoCEchoPluginCSharp.cpp
-        ProtoCEchoPluginCSharp.hpp
-    )
-endif()
+target_sources(protobuf.protoc_echo_plugin_csharp PRIVATE
+    Main.cpp
+    ProtoCEchoPluginCSharp.cpp
+    ProtoCEchoPluginCSharp.hpp
+)

--- a/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
@@ -1,13 +1,14 @@
-add_executable(protobuf.protoc_echo_plugin_csharp)
-emil_build_for(protobuf.protoc_echo_plugin_csharp HOST All)
-install(TARGETS protobuf.protoc_echo_plugin_csharp EXPORT emilProtobufTargets DESTINATION bin)
+if (EMIL_HOST_BUILD)
+    add_executable(protobuf.protoc_echo_plugin_csharp)
+    install(TARGETS protobuf.protoc_echo_plugin_csharp EXPORT emilProtobufTargets DESTINATION bin)
 
-target_link_libraries(protobuf.protoc_echo_plugin_csharp PUBLIC
-    protobuf.protoc_echo_plugin_lib
-)
+    target_link_libraries(protobuf.protoc_echo_plugin_csharp PUBLIC
+        protobuf.protoc_echo_plugin_lib
+    )
 
-target_sources(protobuf.protoc_echo_plugin_csharp PRIVATE
-    Main.cpp
-    ProtoCEchoPluginCSharp.cpp
-    ProtoCEchoPluginCSharp.hpp
-)
+    target_sources(protobuf.protoc_echo_plugin_csharp PRIVATE
+        Main.cpp
+        ProtoCEchoPluginCSharp.cpp
+        ProtoCEchoPluginCSharp.hpp
+    )
+endif()

--- a/protobuf/protoc_echo_plugin_java/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_java/CMakeLists.txt
@@ -1,13 +1,14 @@
-add_executable(protobuf.protoc_echo_plugin_java)
-emil_build_for(protobuf.protoc_echo_plugin_java HOST All)
-install(TARGETS protobuf.protoc_echo_plugin_java EXPORT emilProtobufTargets DESTINATION bin)
+if (EMIL_HOST_BUILD)
+    add_executable(protobuf.protoc_echo_plugin_java)
+    install(TARGETS protobuf.protoc_echo_plugin_java EXPORT emilProtobufTargets DESTINATION bin)
 
-target_link_libraries(protobuf.protoc_echo_plugin_java PUBLIC
-    protobuf.protoc_echo_plugin_lib
-)
+    target_link_libraries(protobuf.protoc_echo_plugin_java PUBLIC
+        protobuf.protoc_echo_plugin_lib
+    )
 
-target_sources(protobuf.protoc_echo_plugin_java PRIVATE
-    Main.cpp
-    ProtoCEchoPluginJava.cpp
-    ProtoCEchoPluginJava.hpp
-)
+    target_sources(protobuf.protoc_echo_plugin_java PRIVATE
+        Main.cpp
+        ProtoCEchoPluginJava.cpp
+        ProtoCEchoPluginJava.hpp
+    )
+endif()

--- a/protobuf/protoc_echo_plugin_java/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_java/CMakeLists.txt
@@ -1,14 +1,13 @@
-if (EMIL_HOST_BUILD)
-    add_executable(protobuf.protoc_echo_plugin_java)
-    install(TARGETS protobuf.protoc_echo_plugin_java EXPORT emilProtobufTargets DESTINATION bin)
+add_executable(protobuf.protoc_echo_plugin_java)
+emil_build_for(protobuf.protoc_echo_plugin_java HOST All)
+install(TARGETS protobuf.protoc_echo_plugin_java EXPORT emilProtobufTargets DESTINATION bin)
 
-    target_link_libraries(protobuf.protoc_echo_plugin_java PUBLIC
-        protobuf.protoc_echo_plugin_lib
-    )
+target_link_libraries(protobuf.protoc_echo_plugin_java PUBLIC
+    protobuf.protoc_echo_plugin_lib
+)
 
-    target_sources(protobuf.protoc_echo_plugin_java PRIVATE
-        Main.cpp
-        ProtoCEchoPluginJava.cpp
-        ProtoCEchoPluginJava.hpp
-    )
-endif()
+target_sources(protobuf.protoc_echo_plugin_java PRIVATE
+    Main.cpp
+    ProtoCEchoPluginJava.cpp
+    ProtoCEchoPluginJava.hpp
+)

--- a/services/ble/CMakeLists.txt
+++ b/services/ble/CMakeLists.txt
@@ -22,10 +22,5 @@ target_sources(services.ble PRIVATE
     GattServerCharacteristicImpl.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/services/ble/test/CMakeLists.txt
+++ b/services/ble/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.ble_test)
+emil_build_for(services.ble_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.ble_test)
 
 target_link_libraries(services.ble_test PUBLIC

--- a/services/ble/test/CMakeLists.txt
+++ b/services/ble/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.ble_test)
-emil_build_for(services.ble_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.ble_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.ble_test)
 
 target_link_libraries(services.ble_test PUBLIC

--- a/services/ble/test_doubles/CMakeLists.txt
+++ b/services/ble/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(services.ble_test_doubles INTERFACE)
-emil_build_for(services.ble_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(services.ble_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(services.ble_test_doubles INTERFACE
     services.ble

--- a/services/ble/test_doubles/CMakeLists.txt
+++ b/services/ble/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(services.ble_test_doubles ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(services.ble_test_doubles INTERFACE)
+emil_build_for(services.ble_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(services.ble_test_doubles INTERFACE
     services.ble

--- a/services/cucumber/CMakeLists.txt
+++ b/services/cucumber/CMakeLists.txt
@@ -28,6 +28,4 @@ target_sources(services.cucumber PRIVATE
     TracingCucumberWireProtocolServer.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/services/cucumber/test/CMakeLists.txt
+++ b/services/cucumber/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.cucumber_test)
+emil_build_for(services.cucumber_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.cucumber_test)
 
 target_link_libraries(services.cucumber_test PUBLIC

--- a/services/cucumber/test/CMakeLists.txt
+++ b/services/cucumber/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.cucumber_test)
-emil_build_for(services.cucumber_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.cucumber_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.cucumber_test)
 
 target_link_libraries(services.cucumber_test PUBLIC

--- a/services/network/CMakeLists.txt
+++ b/services/network/CMakeLists.txt
@@ -110,10 +110,5 @@ if (EMIL_HOST_BUILD)
     )
 endif()
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/services/network/test/CMakeLists.txt
+++ b/services/network/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.network_test)
-emil_build_for(services.network_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.network_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.network_test)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang|AppleClang")

--- a/services/network/test/CMakeLists.txt
+++ b/services/network/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.network_test)
+emil_build_for(services.network_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.network_test)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang|AppleClang")

--- a/services/network/test_doubles/CMakeLists.txt
+++ b/services/network/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(services.network_test_doubles STATIC)
-emil_build_for(services.network_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(services.network_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(services.network_test_doubles PRIVATE
     services.network

--- a/services/network/test_doubles/CMakeLists.txt
+++ b/services/network/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(services.network_test_doubles ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(services.network_test_doubles STATIC)
+emil_build_for(services.network_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(services.network_test_doubles PRIVATE
     services.network

--- a/services/network_instantiations/CMakeLists.txt
+++ b/services/network_instantiations/CMakeLists.txt
@@ -1,49 +1,48 @@
-if (EMIL_HOST_BUILD)
-    add_library(services.network_instantiations ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(services.network_instantiations STATIC)
+emil_build_for(services.network_instantiations HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 
+target_sources(services.network_instantiations PRIVATE
+    NameLookup.cpp
+    NameLookup.hpp
+    NetworkAdapter.cpp
+    NetworkAdapter.hpp
+)
+
+target_link_libraries(services.network_instantiations PUBLIC
+    services.network
+)
+
+if (EMIL_BUILD_WIN)
     target_sources(services.network_instantiations PRIVATE
-        NameLookup.cpp
-        NameLookup.hpp
-        NetworkAdapter.cpp
-        NetworkAdapter.hpp
+        ConnectionWin.cpp
+        ConnectionWin.hpp
+        DatagramWin.cpp
+        DatagramWin.hpp
+        EventDispatcherWithNetworkWin.cpp
+        EventDispatcherWithNetworkWin.hpp
     )
 
     target_link_libraries(services.network_instantiations PUBLIC
-        services.network
+        ws2_32.lib
+        iphlpapi.lib
     )
 
-    if (EMIL_BUILD_WIN)
-        target_sources(services.network_instantiations PRIVATE
-            ConnectionWin.cpp
-            ConnectionWin.hpp
-            DatagramWin.cpp
-            DatagramWin.hpp
-            EventDispatcherWithNetworkWin.cpp
-            EventDispatcherWithNetworkWin.hpp
-        )
+    target_compile_definitions(services.network_instantiations PUBLIC EMIL_NETWORK_WIN)
+endif()
 
-        target_link_libraries(services.network_instantiations PUBLIC
-            ws2_32.lib
-            iphlpapi.lib
-        )
+if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
+    target_sources(services.network_instantiations PRIVATE
+        ConnectionBsd.cpp
+        ConnectionBsd.hpp
+        DatagramBsd.cpp
+        DatagramBsd.hpp
+        EventDispatcherWithNetworkBsd.cpp
+        EventDispatcherWithNetworkBsd.hpp
+    )
 
-        target_compile_definitions(services.network_instantiations PUBLIC EMIL_NETWORK_WIN)
-    endif()
+    target_link_libraries(services.network_instantiations PUBLIC
+        pthread
+    )
 
-    if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
-        target_sources(services.network_instantiations PRIVATE
-            ConnectionBsd.cpp
-            ConnectionBsd.hpp
-            DatagramBsd.cpp
-            DatagramBsd.hpp
-            EventDispatcherWithNetworkBsd.cpp
-            EventDispatcherWithNetworkBsd.hpp
-        )
-
-        target_link_libraries(services.network_instantiations PUBLIC
-            pthread
-        )
-
-        target_compile_definitions(services.network_instantiations PUBLIC EMIL_NETWORK_BSD)
-    endif()
+    target_compile_definitions(services.network_instantiations PUBLIC EMIL_NETWORK_BSD)
 endif()

--- a/services/synchronous_util/CMakeLists.txt
+++ b/services/synchronous_util/CMakeLists.txt
@@ -15,6 +15,4 @@ target_sources(services.synchronous_util PRIVATE
     SynchronousSpiMasterWithChipSelect.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/services/synchronous_util/test/CMakeLists.txt
+++ b/services/synchronous_util/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.synchronous_util_test)
-emil_build_for(services.synchronous_util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.synchronous_util_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.synchronous_util_test)
 
 target_link_libraries(services.synchronous_util_test PUBLIC

--- a/services/synchronous_util/test/CMakeLists.txt
+++ b/services/synchronous_util/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.synchronous_util_test)
+emil_build_for(services.synchronous_util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.synchronous_util_test)
 
 target_link_libraries(services.synchronous_util_test PUBLIC

--- a/services/tracer/CMakeLists.txt
+++ b/services/tracer/CMakeLists.txt
@@ -35,6 +35,4 @@ target_sources(services.tracer PRIVATE
     TracingReset.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/services/tracer/test/CMakeLists.txt
+++ b/services/tracer/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.tracer_test)
-emil_build_for(services.tracer_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.tracer_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.tracer_test)
 
 target_link_libraries(services.tracer_test PUBLIC

--- a/services/tracer/test/CMakeLists.txt
+++ b/services/tracer/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.tracer_test)
+emil_build_for(services.tracer_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.tracer_test)
 
 target_link_libraries(services.tracer_test PUBLIC

--- a/services/util/CMakeLists.txt
+++ b/services/util/CMakeLists.txt
@@ -75,10 +75,5 @@ if (EMIL_INCLUDE_MBEDTLS)
     )
 endif()
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(services.util_test)
-emil_build_for(services.util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(services.util_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.util_test)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang|AppleClang")

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(services.util_test)
+emil_build_for(services.util_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(services.util_test)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang|AppleClang")

--- a/services/util/test_doubles/CMakeLists.txt
+++ b/services/util/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(services.util_test_doubles INTERFACE)
-emil_build_for(services.util_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(services.util_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(services.util_test_doubles INTERFACE
     gmock

--- a/services/util/test_doubles/CMakeLists.txt
+++ b/services/util/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(services.util_test_doubles ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(services.util_test_doubles INTERFACE)
+emil_build_for(services.util_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(services.util_test_doubles INTERFACE
     gmock

--- a/upgrade/boot_loader/CMakeLists.txt
+++ b/upgrade/boot_loader/CMakeLists.txt
@@ -39,10 +39,5 @@ target_sources(upgrade.boot_loader PRIVATE
     VerifierHashOnly.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
-
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
+add_subdirectory(test)
+add_subdirectory(test_doubles)

--- a/upgrade/boot_loader/test/CMakeLists.txt
+++ b/upgrade/boot_loader/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(upgrade.boot_loader_test)
-emil_build_for(upgrade.boot_loader_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(upgrade.boot_loader_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.boot_loader_test)
 
 target_link_libraries(upgrade.boot_loader_test PUBLIC

--- a/upgrade/boot_loader/test/CMakeLists.txt
+++ b/upgrade/boot_loader/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(upgrade.boot_loader_test)
+emil_build_for(upgrade.boot_loader_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.boot_loader_test)
 
 target_link_libraries(upgrade.boot_loader_test PUBLIC

--- a/upgrade/boot_loader/test_doubles/CMakeLists.txt
+++ b/upgrade/boot_loader/test_doubles/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(upgrade.boot_loader_test_doubles STATIC)
-emil_build_for(upgrade.boot_loader_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(upgrade.boot_loader_test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(upgrade.boot_loader_test_doubles PRIVATE
     gmock

--- a/upgrade/boot_loader/test_doubles/CMakeLists.txt
+++ b/upgrade/boot_loader/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(upgrade.boot_loader_test_doubles ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(upgrade.boot_loader_test_doubles STATIC)
+emil_build_for(upgrade.boot_loader_test_doubles PREREQUISITE_BOOL BUILD_TESTING)
 
 target_link_libraries(upgrade.boot_loader_test_doubles PRIVATE
     gmock

--- a/upgrade/deploy_pack_to_external/CMakeLists.txt
+++ b/upgrade/deploy_pack_to_external/CMakeLists.txt
@@ -11,6 +11,4 @@ target_sources(upgrade.deploy_pack_to_external PRIVATE
     DeployPackToExternal.hpp
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/upgrade/deploy_pack_to_external/test/CMakeLists.txt
+++ b/upgrade/deploy_pack_to_external/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(upgrade.deploy_pack_to_external_test)
+emil_build_for(upgrade.deploy_pack_to_external_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.deploy_pack_to_external_test)
 
 target_link_libraries(upgrade.deploy_pack_to_external_test PUBLIC

--- a/upgrade/deploy_pack_to_external/test/CMakeLists.txt
+++ b/upgrade/deploy_pack_to_external/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(upgrade.deploy_pack_to_external_test)
-emil_build_for(upgrade.deploy_pack_to_external_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(upgrade.deploy_pack_to_external_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.deploy_pack_to_external_test)
 
 target_link_libraries(upgrade.deploy_pack_to_external_test PUBLIC

--- a/upgrade/pack_builder/CMakeLists.txt
+++ b/upgrade/pack_builder/CMakeLists.txt
@@ -1,58 +1,52 @@
-if (EMIL_HOST_BUILD)
-    add_library(upgrade.pack_builder ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(upgrade.pack_builder STATIC)
+emil_build_for(upgrade.pack_builder HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_link_libraries(upgrade.pack_builder PUBLIC
-        mbedcrypto
-        crypto.micro_ecc
-        crypto.tiny_aes128
-        hal.interfaces
-        infra.syntax
-        upgrade.pack
-    )
+target_link_libraries(upgrade.pack_builder PUBLIC
+    mbedcrypto
+    crypto.micro_ecc
+    crypto.tiny_aes128
+    hal.interfaces
+    infra.syntax
+    upgrade.pack
+)
 
-    target_sources(upgrade.pack_builder PRIVATE
-        BinaryObject.cpp
-        BinaryObject.hpp
-        Elf.hpp
-        ImageAuthenticatorHmac.cpp
-        ImageAuthenticatorHmac.hpp
-        ImageEncryptorAes.cpp
-        ImageEncryptorAes.hpp
-        ImageEncryptorNone.cpp
-        ImageEncryptorNone.hpp
-        ImageSecurity.hpp
-        ImageSigner.hpp
-        ImageSignerEcDsa.cpp
-        ImageSignerEcDsa.hpp
-        ImageSignerHashOnly.cpp
-        ImageSignerHashOnly.hpp
-        Input.cpp
-        Input.hpp
-        InputBinary.cpp
-        InputBinary.hpp
-        InputCommand.cpp
-        InputCommand.hpp
-        InputElf.cpp
-        InputElf.hpp
-        InputFactory.hpp
-        InputHex.cpp
-        InputHex.hpp
-        SparseVector.hpp
-        SupportedTargets.cpp
-        SupportedTargets.hpp
-        UpgradePackBuilder.cpp
-        UpgradePackBuilder.hpp
-        UpgradePackConfigParser.cpp
-        UpgradePackConfigParser.hpp
-        UpgradePackInputFactory.cpp
-        UpgradePackInputFactory.hpp
-    )
+target_sources(upgrade.pack_builder PRIVATE
+    BinaryObject.cpp
+    BinaryObject.hpp
+    Elf.hpp
+    ImageAuthenticatorHmac.cpp
+    ImageAuthenticatorHmac.hpp
+    ImageEncryptorAes.cpp
+    ImageEncryptorAes.hpp
+    ImageEncryptorNone.cpp
+    ImageEncryptorNone.hpp
+    ImageSecurity.hpp
+    ImageSigner.hpp
+    ImageSignerEcDsa.cpp
+    ImageSignerEcDsa.hpp
+    ImageSignerHashOnly.cpp
+    ImageSignerHashOnly.hpp
+    Input.cpp
+    Input.hpp
+    InputBinary.cpp
+    InputBinary.hpp
+    InputCommand.cpp
+    InputCommand.hpp
+    InputElf.cpp
+    InputElf.hpp
+    InputFactory.hpp
+    InputHex.cpp
+    InputHex.hpp
+    SparseVector.hpp
+    SupportedTargets.cpp
+    SupportedTargets.hpp
+    UpgradePackBuilder.cpp
+    UpgradePackBuilder.hpp
+    UpgradePackConfigParser.cpp
+    UpgradePackConfigParser.hpp
+    UpgradePackInputFactory.cpp
+    UpgradePackInputFactory.hpp
+)
 
-    if (EMIL_BUILD_TESTS)
-        add_subdirectory(test)
-    endif()
-
-    if (BUILD_TESTING)
-        add_subdirectory(test_helper)
-    endif()
-endif()
+add_subdirectory(test)
+add_subdirectory(test_helper)

--- a/upgrade/pack_builder/test/CMakeLists.txt
+++ b/upgrade/pack_builder/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(upgrade.pack_builder_test)
-emil_build_for(upgrade.pack_builder_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(upgrade.pack_builder_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.pack_builder_test)
 
 target_link_libraries(upgrade.pack_builder_test PUBLIC

--- a/upgrade/pack_builder/test/CMakeLists.txt
+++ b/upgrade/pack_builder/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(upgrade.pack_builder_test)
+emil_build_for(upgrade.pack_builder_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.pack_builder_test)
 
 target_link_libraries(upgrade.pack_builder_test PUBLIC

--- a/upgrade/pack_builder/test_helper/CMakeLists.txt
+++ b/upgrade/pack_builder/test_helper/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(upgrade.pack_builder_test_helper INTERFACE)
-emil_build_for(upgrade.pack_builder_test_helper PREREQUISITE_BOOL BUILD_TESTING)
+emil_build_for(upgrade.pack_builder_test_helper BOOL BUILD_TESTING)
 
 target_sources(upgrade.pack_builder_test_helper PRIVATE
     ZeroFilledString.hpp

--- a/upgrade/pack_builder/test_helper/CMakeLists.txt
+++ b/upgrade/pack_builder/test_helper/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(upgrade.pack_builder_test_helper ${EMIL_EXCLUDE_FROM_ALL} INTERFACE)
+add_library(upgrade.pack_builder_test_helper INTERFACE)
+emil_build_for(upgrade.pack_builder_test_helper PREREQUISITE_BOOL BUILD_TESTING)
 
 target_sources(upgrade.pack_builder_test_helper PRIVATE
     ZeroFilledString.hpp
@@ -8,6 +9,4 @@ target_include_directories(upgrade.pack_builder_test_helper INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../..>"
 )
 
-if (EMIL_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/upgrade/pack_builder/test_helper/test/CMakeLists.txt
+++ b/upgrade/pack_builder/test_helper/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(upgrade.pack_builder_test_helper_test)
-emil_build_for(upgrade.pack_builder_test_helper_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(upgrade.pack_builder_test_helper_test BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.pack_builder_test_helper_test)
 
 target_link_libraries(upgrade.pack_builder_test_helper_test PUBLIC

--- a/upgrade/pack_builder/test_helper/test/CMakeLists.txt
+++ b/upgrade/pack_builder/test_helper/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(upgrade.pack_builder_test_helper_test)
+emil_build_for(upgrade.pack_builder_test_helper_test PREREQUISITE_BOOL EMIL_BUILD_TESTS)
 emil_add_test(upgrade.pack_builder_test_helper_test)
 
 target_link_libraries(upgrade.pack_builder_test_helper_test PUBLIC

--- a/upgrade/pack_builder_instantiations/CMakeLists.txt
+++ b/upgrade/pack_builder_instantiations/CMakeLists.txt
@@ -1,16 +1,15 @@
-if (EMIL_HOST_BUILD)
-    add_library(upgrade.pack_builder_instantiations ${EMIL_EXCLUDE_FROM_ALL} STATIC)
+add_library(upgrade.pack_builder_instantiations STATIC)
+emil_build_for(upgrade.pack_builder_instantiations HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 
-    target_link_libraries(upgrade.pack_builder_instantiations PUBLIC
-        args
-        hal.generic
-        upgrade.pack_builder
-    )
+target_link_libraries(upgrade.pack_builder_instantiations PUBLIC
+    args
+    hal.generic
+    upgrade.pack_builder
+)
 
-    target_sources(upgrade.pack_builder_instantiations PRIVATE
-        UpgradePackBuilderApplication.cpp
-        UpgradePackBuilderApplication.hpp
-        UpgradePackBuilderFacade.cpp
-        UpgradePackBuilderFacade.hpp
-    )
-endif()
+target_sources(upgrade.pack_builder_instantiations PRIVATE
+    UpgradePackBuilderApplication.cpp
+    UpgradePackBuilderApplication.hpp
+    UpgradePackBuilderFacade.cpp
+    UpgradePackBuilderFacade.hpp
+)

--- a/upgrade/security_key_generator/CMakeLists.txt
+++ b/upgrade/security_key_generator/CMakeLists.txt
@@ -1,18 +1,17 @@
-if (EMIL_HOST_BUILD)
-    add_executable(upgrade.security_key_generator)
-    install(TARGETS upgrade.security_key_generator EXPORT emilUpgradeTargets DESTINATION bin)
+add_executable(upgrade.security_key_generator)
+emil_build_for(upgrade.security_key_generator HOST All)
+install(TARGETS upgrade.security_key_generator EXPORT emilUpgradeTargets DESTINATION bin)
 
-    target_link_libraries(upgrade.security_key_generator PUBLIC
-        args
-        mbedcrypto
-        hal.generic
-        upgrade.pack_keys
-        upgrade.pack_builder
-    )
+target_link_libraries(upgrade.security_key_generator PUBLIC
+    args
+    mbedcrypto
+    hal.generic
+    upgrade.pack_keys
+    upgrade.pack_builder
+)
 
-    target_sources(upgrade.security_key_generator PRIVATE
-        Main.cpp
-        MaterialGenerator.cpp
-        MaterialGenerator.hpp
-    )
-endif()
+target_sources(upgrade.security_key_generator PRIVATE
+    Main.cpp
+    MaterialGenerator.cpp
+    MaterialGenerator.hpp
+)


### PR DESCRIPTION
build: refactor CMakeLists files to use emil_build_for instead of conditionally adding targets