### PR TITLE
fix: usable memory loss in HttpClientBasic::Path

### DIFF
--- a/services/network/HttpClientBasic.cpp
+++ b/services/network/HttpClientBasic.cpp
@@ -73,7 +73,7 @@ namespace services
     {
         auto path = services::PathFromUrl(url);
         auto offset = path.empty() ? url.size() : path.begin() - url.begin();
-        return infra::BoundedString(infra::MakeRange(url.begin() + offset, url.begin() + url.max_size() - offset), path.size());
+        return infra::BoundedString(infra::MakeRange(url.begin() + offset, url.begin() + url.max_size()), path.size());
     }
 
     services::HttpHeaders HttpClientBasic::Headers() const


### PR DESCRIPTION
This change is a one liner.

When Path is extracted, resulting BoundedString should have a internal range of size ;
 - maxSize - hostUrlSize but previously it was maxSize - hostUrlSize*2

What was the issue?
- String range was also trimmed at the end, the size of the host url.