### PR TITLE
ci: don't auto-update echo plugin versions

### DIFF
--- a/protobuf/echo/protocol_buffer_echo.cmake
+++ b/protobuf/echo/protocol_buffer_echo.cmake
@@ -17,7 +17,7 @@ function(emil_fetch_echo_plugins)
         return()
     endif()
 
-    set(emil_version "3.2.0") # x-release-please-version
+    set(emil_version "3.2.0")
 
     if (CMAKE_HOST_WIN32)
         set(os_postfix "win64")


### PR DESCRIPTION
When the release-please Action creates a releasable PR the assets can't be downloaded from that release yet. This PR disables automatically updating the echo plugin version that is downloaded until a better solution is found.