### PR TITLE
chore: reduce interval of clusterfuzzlite updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   - package-ecosystem: docker
     directory: .clusterfuzzlite
     schedule:
-      interval: daily
+      interval: monthly


### PR DESCRIPTION
The Docker container for clusterfuzzlite is built and published automatically. This means a new daily pull request. Reduce the frequency of update to monthly.