### PR TITLE
build: exclude protobuf tools and upgrade.security_key_generator

### DIFF
--- a/protobuf/echo_console/CMakeLists.txt
+++ b/protobuf/echo_console/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(protobuf.echo_console)
-emil_build_for(protobuf.echo_console HOST All)
+emil_build_for(protobuf.echo_console HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 install(TARGETS protobuf.echo_console EXPORT emilProtobufTargets DESTINATION bin)
 
 target_link_libraries(protobuf.echo_console PUBLIC

--- a/protobuf/protoc_echo_plugin/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin/CMakeLists.txt
@@ -24,6 +24,7 @@ if (EMIL_HOST_BUILD)
     )
 
     add_executable(protobuf.protoc_echo_plugin)
+    emil_build_for(protobuf.protoc_echo_plugin BOOL EMIL_STANDALONE)
     install(TARGETS protobuf.protoc_echo_plugin EXPORT emilProtobufTargets DESTINATION bin)
 
     target_link_libraries(protobuf.protoc_echo_plugin PUBLIC

--- a/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_csharp/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (EMIL_HOST_BUILD)
     add_executable(protobuf.protoc_echo_plugin_csharp)
+    emil_build_for(protobuf.protoc_echo_plugin_csharp BOOL EMIL_STANDALONE)
     install(TARGETS protobuf.protoc_echo_plugin_csharp EXPORT emilProtobufTargets DESTINATION bin)
 
     target_link_libraries(protobuf.protoc_echo_plugin_csharp PUBLIC

--- a/protobuf/protoc_echo_plugin_java/CMakeLists.txt
+++ b/protobuf/protoc_echo_plugin_java/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (EMIL_HOST_BUILD)
     add_executable(protobuf.protoc_echo_plugin_java)
+    emil_build_for(protobuf.protoc_echo_plugin_java BOOL EMIL_STANDALONE)
     install(TARGETS protobuf.protoc_echo_plugin_java EXPORT emilProtobufTargets DESTINATION bin)
 
     target_link_libraries(protobuf.protoc_echo_plugin_java PUBLIC

--- a/upgrade/pack/UpgradeKeys.proto
+++ b/upgrade/pack/UpgradeKeys.proto
@@ -17,6 +17,6 @@ message ecDsa224key
 
 message keys
 {
-	aes128key aesKey = 1;
-	ecDsa224key ecDsaKey = 2;
+    aes128key aesKey = 1;
+    ecDsa224key ecDsaKey = 2;
 }

--- a/upgrade/security_key_generator/CMakeLists.txt
+++ b/upgrade/security_key_generator/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(upgrade.security_key_generator)
-emil_build_for(upgrade.security_key_generator HOST All)
+emil_build_for(upgrade.security_key_generator HOST All PREREQUISITE_BOOL EMIL_STANDALONE)
 install(TARGETS upgrade.security_key_generator EXPORT emilUpgradeTargets DESTINATION bin)
 
 target_link_libraries(upgrade.security_key_generator PUBLIC

--- a/upgrade/security_key_generator/MaterialGenerator.cpp
+++ b/upgrade/security_key_generator/MaterialGenerator.cpp
@@ -21,10 +21,6 @@ namespace application
         materialGenerator = this;
     }
 
-    MaterialGenerator::~MaterialGenerator()
-    {
-    }
-
     void MaterialGenerator::GenerateKeys()
     {
         aesKey.resize(aesKeyLength / 8, 0);

--- a/upgrade/security_key_generator/MaterialGenerator.hpp
+++ b/upgrade/security_key_generator/MaterialGenerator.hpp
@@ -12,7 +12,6 @@ namespace application
     {
     public:
         explicit MaterialGenerator(hal::SynchronousRandomDataGenerator& randomDataGenerator);
-        ~MaterialGenerator();
 
         static const std::size_t aesKeyLength = 128;
         static const std::size_t hmacKeyLength = 256;


### PR DESCRIPTION
build: exclude protobuf tools and upgrade.security_key_generator from all unless emil is built standalone