### PR TITLE
chore: enable compact status bar for CMake Tools by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "cmake.copyCompileCommands": "${workspaceFolder}/build/compile_commands.json",
   "sonarlint.pathToCompileCommands": "${workspaceFolder}/build/compile_commands.json",
-  "clangd.arguments": ["--query-driver=/**/arm-none-eabi-*"]
+  "clangd.arguments": ["--query-driver=/**/arm-none-eabi-*"],
+  "cmake.statusbar.visibility": "compact",
+  "cmake.useProjectStatusView": false
 }


### PR DESCRIPTION
# Summary
CMake Tools might not be configured to be shown on status bar in VSCode. (AFAIK this is due to A/B testing :) )
It would be make things easier if it's shown by default. 

For some, status bar might look something like this:
![image](https://github.com/philips-internal/amp-connectivity-nodes/assets/86656336/36d52d65-e9e3-4d07-b34d-ff9fc0cac55b)

However, most of us use different targets and would want to switch with one click using the status bar.
After this change status bar should look like this:
![image](https://github.com/philips-internal/amp-connectivity-nodes/assets/86656336/1d21cd19-29f5-4231-ae9b-d079288cfa9c)

