### PR TITLE
chore: switch static analysis to container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   // This devcontainer has been set-up to run docker-from-docker scenarios as per
   // https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-from-docker
   "name": "amp-devcontainer",
-  "image": "ghcr.io/philips-software/amp-devcontainer:2.2.0",
+  "image": "ghcr.io/philips-software/amp-devcontainer:2.5.0",
   "runArgs": ["--add-host=host.docker.internal:host-gateway"],
   "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" },
   "mounts": [

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,7 +80,7 @@ jobs:
           languages: cpp
       - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
         with:
-          configurePreset: "ContinuousIntegration"
-          buildPreset: "ContinuousIntegration"
+          configurePreset: "host"
+          buildPreset: "host-Debug"
           configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
       - uses: github/codeql-action/analyze@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,26 +18,20 @@ jobs:
   sonar:
     name: SonarCloud
     runs-on: ubuntu-latest
+    container: ghcr.io/philips-software/amp-devcontainer:2.5.0
     env:
-      SONAR_SCANNER_VERSION: 4.7.0.2747
+      SONAR_SCANNER_VERSION: 5.0.1.3006
       SONAR_SERVER_URL: "https://sonarcloud.io"
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0 # Disable shallow clone to enable blame information
           persist-credentials: false
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends jq ninja-build xsltproc
-      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      - uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318
-        with:
-          packages: gcovr==5.2
-      - name: Install Sonar Scanner & Mull
+      - name: Install Sonar Scanner
         run: |
           wget -qN "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip"
           unzip -qqo "sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip"
           echo "${PWD}/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> "$GITHUB_PATH"
-          wget -qN https://github.com/mull-project/mull/releases/download/0.18.0/Mull-12-0.18.0-LLVM-12.0-ubuntu-20.04.deb
-          sudo dpkg -i Mull-12-0.18.0-LLVM-12.0-ubuntu-20.04.deb
       - uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
         with:
           key: ${{ github.job }}
@@ -48,11 +42,12 @@ jobs:
           cmake --build --preset coverage
           GTEST_OUTPUT="xml:${PWD}/testresults/" ctest --preset coverage
           gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j 2 --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
-      - name: Build & Run Mutation Tests
-        run: |
-          cmake --preset mutation-testing -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build --preset mutation-testing
-          ctest --preset mutation-testing
+      - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
+        with:
+          configurePreset: "MutationTesting"
+          buildPreset: "MutationTesting"
+          testPreset: "MutationTesting"
+          configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
       - name: Convert Results
         run: |
           { echo '<testExecutions version="1">'; xsltproc .github/formatters/gtest-to-generic-execution.xslt testresults/*.xml; echo '</testExecutions>'; } | tee execution.xml > /dev/null
@@ -70,20 +65,22 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    container: ghcr.io/philips-software/amp-devcontainer:2.5.0
     permissions:
       security-events: write
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           persist-credentials: false
-      - run: sudo apt-get update && sudo apt-get install ninja-build
       - uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
         with:
           key: ${{ github.job }}
       - uses: github/codeql-action/init@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
         with:
           languages: cpp
-      - run: |
-          cmake --preset host -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build --preset host-Debug
+      - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
+        with:
+          configurePreset: "ContinuousIntegration"
+          buildPreset: "ContinuousIntegration"
+          configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
       - uses: github/codeql-action/analyze@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,7 +41,7 @@ jobs:
           cmake --preset coverage -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset coverage
           GTEST_OUTPUT="xml:${PWD}/testresults/" ctest --preset coverage
-          gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j $(nproc) --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
+          gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j "$(nproc)" --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
       - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
         with:
           configurePreset: "mutation-testing"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,9 +44,9 @@ jobs:
           gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j 2 --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
       - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
         with:
-          configurePreset: "MutationTesting"
-          buildPreset: "MutationTesting"
-          testPreset: "MutationTesting"
+          configurePreset: "mutation-testing"
+          buildPreset: "mutation-testing"
+          testPreset: "mutation-testing"
           configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
       - name: Convert Results
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,7 +41,7 @@ jobs:
           cmake --preset coverage -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset coverage
           GTEST_OUTPUT="xml:${PWD}/testresults/" ctest --preset coverage
-          gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j 2 --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
+          gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort();' --exclude-unreachable-branches --exclude-throw-branches -j $(nproc) --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.* --exclude=.*/test/.*
       - uses: lukka/run-cmake@c2b72aff009141774c5a5fabe74ea46c8c04d9c4 # v10.6
         with:
           configurePreset: "mutation-testing"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
         "EMIL_ENABLE_MUTATION_TESTING": "On",
-        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
+        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--allow-surviving;--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
       },
       "generator": "Ninja"
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "configurePresets": [
     {
       "name": "defaults",
@@ -52,8 +52,8 @@
       "displayName": "Configuration for Mutation Testing",
       "inherits": "host",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-12",
-        "CMAKE_CXX_COMPILER": "clang++-12",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
         "EMIL_ENABLE_MUTATION_TESTING": "On",
         "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 3,
   "configurePresets": [
     {
       "name": "defaults",

--- a/cmake/emil_test_helpers.cmake
+++ b/cmake/emil_test_helpers.cmake
@@ -6,7 +6,7 @@ function(emil_fetch_googletest)
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest
-        GIT_TAG        b796f7d44681514f58a683a3a71ff17c94edb0c1 # v1.13.0
+        GIT_TAG        release-1.12.1
     )
 
     set(gtest_force_shared_crt On CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/cmake/emil_test_helpers.cmake
+++ b/cmake/emil_test_helpers.cmake
@@ -34,19 +34,10 @@ function(emil_enable_testing)
 
     if (EMIL_ENABLE_MUTATION_TESTING)
         if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-            execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
-
-            if(CLANG_VERSION VERSION_GREATER 15.0 OR CLANG_VERSION VERSION_EQUAL 15.0)
-                add_compile_options(
-                    -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
-                    -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend
-                )
-            else()
-                add_compile_options(
-                    -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
-                    -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend-12
-                )
-            endif()
+            add_compile_options(
+                -g -O0 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping
+                -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend
+            )
 
             add_link_options(-fprofile-instr-generate)
         else()
@@ -68,13 +59,7 @@ function(emil_add_test target)
     get_target_property(exclude ${target} EXCLUDE_FROM_ALL)
     if (NOT ${exclude})
         if (EMIL_ENABLE_MUTATION_TESTING)
-            execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
-
-            if(CLANG_VERSION VERSION_GREATER 15.0 OR CLANG_VERSION VERSION_EQUAL 15.0)
-                add_test(NAME ${target} COMMAND mull-runner ${EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS} $<TARGET_FILE:${target}>)
-            else()
-                add_test(NAME ${target} COMMAND mull-runner-12 ${EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS} $<TARGET_FILE:${target}>)
-            endif()
+            add_test(NAME ${target} COMMAND mull-runner ${EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS} $<TARGET_FILE:${target}>)
         else()
             add_test(NAME ${target} COMMAND ${target})
         endif()

--- a/cmake/emil_test_helpers.cmake
+++ b/cmake/emil_test_helpers.cmake
@@ -2,13 +2,11 @@ option(EMIL_ENABLE_COVERAGE "Enable compiler flags for code coverage measurement
 option(EMIL_ENABLE_MUTATION_TESTING "Enable compiler flags for mutation testing" Off)
 set(EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS "" CACHE STRING "Additional arguments for the mutation testing runner")
 
-function(emil_enable_testing)
-    include(GoogleTest)
-
+function(emil_fetch_googletest)
     FetchContent_Declare(
         googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG        release-1.12.1
+        GIT_REPOSITORY https://github.com/google/googletest
+        GIT_TAG        b796f7d44681514f58a683a3a71ff17c94edb0c1 # v1.13.0
     )
 
     set(gtest_force_shared_crt On CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings
@@ -18,6 +16,12 @@ function(emil_enable_testing)
 
     set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER External/GoogleTest)
     mark_as_advanced(BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS gmock_build_tests gtest_build_samples test_build_tests gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols)
+endfunction()
+
+function(emil_enable_testing)
+    include(GoogleTest)
+
+    emil_fetch_googletest()
 
     if (EMIL_ENABLE_COVERAGE)
         add_compile_options(

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     mbedtls
     GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls
-    GIT_TAG 72718dd87e087215ce9155a826ee5a66cfbe9631 # v3.4.1
+    GIT_TAG 869298bffeea13b205343361b7a7daf2b210e33d # v3.2.1
 )
 
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL On)
@@ -17,6 +17,10 @@ function(add_mbedtls_target_properties)
     foreach(target ${ARGN})
         target_compile_options(${target} PUBLIC
             -DMBEDTLS_CONFIG_FILE="mbedtls/mbedtls_emil_config.h"
+            # see https://github.com/Mbed-TLS/mbedtls/pull/6966
+            # mbedtls sets the -Wdocumentation flag, which is throwing warnings
+            # since clang-15
+            $<$<CXX_COMPILER_ID:Clang>:-Wno-documentation>
         )
 
         target_include_directories(${target} PUBLIC

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     mbedtls
     GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls
-    GIT_TAG 869298bffeea13b205343361b7a7daf2b210e33d # v3.2.1
+    GIT_TAG 72718dd87e087215ce9155a826ee5a66cfbe9631 # v3.4.1
 )
 
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL On)


### PR DESCRIPTION
Switch ci steps that conduct static analysis to amp-devcontainer to pin all the necessary dependencies. As opposed to running on the GitHub provided runner image with changing software specifications.