### PR TITLE
chore: remove static functions from GapAdvertisingDataParser class

### DIFF
--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -111,7 +111,7 @@ namespace services
         : data(data)
     { }
 
-    infra::ConstByteRange GapAdvertisingDataParser::LocalName()
+    infra::ConstByteRange GapAdvertisingDataParser::LocalName() const
     {
         auto localName = ParserAdvertisingData(GapAdvertisementDataType::completeLocalName);
 
@@ -121,7 +121,7 @@ namespace services
             return localName;
     }
 
-    infra::ConstByteRange GapAdvertisingDataParser::ManufacturerSpecificData()
+    infra::ConstByteRange GapAdvertisingDataParser::ManufacturerSpecificData() const
     {
         return ParserAdvertisingData(GapAdvertisementDataType::manufacturerSpecificData);
     }

--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -107,33 +107,38 @@ namespace services
         GapCentralObserver::Subject().StopDeviceDiscovery();
     }
 
-    infra::ConstByteRange GapAdvertisingDataParser::LocalName(infra::ConstByteRange data)
+    GapAdvertisingDataParser::GapAdvertisingDataParser(infra::ConstByteRange data)
+        : data(data)
+    { }
+
+    infra::ConstByteRange GapAdvertisingDataParser::LocalName()
     {
-        auto localName = ParserAdvertisingData(data, GapAdvertisementDataType::completeLocalName);
+        auto localName = ParserAdvertisingData(GapAdvertisementDataType::completeLocalName);
 
         if (localName.empty())
-            return ParserAdvertisingData(data, GapAdvertisementDataType::shortenedLocalName);
+            return ParserAdvertisingData(GapAdvertisementDataType::shortenedLocalName);
         else
             return localName;
     }
 
-    infra::ConstByteRange GapAdvertisingDataParser::ManufacturerSpecificData(infra::ConstByteRange data)
+    infra::ConstByteRange GapAdvertisingDataParser::ManufacturerSpecificData()
     {
-        return ParserAdvertisingData(data, GapAdvertisementDataType::manufacturerSpecificData);
+        return ParserAdvertisingData(GapAdvertisementDataType::manufacturerSpecificData);
     }
 
-    infra::ConstByteRange GapAdvertisingDataParser::ParserAdvertisingData(infra::ConstByteRange data, GapAdvertisementDataType type)
+    infra::ConstByteRange GapAdvertisingDataParser::ParserAdvertisingData(GapAdvertisementDataType type) const
     {
         const uint8_t lengthOffset = 0;
         const uint8_t advertisingTypeOffset = 1;
         const uint8_t payloadStartOffset = 2;
+        infra::ConstByteRange searchRange = data;
 
-        while (!data.empty() && data[lengthOffset] != 0)
+        while (!searchRange.empty() && searchRange[lengthOffset] != 0)
         {
-            auto advertisingType = data[advertisingTypeOffset];
-            auto payloadSize = data[lengthOffset] + 1;
-            infra::ConstByteRange payload(data.begin() + payloadStartOffset, data.begin() + payloadSize);
-            data.shrink_from_front_to(data.size() - payloadSize);
+            auto advertisingType = searchRange[advertisingTypeOffset];
+            auto payloadSize = searchRange[lengthOffset] + 1;
+            infra::ConstByteRange payload(searchRange.begin() + payloadStartOffset, searchRange.begin() + payloadSize);
+            searchRange.shrink_from_front_to(searchRange.size() - payloadSize);
 
             if (payload.size() > 1 && advertisingType == static_cast<uint8_t>(type))
                 return payload;

--- a/services/ble/Gap.hpp
+++ b/services/ble/Gap.hpp
@@ -125,8 +125,8 @@ namespace services
     public:
         explicit GapAdvertisingDataParser(infra::ConstByteRange data);
 
-        infra::ConstByteRange LocalName();
-        infra::ConstByteRange ManufacturerSpecificData();
+        infra::ConstByteRange LocalName() const;
+        infra::ConstByteRange ManufacturerSpecificData() const;
 
     private:
         infra::ConstByteRange data;

--- a/services/ble/Gap.hpp
+++ b/services/ble/Gap.hpp
@@ -123,11 +123,16 @@ namespace services
     class GapAdvertisingDataParser
     {
     public:
-        static infra::ConstByteRange LocalName(infra::ConstByteRange data);
-        static infra::ConstByteRange ManufacturerSpecificData(infra::ConstByteRange data);
+        explicit GapAdvertisingDataParser(infra::ConstByteRange data);
+
+        infra::ConstByteRange LocalName();
+        infra::ConstByteRange ManufacturerSpecificData();
 
     private:
-        static infra::ConstByteRange ParserAdvertisingData(infra::ConstByteRange data, GapAdvertisementDataType type);
+        infra::ConstByteRange data;
+
+    private:
+        infra::ConstByteRange ParserAdvertisingData(GapAdvertisementDataType type) const;
     };
 
     class GapPeripheralPairing;

--- a/services/ble/test/TestGapCentral.cpp
+++ b/services/ble/test/TestGapCentral.cpp
@@ -95,43 +95,48 @@ namespace services
     TEST(GapAdvertisingDataParserTest, payload_does_not_contain_valid_info)
     {
         std::array<uint8_t, 1> data{ { 0x00 } };
+        services::GapAdvertisingDataParser gapAdvertisingDataParser(infra::MakeConstByteRange(data));
 
-        EXPECT_EQ(infra::ConstByteRange(), services::GapAdvertisingDataParser::LocalName(infra::MakeConstByteRange(data)));
-        EXPECT_EQ(infra::ConstByteRange(), services::GapAdvertisingDataParser::ManufacturerSpecificData(infra::MakeConstByteRange(data)));
+        EXPECT_EQ(infra::ConstByteRange(), gapAdvertisingDataParser.LocalName());
+        EXPECT_EQ(infra::ConstByteRange(), gapAdvertisingDataParser.ManufacturerSpecificData());
     }
 
     TEST(GapAdvertisingDataParserTest, get_local_name_using_type_shortenedLocalName)
     {
         std::array<uint8_t, 5> data{ { 0x04, 0x08, 0x73, 0x74, 0x72 } };
+        services::GapAdvertisingDataParser gapAdvertisingDataParser(infra::MakeConstByteRange(data));
 
-        EXPECT_EQ("str", ByteRangeAsStdString(services::GapAdvertisingDataParser::LocalName(infra::MakeConstByteRange(data))));
-        EXPECT_EQ(infra::ConstByteRange(), services::GapAdvertisingDataParser::ManufacturerSpecificData(infra::MakeConstByteRange(data)));
+        EXPECT_EQ("str", ByteRangeAsStdString(gapAdvertisingDataParser.LocalName()));
+        EXPECT_EQ(infra::ConstByteRange(), gapAdvertisingDataParser.ManufacturerSpecificData());
     }
 
     TEST(GapAdvertisingDataParserTest, get_local_name_using_type_completeLocalName)
     {
         std::array<uint8_t, 8> data{ { 0x07, 0x09, 0x73, 0x74, 0x72, 0x69, 0x6E, 0x67 } };
+        services::GapAdvertisingDataParser gapAdvertisingDataParser(infra::MakeConstByteRange(data));
 
-        EXPECT_EQ("string", ByteRangeAsStdString(services::GapAdvertisingDataParser::LocalName(infra::MakeConstByteRange(data))));
-        EXPECT_EQ(infra::ConstByteRange(), services::GapAdvertisingDataParser::ManufacturerSpecificData(infra::MakeConstByteRange(data)));
+        EXPECT_EQ("string", ByteRangeAsStdString(gapAdvertisingDataParser.LocalName()));
+        EXPECT_EQ(infra::ConstByteRange(), gapAdvertisingDataParser.ManufacturerSpecificData());
     }
 
     TEST(GapAdvertisingDataParserTest, get_manufacturer_specific_data)
     {
         std::array<uint8_t, 6> data{ { 0x05, 0xff, 0xaa, 0xbb, 0xcc, 0xdd } };
         std::array<uint8_t, 4> payloadParser{ { 0xaa, 0xbb, 0xcc, 0xdd } };
+        services::GapAdvertisingDataParser gapAdvertisingDataParser(infra::MakeConstByteRange(data));
 
-        EXPECT_EQ(infra::ConstByteRange(), services::GapAdvertisingDataParser::LocalName(infra::MakeConstByteRange(data)));
-        EXPECT_TRUE(infra::ContentsEqual(infra::MakeConstByteRange(payloadParser), services::GapAdvertisingDataParser::ManufacturerSpecificData(infra::MakeConstByteRange(data))));
+        EXPECT_EQ(infra::ConstByteRange(), gapAdvertisingDataParser.LocalName());
+        EXPECT_TRUE(infra::ContentsEqual(infra::MakeConstByteRange(payloadParser), gapAdvertisingDataParser.ManufacturerSpecificData()));
     }
 
     TEST(GapAdvertisingDataParserTest, useful_info_after_first_ad_structure)
     {
         std::array<uint8_t, 21> data{ { 0x02, 0x01, 0x06, 0x08, 0x09, 0x70, 0x68, 0x69, 0x6C, 0x69, 0x70, 0x73, 0x02, 0x0a, 0x08, 0x05, 0xff, 0xaa, 0xbb, 0xcc, 0xdd } };
         std::array<uint8_t, 4> payloadParser{ { 0xaa, 0xbb, 0xcc, 0xdd } };
+        services::GapAdvertisingDataParser gapAdvertisingDataParser(infra::MakeConstByteRange(data));
 
-        EXPECT_EQ("philips", ByteRangeAsStdString(services::GapAdvertisingDataParser::LocalName(infra::MakeConstByteRange(data))));
-        EXPECT_TRUE(infra::ContentsEqual(infra::MakeConstByteRange(payloadParser), services::GapAdvertisingDataParser::ManufacturerSpecificData(infra::MakeConstByteRange(data))));
+        EXPECT_EQ("philips", ByteRangeAsStdString(gapAdvertisingDataParser.LocalName()));
+        EXPECT_TRUE(infra::ContentsEqual(infra::MakeConstByteRange(payloadParser), gapAdvertisingDataParser.ManufacturerSpecificData()));
     }
 
     TEST(GapInsertionOperatorEventTypeTest, event_type_overload_operator)


### PR DESCRIPTION
remove static functions from GapAdvertisingDataParser class