### PR TITLE
chore: solved build error with TracingEcho::PrintField being too greedy with enum types

### DIFF
--- a/protobuf/echo/TracingEcho.hpp
+++ b/protobuf/echo/TracingEcho.hpp
@@ -49,7 +49,7 @@ namespace services
     {}
 
     template<class T>
-    void PrintField(const T& value, services::Tracer& tracer, typename T::template Type<0>* = 0)
+    void PrintField(const T& value, services::Tracer& tracer, typename std::enable_if<!std::is_enum<T>::value>::type* = 0)
     {
         tracer.Continue() << "{";
         PrintSubFields<0>(value, tracer);
@@ -57,7 +57,7 @@ namespace services
     }
 
     template<class T>
-    void PrintField(const infra::BoundedVector<T>& value, services::Tracer& tracer, typename T::template Type<0>* = 0)
+    void PrintField(const infra::BoundedVector<T>& value, services::Tracer& tracer, typename std::enable_if<!std::is_enum<T>::value>::type* = 0)
     {
         tracer.Continue() << "[";
         for (auto& v : value)


### PR DESCRIPTION
Added SFINEA to solve a overload of PrintField beeing too greedy on enum types. Two templated versions exist, one to print any type of containers, and one to print a value directly.

The container overload version was too greedy, trying to print an enum type, thus resulting in a compilation error because you can't iterate over an enum.