### PR TITLE
fix: UpgradePackBuilderFacade setting mbedtls global memory pool on stack

### DIFF
--- a/upgrade/pack_builder_instantiations/UpgradePackBuilderFacade.cpp
+++ b/upgrade/pack_builder_instantiations/UpgradePackBuilderFacade.cpp
@@ -1,7 +1,6 @@
 #include "upgrade/pack_builder_instantiations/UpgradePackBuilderFacade.hpp"
 #include "hal/generic/FileSystemGeneric.hpp"
 #include "hal/generic/SynchronousRandomDataGeneratorGeneric.hpp"
-#include "mbedtls/memory_buffer_alloc.h"
 #include "upgrade/pack_builder/BinaryObject.hpp"
 #include "upgrade/pack_builder/ImageEncryptorAes.hpp"
 #include "upgrade/pack_builder/ImageEncryptorNone.hpp"
@@ -23,11 +22,7 @@ namespace main_
 
     UpgradePackBuilderFacade::UpgradePackBuilderFacade(const application::UpgradePackBuilder::HeaderInfo& headerInfo)
         : headerInfo(headerInfo)
-    {
-        // Initialize the MbedTLS memory pool
-        unsigned char memory_buf[100000];
-        mbedtls_memory_buffer_alloc_init(memory_buf, sizeof(memory_buf));
-    }
+    {}
 
     void UpgradePackBuilderFacade::Build(const application::SupportedTargets& supportedTargets, const TargetAndFiles& requestedTargets, const std::string& outputFilename,
         const BuildOptions& buildOptions, infra::JsonObject& configuration, const DefaultKeyMaterial& keys)


### PR DESCRIPTION
# Summary
- This PR fixes the crash when ConnectionMbedTls is combined with UpgradePackBuilderFacade

# Issue Reproduction
1- Create ConnectionMbedTls
2- Run UpgradePackBuilderFacade 
3- Attempt to create ConnectionMbedTls for another host
4- Observe failure on `mbedtls_ssl_session_free()`

# Details 
- When UpgradePackBuilderFacade is combined with ConnectionMbedTls, connection memory pool is allocated on the heap. However, UpgradePackBuilderFacade sets global mbed tls buffers on stack, which then causes free() to be called on heap pointers in the context of stack.
- When MBEDTLS_MEMORY_DEBUG is defined; `FATAL: mbedtls_free() outside of managed space` is printed. This indicates either the memory pool is corrupted or the pointers. In this case, mbedtls memory pool is set to stack memory while initialization of a ConnectionMbedTls had been done on the heap. When ConnectionMbedTls tries to free its resources in the pool, because the pool has changed, this operation becomes invalid and causes the program to exit. 