### PR TITLE
ci: only run dependency-review on pull requests

### DIFF
--- a/.github/workflows/dependency-scanner.yml
+++ b/.github/workflows/dependency-scanner.yml
@@ -4,9 +4,6 @@ name: Dependency Scanner
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
   merge_group:
 
 permissions:
@@ -21,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: philips-forks/cmake-dependency-submission@72880580a7cafc16145d82268f1892c0ece3da2a # main
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: [dependency-submission]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/dependency-review-action@1360a344ccb0ab6e9475edef90ad2f46bf8003b1 # v3.0.6
         with:
           comment-summary-in-pr: true


### PR DESCRIPTION
The dependency-review-action can run only in PR context. Disable it for the merge queue.

Also remove the push event, the merge queue already runs in the context of main.