### PR TITLE
fix: ensure forwarding constructors have constraints

### DIFF
--- a/infra/stream/InputStream.cpp
+++ b/infra/stream/InputStream.cpp
@@ -411,44 +411,6 @@ namespace infra
         }
     }
 
-    DataInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader)
-        : DataInputStream(reader, errorPolicy)
-    {}
-
-    DataInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader, SoftFail)
-        : DataInputStream(reader, errorPolicy)
-        , errorPolicy(softFail)
-    {}
-
-    DataInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader, NoFail)
-        : DataInputStream(reader, errorPolicy)
-        , errorPolicy(noFail)
-    {}
-
-    DataInputStream::WithErrorPolicy::WithErrorPolicy(const WithErrorPolicy& other)
-        : DataInputStream(other.Reader(), errorPolicy)
-        , errorPolicy(other.ErrorPolicy())
-    {}
-
-    TextInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader)
-        : TextInputStream(reader, errorPolicy)
-    {}
-
-    TextInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader, SoftFail)
-        : TextInputStream(reader, errorPolicy)
-        , errorPolicy(softFail)
-    {}
-
-    TextInputStream::WithErrorPolicy::WithErrorPolicy(StreamReader& reader, NoFail)
-        : TextInputStream(reader, errorPolicy)
-        , errorPolicy(noFail)
-    {}
-
-    TextInputStream::WithErrorPolicy::WithErrorPolicy(const WithErrorPolicy& other)
-        : TextInputStream(other.Reader(), errorPolicy)
-        , errorPolicy(other.ErrorPolicy())
-    {}
-
     namespace
     {
         uint8_t DecodeHexByte(char hex)

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -63,9 +63,9 @@ namespace infra
         StreamErrorPolicy& errorPolicy;
     };
 
-    template<class Parent, class TheReader>
+    template<class Parent, class ReaderType>
     class InputStreamWithReader
-        : private detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>
+        : private detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>
         , public Parent
     {
     public:
@@ -82,7 +82,7 @@ namespace infra
         InputStreamWithReader& operator=(const InputStreamWithReader& other) = delete;
         ~InputStreamWithReader() = default;
 
-        TheReader& Reader();
+        ReaderType& Reader();
 
     private:
         StreamErrorPolicy errorPolicy;
@@ -216,50 +216,50 @@ namespace infra
         return result;
     }
 
-    template<class Parent, class TheReader>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader()
+    template<class Parent, class ReaderType>
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader()
         : Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheReader>
+    template<class Parent, class ReaderType>
     template<class Arg>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<InputStreamWithReader, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
-        : detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>(std::forward<Arg>(arg))
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<InputStreamWithReader, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
+        : detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>(std::forward<Arg>(arg))
         , Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheReader>
+    template<class Parent, class ReaderType>
     template<class Arg0, class Arg1, class... Args>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args)
-        : detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheReader>
+    template<class Parent, class ReaderType>
     template<class Storage, class... Args>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader(Storage&& storage, const SoftFail&, Args&&... args)
-        : detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader(Storage&& storage, const SoftFail&, Args&&... args)
+        : detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
         , errorPolicy(softFail)
     {}
 
-    template<class Parent, class TheReader>
+    template<class Parent, class ReaderType>
     template<class Storage, class... Args>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader(Storage&& storage, const NoFail&, Args&&... args)
-        : detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader(Storage&& storage, const NoFail&, Args&&... args)
+        : detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
         , errorPolicy(noFail)
     {}
 
-    template<class Parent, class TheReader>
-    InputStreamWithReader<Parent, TheReader>::InputStreamWithReader(const InputStreamWithReader& other)
-        : detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>(static_cast<const detail::StorageHolder<TheReader, InputStreamWithReader<Parent, TheReader>>&>(other))
+    template<class Parent, class ReaderType>
+    InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader(const InputStreamWithReader& other)
+        : detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>(static_cast<const detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>&>(other))
         , Parent(this->storage, errorPolicy)
         , errorPolicy(other.ErrorPolicy())
     {}
 
-    template<class Parent, class TheReader>
-    TheReader& InputStreamWithReader<Parent, TheReader>::InputStreamWithReader::Reader()
+    template<class Parent, class ReaderType>
+    ReaderType& InputStreamWithReader<Parent, ReaderType>::InputStreamWithReader::Reader()
     {
         return this->storage;
     }

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -78,7 +78,7 @@ namespace infra
         InputStreamWithReader(Storage&& storage, const SoftFail&, Args&&... args);
         template<class Storage, class... Args>
         InputStreamWithReader(Storage&& storage, const NoFail&, Args&&... args);
-        InputStreamWithReader(const InputStreamWithReader& other);
+        InputStreamWithReader(const InputStreamWithReader& other); //NOSONAR
         InputStreamWithReader& operator=(const InputStreamWithReader& other) = delete;
         ~InputStreamWithReader() = default;
 
@@ -96,7 +96,8 @@ namespace infra
         explicit InputStreamWithErrorPolicy(StreamReader& reader);
         InputStreamWithErrorPolicy(StreamReader& reader, SoftFail);
         InputStreamWithErrorPolicy(StreamReader& reader, NoFail);
-        InputStreamWithErrorPolicy(const InputStreamWithErrorPolicy& other);
+        InputStreamWithErrorPolicy(const InputStreamWithErrorPolicy& other); //NOSONAR
+        InputStreamWithErrorPolicy& operator=(const InputStreamWithErrorPolicy& other) = delete;
         ~InputStreamWithErrorPolicy() = default;
 
     private:

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -64,7 +64,7 @@ namespace infra
     };
 
     template<class Parent, class ReaderType>
-    class InputStreamWithReader
+    class InputStreamWithReader //NOSONAR
         : private detail::StorageHolder<ReaderType, InputStreamWithReader<Parent, ReaderType>>
         , public Parent
     {
@@ -78,7 +78,7 @@ namespace infra
         InputStreamWithReader(Storage&& storage, const SoftFail&, Args&&... args);
         template<class Storage, class... Args>
         InputStreamWithReader(Storage&& storage, const NoFail&, Args&&... args);
-        InputStreamWithReader(const InputStreamWithReader& other); //NOSONAR
+        InputStreamWithReader(const InputStreamWithReader& other);
         InputStreamWithReader& operator=(const InputStreamWithReader& other) = delete;
         ~InputStreamWithReader() = default;
 
@@ -89,14 +89,14 @@ namespace infra
     };
 
     template<class Parent>
-    class InputStreamWithErrorPolicy
+    class InputStreamWithErrorPolicy //NOSONAR
         : public Parent
     {
     public:
         explicit InputStreamWithErrorPolicy(StreamReader& reader);
         InputStreamWithErrorPolicy(StreamReader& reader, SoftFail);
         InputStreamWithErrorPolicy(StreamReader& reader, NoFail);
-        InputStreamWithErrorPolicy(const InputStreamWithErrorPolicy& other); //NOSONAR
+        InputStreamWithErrorPolicy(const InputStreamWithErrorPolicy& other);
         InputStreamWithErrorPolicy& operator=(const InputStreamWithErrorPolicy& other) = delete;
         ~InputStreamWithErrorPolicy() = default;
 

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -137,7 +137,7 @@ namespace infra
     public:
         WithReader();
         template<class Arg>
-        explicit WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        explicit WithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<WithReader, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
         template<class Arg0, class Arg1, class... Args>
         explicit WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
@@ -176,7 +176,7 @@ namespace infra
     public:
         WithReader();
         template<class Arg>
-        explicit WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        explicit WithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<WithReader, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
         template<class Arg0, class Arg1, class... Args>
         explicit WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
@@ -261,8 +261,8 @@ namespace infra
 
     template<class TheReader>
     template<class Arg>
-    DataInputStream::WithReader<TheReader>::WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader,
-        typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+    DataInputStream::WithReader<TheReader>::WithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<WithReader,
+        std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
         : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg>(arg))
         , DataInputStream(this->storage, errorPolicy)
     {}
@@ -310,7 +310,7 @@ namespace infra
 
     template<class TheReader>
     template<class Arg>
-    TextInputStream::WithReader<TheReader>::WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+    TextInputStream::WithReader<TheReader>::WithReader(Arg&& arg, std::enable_if_t<!std::is_same_v<WithReader, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
         : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg>(arg))
         , TextInputStream(this->storage, errorPolicy)
     {}

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -135,8 +135,11 @@ namespace infra
         , public DataInputStream
     {
     public:
-        template<class... Args>
-        explicit WithReader(Args&&... args);
+        WithReader();
+        template<class Arg>
+        explicit WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        template<class Arg0, class Arg1, class... Args>
+        explicit WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
         WithReader(Storage&& storage, const SoftFail&, Args&&... args);
         template<class Storage, class... Args>
@@ -171,8 +174,11 @@ namespace infra
         , public TextInputStream
     {
     public:
-        template<class... Args>
-        explicit WithReader(Args&&... args);
+        WithReader();
+        template<class Arg>
+        explicit WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        template<class Arg0, class Arg1, class... Args>
+        explicit WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
         WithReader(Storage&& storage, const SoftFail&, Args&&... args);
         template<class Storage, class... Args>
@@ -249,9 +255,22 @@ namespace infra
     }
 
     template<class TheReader>
-    template<class... Args>
-    DataInputStream::WithReader<TheReader>::WithReader(Args&&... args)
-        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Args>(args)...)
+    DataInputStream::WithReader<TheReader>::WithReader()
+        : DataInputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheReader>
+    template<class Arg>
+    DataInputStream::WithReader<TheReader>::WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader,
+        typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg>(arg))
+        , DataInputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheReader>
+    template<class Arg0, class Arg1, class... Args>
+    DataInputStream::WithReader<TheReader>::WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , DataInputStream(this->storage, errorPolicy)
     {}
 
@@ -285,9 +304,21 @@ namespace infra
     }
 
     template<class TheReader>
-    template<class... Args>
-    TextInputStream::WithReader<TheReader>::WithReader(Args&&... args)
-        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Args>(args)...)
+    TextInputStream::WithReader<TheReader>::WithReader()
+        : TextInputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheReader>
+    template<class Arg>
+    TextInputStream::WithReader<TheReader>::WithReader(Arg&& arg, typename std::enable_if<!std::is_same<WithReader, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg>(arg))
+        , TextInputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheReader>
+    template<class Arg0, class Arg1, class... Args>
+    TextInputStream::WithReader<TheReader>::WithReader(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<TheReader, WithReader<TheReader>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , TextInputStream(this->storage, errorPolicy)
     {}
 

--- a/infra/stream/OutputStream.cpp
+++ b/infra/stream/OutputStream.cpp
@@ -342,44 +342,6 @@ namespace infra
             Writer().Insert(MakeByteRange(width.padding), ErrorPolicy());
     }
 
-    DataOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer)
-        : DataOutputStream(writer, errorPolicy)
-    {}
-
-    DataOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer, SoftFail)
-        : DataOutputStream(writer, errorPolicy)
-        , errorPolicy(softFail)
-    {}
-
-    DataOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer, NoFail)
-        : DataOutputStream(writer, errorPolicy)
-        , errorPolicy(noFail)
-    {}
-
-    DataOutputStream::WithErrorPolicy::WithErrorPolicy(const WithErrorPolicy& other)
-        : DataOutputStream(other.Writer(), errorPolicy)
-        , errorPolicy(other.ErrorPolicy())
-    {}
-
-    TextOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer)
-        : TextOutputStream(writer, errorPolicy)
-    {}
-
-    TextOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer, SoftFail)
-        : TextOutputStream(writer, errorPolicy)
-        , errorPolicy(softFail)
-    {}
-
-    TextOutputStream::WithErrorPolicy::WithErrorPolicy(StreamWriter& writer, NoFail)
-        : TextOutputStream(writer, errorPolicy)
-        , errorPolicy(noFail)
-    {}
-
-    TextOutputStream::WithErrorPolicy::WithErrorPolicy(const WithErrorPolicy& other)
-        : TextOutputStream(other.Writer(), errorPolicy)
-        , errorPolicy(other.ErrorPolicy())
-    {}
-
     AsAsciiHelper::AsAsciiHelper(ConstByteRange data)
         : data(data)
     {}

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -83,7 +83,7 @@ namespace infra
     };
 
     template<class Parent, class WriterType>
-    class OutputStreamWithWriter
+    class OutputStreamWithWriter //NOSONAR
         : private detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>
         , public Parent
     {
@@ -97,7 +97,7 @@ namespace infra
         OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args);
         template<class Storage, class... Args>
         OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args);
-        OutputStreamWithWriter(const OutputStreamWithWriter& other); //NOSONAR
+        OutputStreamWithWriter(const OutputStreamWithWriter& other);
         OutputStreamWithWriter& operator=(const OutputStreamWithWriter& other) = delete;
         ~OutputStreamWithWriter() = default;
 
@@ -108,14 +108,14 @@ namespace infra
     };
 
     template<class Parent>
-    class OutputStreamWithErrorPolicy
+    class OutputStreamWithErrorPolicy //NOSONAR
         : public Parent
     {
     public:
         explicit OutputStreamWithErrorPolicy(StreamWriter& writer);
         OutputStreamWithErrorPolicy(StreamWriter& writer, SoftFail);
         OutputStreamWithErrorPolicy(StreamWriter& writer, NoFail);
-        OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other); //NOSONAR
+        OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other);
         OutputStreamWithErrorPolicy& operator=(const OutputStreamWithErrorPolicy& other) = delete;
         ~OutputStreamWithErrorPolicy() = default;
 

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -210,7 +210,7 @@ namespace infra
     public:
         WithWriter();
         template<class Arg>
-        explicit WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        explicit WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
         template<class Arg0, class Arg1, class... Args>
         explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
@@ -249,7 +249,7 @@ namespace infra
     public:
         WithWriter();
         template<class Arg>
-        explicit WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        explicit WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
         template<class Arg0, class Arg1, class... Args>
         explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
@@ -412,7 +412,7 @@ namespace infra
 
     template<class TheWriter>
     template<class Arg>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
         : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
         , DataOutputStream(this->storage, errorPolicy)
     {}
@@ -460,7 +460,7 @@ namespace infra
 
     template<class TheWriter>
     template<class Arg>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
         : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
         , TextOutputStream(this->storage, errorPolicy)
     {}

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -208,8 +208,11 @@ namespace infra
         , public DataOutputStream
     {
     public:
-        template<class... Args>
-        explicit WithWriter(Args&&... args);
+        WithWriter();
+        template<class Arg>
+        explicit WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        template<class Arg0, class Arg1, class... Args>
+        explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
         WithWriter(Storage&& storage, SoftFail, Args&&... args);
         template<class Storage, class... Args>
@@ -244,8 +247,11 @@ namespace infra
         , public TextOutputStream
     {
     public:
-        template<class... Args>
-        explicit WithWriter(Args&&... args);
+        WithWriter();
+        template<class Arg>
+        explicit WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        template<class Arg0, class Arg1, class... Args>
+        explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class Storage, class... Args>
         WithWriter(Storage&& storage, SoftFail, Args&&... args);
         template<class Storage, class... Args>
@@ -400,9 +406,21 @@ namespace infra
     }
 
     template<class TheWriter>
-    template<class... Args>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Args>(args)...)
+    DataOutputStream::WithWriter<TheWriter>::WithWriter()
+        : DataOutputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheWriter>
+    template<class Arg>
+    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
+        , DataOutputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheWriter>
+    template<class Arg0, class Arg1, class... Args>
+    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , DataOutputStream(this->storage, errorPolicy)
     {}
 
@@ -436,9 +454,21 @@ namespace infra
     }
 
     template<class TheWriter>
-    template<class... Args>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Args>(args)...)
+    TextOutputStream::WithWriter<TheWriter>::WithWriter()
+        : TextOutputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheWriter>
+    template<class Arg>
+    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, typename std::enable_if<!std::is_same<WithWriter, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
+        , TextOutputStream(this->storage, errorPolicy)
+    {}
+
+    template<class TheWriter>
+    template<class Arg0, class Arg1, class... Args>
+    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , TextOutputStream(this->storage, errorPolicy)
     {}
 

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -82,9 +82,9 @@ namespace infra
         StreamErrorPolicy& errorPolicy;
     };
 
-    template<class Parent, class TheWriter>
+    template<class Parent, class WriterType>
     class OutputStreamWithWriter
-        : private detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>
+        : private detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>
         , public Parent
     {
     public:
@@ -101,7 +101,7 @@ namespace infra
         OutputStreamWithWriter& operator=(const OutputStreamWithWriter& other) = delete;
         ~OutputStreamWithWriter() = default;
 
-        TheWriter& Writer();
+        WriterType& Writer();
 
     private:
         StreamErrorPolicy errorPolicy;
@@ -367,50 +367,50 @@ namespace infra
         return *this;
     }
 
-    template<class Parent, class TheWriter>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter()
+    template<class Parent, class WriterType>
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter()
         : Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheWriter>
+    template<class Parent, class WriterType>
     template<class Arg>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<OutputStreamWithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
-        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Arg>(arg))
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<OutputStreamWithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
+        : detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>(std::forward<Arg>(arg))
         , Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheWriter>
+    template<class Parent, class WriterType>
     template<class Arg0, class Arg1, class... Args>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
-        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
     {}
 
-    template<class Parent, class TheWriter>
+    template<class Parent, class WriterType>
     template<class Storage, class... Args>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args)
+        : detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
         , errorPolicy(softFail)
     {}
 
-    template<class Parent, class TheWriter>
+    template<class Parent, class WriterType>
     template<class Storage, class... Args>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args)
+        : detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
         , Parent(this->storage, errorPolicy)
         , errorPolicy(noFail)
     {}
 
-    template<class Parent, class TheWriter>
-    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(const OutputStreamWithWriter& other)
-        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(static_cast<detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>&>(other))
+    template<class Parent, class WriterType>
+    OutputStreamWithWriter<Parent, WriterType>::OutputStreamWithWriter(const OutputStreamWithWriter& other)
+        : detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>(static_cast<detail::StorageHolder<WriterType, OutputStreamWithWriter<Parent, WriterType>>&>(other))
         , Parent(this->storage, errorPolicy)
         , errorPolicy(other.ErrorPolicy())
     {}
 
-    template<class Parent, class TheWriter>
-    TheWriter& OutputStreamWithWriter<Parent, TheWriter>::Writer()
+    template<class Parent, class WriterType>
+    WriterType& OutputStreamWithWriter<Parent, WriterType>::Writer()
     {
         return this->storage;
     }

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -97,7 +97,7 @@ namespace infra
         OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args);
         template<class Storage, class... Args>
         OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args);
-        OutputStreamWithWriter(const OutputStreamWithWriter& other);
+        OutputStreamWithWriter(const OutputStreamWithWriter& other); //NOSONAR
         OutputStreamWithWriter& operator=(const OutputStreamWithWriter& other) = delete;
         ~OutputStreamWithWriter() = default;
 
@@ -115,7 +115,8 @@ namespace infra
         explicit OutputStreamWithErrorPolicy(StreamWriter& writer);
         OutputStreamWithErrorPolicy(StreamWriter& writer, SoftFail);
         OutputStreamWithErrorPolicy(StreamWriter& writer, NoFail);
-        OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other);
+        OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other); //NOSONAR
+        OutputStreamWithErrorPolicy& operator=(const OutputStreamWithErrorPolicy& other) = delete;
         ~OutputStreamWithErrorPolicy() = default;
 
     private:

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -82,13 +82,53 @@ namespace infra
         StreamErrorPolicy& errorPolicy;
     };
 
+    template<class Parent, class TheWriter>
+    class OutputStreamWithWriter
+        : private detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>
+        , public Parent
+    {
+    public:
+        OutputStreamWithWriter();
+        template<class Arg>
+        explicit OutputStreamWithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<OutputStreamWithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
+        template<class Arg0, class Arg1, class... Args>
+        explicit OutputStreamWithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
+        template<class Storage, class... Args>
+        OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args);
+        template<class Storage, class... Args>
+        OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args);
+        OutputStreamWithWriter(const OutputStreamWithWriter& other);
+        OutputStreamWithWriter& operator=(const OutputStreamWithWriter& other) = delete;
+        ~OutputStreamWithWriter() = default;
+
+        TheWriter& Writer();
+
+    private:
+        StreamErrorPolicy errorPolicy;
+    };
+
+    template<class Parent>
+    class OutputStreamWithErrorPolicy
+        : public Parent
+    {
+    public:
+        explicit OutputStreamWithErrorPolicy(StreamWriter& writer);
+        OutputStreamWithErrorPolicy(StreamWriter& writer, SoftFail);
+        OutputStreamWithErrorPolicy(StreamWriter& writer, NoFail);
+        OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other);
+        ~OutputStreamWithErrorPolicy() = default;
+
+    private:
+        StreamErrorPolicy errorPolicy;
+    };
+
     class DataOutputStream
         : public OutputStream
     {
     public:
         template<class Writer>
-        class WithWriter;
-        class WithErrorPolicy;
+        using WithWriter = OutputStreamWithWriter<DataOutputStream, Writer>;
+        using WithErrorPolicy = OutputStreamWithErrorPolicy<DataOutputStream>;
 
         using OutputStream::OutputStream;
 
@@ -105,8 +145,8 @@ namespace infra
     {
     public:
         template<class Writer>
-        class WithWriter;
-        class WithErrorPolicy;
+        using WithWriter = OutputStreamWithWriter<TextOutputStream, Writer>;
+        using WithErrorPolicy = OutputStreamWithErrorPolicy<TextOutputStream>;
 
         TextOutputStream(StreamWriter& writer, StreamErrorPolicy& errorPolicy);
 
@@ -200,84 +240,6 @@ namespace infra
 
         Radix radix{ Radix::dec };
         Width width{ 0 };
-    };
-
-    template<class TheWriter>
-    class DataOutputStream::WithWriter
-        : private detail::StorageHolder<TheWriter, WithWriter<TheWriter>>
-        , public DataOutputStream
-    {
-    public:
-        WithWriter();
-        template<class Arg>
-        explicit WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
-        template<class Arg0, class Arg1, class... Args>
-        explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
-        template<class Storage, class... Args>
-        WithWriter(Storage&& storage, SoftFail, Args&&... args);
-        template<class Storage, class... Args>
-        WithWriter(Storage&& storage, NoFail, Args&&... args);
-        WithWriter(const WithWriter& other);
-        WithWriter& operator=(const WithWriter& other) = delete;
-        ~WithWriter() = default;
-
-        TheWriter& Writer();
-
-    private:
-        StreamErrorPolicy errorPolicy;
-    };
-
-    class DataOutputStream::WithErrorPolicy
-        : public DataOutputStream
-    {
-    public:
-        explicit WithErrorPolicy(StreamWriter& writer);
-        WithErrorPolicy(StreamWriter& writer, SoftFail);
-        WithErrorPolicy(StreamWriter& writer, NoFail);
-        WithErrorPolicy(const WithErrorPolicy& other);
-        ~WithErrorPolicy() = default;
-
-    private:
-        StreamErrorPolicy errorPolicy;
-    };
-
-    template<class TheWriter>
-    class TextOutputStream::WithWriter
-        : private detail::StorageHolder<TheWriter, WithWriter<TheWriter>>
-        , public TextOutputStream
-    {
-    public:
-        WithWriter();
-        template<class Arg>
-        explicit WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
-        template<class Arg0, class Arg1, class... Args>
-        explicit WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args);
-        template<class Storage, class... Args>
-        WithWriter(Storage&& storage, SoftFail, Args&&... args);
-        template<class Storage, class... Args>
-        WithWriter(Storage&& storage, NoFail, Args&&... args);
-        WithWriter(const WithWriter& other);
-        WithWriter& operator=(const WithWriter& other) = delete;
-        ~WithWriter() = default;
-
-        TheWriter& Writer();
-
-    private:
-        StreamErrorPolicy errorPolicy;
-    };
-
-    class TextOutputStream::WithErrorPolicy
-        : public TextOutputStream
-    {
-    public:
-        explicit WithErrorPolicy(StreamWriter& writer);
-        WithErrorPolicy(StreamWriter& writer, SoftFail);
-        WithErrorPolicy(StreamWriter& writer, NoFail);
-        WithErrorPolicy(const WithErrorPolicy& other);
-        ~WithErrorPolicy() = default;
-
-    private:
-        StreamErrorPolicy errorPolicy;
     };
 
     class AsAsciiHelper
@@ -405,101 +367,76 @@ namespace infra
         return *this;
     }
 
-    template<class TheWriter>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter()
-        : DataOutputStream(this->storage, errorPolicy)
+    template<class Parent, class TheWriter>
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter()
+        : Parent(this->storage, errorPolicy)
     {}
 
-    template<class TheWriter>
+    template<class Parent, class TheWriter>
     template<class Arg>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
-        , DataOutputStream(this->storage, errorPolicy)
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<OutputStreamWithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
+        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Arg>(arg))
+        , Parent(this->storage, errorPolicy)
     {}
 
-    template<class TheWriter>
+    template<class Parent, class TheWriter>
     template<class Arg0, class Arg1, class... Args>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
-        , DataOutputStream(this->storage, errorPolicy)
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
+        , Parent(this->storage, errorPolicy)
     {}
 
-    template<class TheWriter>
+    template<class Parent, class TheWriter>
     template<class Storage, class... Args>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Storage&& storage, SoftFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
-        , DataOutputStream(this->storage, errorPolicy)
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Storage&& storage, SoftFail, Args&&... args)
+        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+        , Parent(this->storage, errorPolicy)
         , errorPolicy(softFail)
     {}
 
-    template<class TheWriter>
+    template<class Parent, class TheWriter>
     template<class Storage, class... Args>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(Storage&& storage, NoFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
-        , DataOutputStream(this->storage, errorPolicy)
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(Storage&& storage, NoFail, Args&&... args)
+        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
+        , Parent(this->storage, errorPolicy)
         , errorPolicy(noFail)
     {}
 
-    template<class TheWriter>
-    DataOutputStream::WithWriter<TheWriter>::WithWriter(const WithWriter& other)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(static_cast<detail::StorageHolder<TheWriter, WithWriter<TheWriter>>&>(other))
-        , DataOutputStream(this->storage, errorPolicy)
+    template<class Parent, class TheWriter>
+    OutputStreamWithWriter<Parent, TheWriter>::OutputStreamWithWriter(const OutputStreamWithWriter& other)
+        : detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>(static_cast<detail::StorageHolder<TheWriter, OutputStreamWithWriter<Parent, TheWriter>>&>(other))
+        , Parent(this->storage, errorPolicy)
         , errorPolicy(other.ErrorPolicy())
     {}
 
-    template<class TheWriter>
-    TheWriter& DataOutputStream::WithWriter<TheWriter>::Writer()
+    template<class Parent, class TheWriter>
+    TheWriter& OutputStreamWithWriter<Parent, TheWriter>::Writer()
     {
         return this->storage;
     }
 
-    template<class TheWriter>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter()
-        : TextOutputStream(this->storage, errorPolicy)
+    template<class Parent>
+    OutputStreamWithErrorPolicy<Parent>::OutputStreamWithErrorPolicy(StreamWriter& writer)
+        : Parent(writer, errorPolicy)
     {}
 
-    template<class TheWriter>
-    template<class Arg>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg&& arg, std::enable_if_t<!std::is_same_v<WithWriter, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg>(arg))
-        , TextOutputStream(this->storage, errorPolicy)
-    {}
-
-    template<class TheWriter>
-    template<class Arg0, class Arg1, class... Args>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Arg0&& arg0, Arg1&& arg1, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...)
-        , TextOutputStream(this->storage, errorPolicy)
-    {}
-
-    template<class TheWriter>
-    template<class Storage, class... Args>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Storage&& storage, SoftFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
-        , TextOutputStream(this->storage, errorPolicy)
+    template<class Parent>
+    OutputStreamWithErrorPolicy<Parent>::OutputStreamWithErrorPolicy(StreamWriter& writer, SoftFail)
+        : Parent(writer, errorPolicy)
         , errorPolicy(softFail)
     {}
 
-    template<class TheWriter>
-    template<class Storage, class... Args>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(Storage&& storage, NoFail, Args&&... args)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(std::forward<Storage>(storage), std::forward<Args>(args)...)
-        , TextOutputStream(this->storage, errorPolicy)
+    template<class Parent>
+    OutputStreamWithErrorPolicy<Parent>::OutputStreamWithErrorPolicy(StreamWriter& writer, NoFail)
+        : Parent(writer, errorPolicy)
         , errorPolicy(noFail)
     {}
 
-    template<class TheWriter>
-    TextOutputStream::WithWriter<TheWriter>::WithWriter(const WithWriter& other)
-        : detail::StorageHolder<TheWriter, WithWriter<TheWriter>>(static_cast<detail::StorageHolder<TheWriter, WithWriter<TheWriter>>&>(other))
-        , TextOutputStream(this->storage, errorPolicy)
+    template<class Parent>
+    OutputStreamWithErrorPolicy<Parent>::OutputStreamWithErrorPolicy(const OutputStreamWithErrorPolicy& other)
+        : Parent(other.Writer(), errorPolicy)
         , errorPolicy(other.ErrorPolicy())
     {}
-
-    template<class TheWriter>
-    TheWriter& TextOutputStream::WithWriter<TheWriter>::Writer()
-    {
-        return this->storage;
-    }
 
     template<class T>
     TextOutputStream::Formatter<T>::Formatter(T value)

--- a/infra/util/SharedPtr.hpp
+++ b/infra/util/SharedPtr.hpp
@@ -737,7 +737,7 @@ namespace infra
             }
 
             template<class Arg>
-            SharedObjectOnHeap(Arg&& arg, typename std::enable_if<!std::is_same<SharedObjectOnHeap, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr)
+            SharedObjectOnHeap(Arg&& arg, std::enable_if_t<!std::is_same_v<SharedObjectOnHeap, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr)
                 : control(&*object, this)
             {
                 object.Construct(std::forward<Arg>(arg));

--- a/infra/util/SharedPtr.hpp
+++ b/infra/util/SharedPtr.hpp
@@ -730,11 +730,24 @@ namespace infra
             : private SharedObjectDeleter
         {
         public:
-            template<class... Args>
-            SharedObjectOnHeap(Args&&... args)
+            SharedObjectOnHeap()
                 : control(&*object, this)
             {
-                object.Construct(std::forward<Args>(args)...);
+                object.Construct();
+            }
+
+            template<class Arg>
+            SharedObjectOnHeap(Arg&& arg, typename std::enable_if<!std::is_same<SharedObjectOnHeap, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr)
+                : control(&*object, this)
+            {
+                object.Construct(std::forward<Arg>(arg));
+            }
+
+            template<class Arg0, class Arg1, class... Args>
+            SharedObjectOnHeap(Arg0&& arg0, Arg1&& arg1, Args&&... args)
+                : control(&*object, this)
+            {
+                object.Construct(std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...);
             }
 
             operator SharedPtr<T>()

--- a/infra/util/WithStorage.hpp
+++ b/infra/util/WithStorage.hpp
@@ -27,7 +27,7 @@ namespace infra
         template<class StorageArg, class... Args>
         WithStorage(InPlace, StorageArg&& storageArg, Args&&... args);
         template<class Arg>
-        WithStorage(Arg&& arg, typename std::enable_if<!std::is_same<WithStorage, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+        WithStorage(Arg&& arg, std::enable_if_t<!std::is_same_v<WithStorage, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
         template<class Arg0, class Arg1, class... Args>
         WithStorage(Arg0&& arg0, Arg1&& arg1, Args&&... args);
         template<class T, class... Args>
@@ -67,7 +67,7 @@ namespace infra
         public:
             StorageHolder() = default;
             template<class Arg>
-            StorageHolder(Arg&& arg, typename std::enable_if<!std::is_same<StorageHolder, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type = nullptr);
+            StorageHolder(Arg&& arg, std::enable_if_t<!std::is_same_v<StorageHolder, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t> = nullptr);
             template<class Arg0, class Arg1, class... Args>
             StorageHolder(Arg0&& arg0, Arg1&& arg1, Args&&... args);
 
@@ -91,7 +91,7 @@ namespace infra
 
     template<class Base, class StorageType>
     template<class Arg>
-    WithStorage<Base, StorageType>::WithStorage(Arg&& arg, typename std::enable_if<!std::is_same<WithStorage, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+    WithStorage<Base, StorageType>::WithStorage(Arg&& arg, std::enable_if_t<!std::is_same_v<WithStorage, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
         : Base(detail::StorageHolder<StorageType, Base>::storage, std::forward<Arg>(arg))
     {}
 
@@ -157,7 +157,7 @@ namespace infra
     {
         template<class StorageType, class Base>
         template<class Arg>
-        StorageHolder<StorageType, Base>::StorageHolder(Arg&& arg, typename std::enable_if<!std::is_same<StorageHolder, typename std::remove_cv<typename std::remove_reference<Arg>::type>::type>::value, void*>::type)
+        StorageHolder<StorageType, Base>::StorageHolder(Arg&& arg, std::enable_if_t<!std::is_same_v<StorageHolder, std::remove_cv_t<std::remove_reference_t<Arg>>>, std::nullptr_t>)
             : storage(std::forward<Arg>(arg))
         {}
 

--- a/services/network/WebSocketClientConnectionObserver.cpp
+++ b/services/network/WebSocketClientConnectionObserver.cpp
@@ -401,7 +401,7 @@ namespace services
     {
         std::array<uint8_t, 16> randomData;
         randomDataGenerator.GenerateRandomData(randomData);
-        infra::StringOutputStream::WithWriter stream(webSocketKey);
+        infra::TextOutputStream::WithWriter<infra::StringOutputStreamWriter> stream(webSocketKey);
         stream << infra::AsBase64(randomData);
 
         headers.emplace_back("Content-Length", "0");

--- a/services/util/WritableConfiguration.hpp
+++ b/services/util/WritableConfiguration.hpp
@@ -132,7 +132,7 @@ namespace services
     template<class T, class TRef>
     void WritableConfiguration<T, TRef>::LoadConfiguration(infra::ConstByteRange memory)
     {
-        infra::ByteInputStream::WithReader stream(memory, infra::noFail);
+        infra::DataInputStream::WithReader<infra::ByteInputStreamReader> stream(memory, infra::noFail);
         auto header = stream.Extract<Header>();
 
         valid = false;


### PR DESCRIPTION
ensure forwarding constructors have constraints that prevent copying / moving objects of the same type