### PR TITLE
fix: Line termination mismatch in hex files

### DIFF
--- a/infra/stream/StdStringInputStream.cpp
+++ b/infra/stream/StdStringInputStream.cpp
@@ -38,8 +38,7 @@ namespace infra
 
     ConstByteRange StdStringInputStreamReader::PeekContiguousRange(std::size_t start)
     {
-        ConstByteRange result(reinterpret_cast<const uint8_t*>(string.data()) + offset + start, reinterpret_cast<const uint8_t*>(string.size()));
-
+        ConstByteRange result(reinterpret_cast<const uint8_t*>(string.data()) + offset + start, reinterpret_cast<const uint8_t*>(string.data()) + string.size());
         return result;
     }
 

--- a/infra/stream/test/TestStdStringInputStream.cpp
+++ b/infra/stream/test/TestStdStringInputStream.cpp
@@ -50,3 +50,13 @@ TEST(StdStringInputStreamTest, PeekLiteral)
     stream.Consume(1);
     EXPECT_TRUE(stream.Empty());
 }
+
+TEST(StdStringInputStreamTest, PeekContiguousRange_returns_expected_range_size)
+{
+    infra::StdStringInputStream::WithStorage stream(infra::inPlace, "abcdef");
+
+    EXPECT_EQ(6, stream.PeekContiguousRange().size());
+
+    stream.Consume(2);
+    EXPECT_EQ(4, stream.PeekContiguousRange().size());
+}

--- a/upgrade/pack_builder/BinaryObject.hpp
+++ b/upgrade/pack_builder/BinaryObject.hpp
@@ -68,7 +68,7 @@ namespace application
     private:
         struct LineContents
         {
-            LineContents(std::string line, const std::string& fileName, int lineNumber);
+            LineContents(const std::string& line, const std::string& fileName, int lineNumber);
 
             uint8_t recordType;
             uint16_t address;

--- a/upgrade/pack_builder/test/TestBinaryObject.cpp
+++ b/upgrade/pack_builder/test/TestBinaryObject.cpp
@@ -127,6 +127,15 @@ TEST(BinaryObjectTest, Hex_TooLongRecord)
     EXPECT_THROW(object.AddHex(std::vector<std::string>{ ":0100000001fe0" }, 0, "file"), application::RecordTooLongException);
 }
 
+TEST(BinaryObjectTest, Hex_TrailingLineTerminator)
+{
+    application::BinaryObject object;
+    object.AddHex(std::vector<std::string>{ ":00000001FF\r" }, 0, "file");
+
+    application::SparseVector<uint8_t> expectedMemory;
+    EXPECT_EQ(expectedMemory, object.Memory());
+}
+
 TEST(BinaryObjectTest, Bin_AddByte)
 {
     application::BinaryObject object;


### PR DESCRIPTION
A .hex file might have line termination with LF (Unix style) or CRLF (Windows style)
Given a .hex with CRLF termination and a pack_builder running on Linux, it would fail to convert the .hex file with Record Too Long exception