### PR TITLE
feat: added SerialCommunicationLoopback

### DIFF
--- a/services/util/CMakeLists.txt
+++ b/services/util/CMakeLists.txt
@@ -58,6 +58,8 @@ target_sources(services.util PRIVATE
     MessageCommunicationWindowed.hpp
     RepeatingButton.cpp
     RepeatingButton.hpp
+    SerialCommunicationLoopback.cpp
+    SerialCommunicationLoopback.hpp
     Sha256.hpp
     SignalLed.cpp
     SignalLed.hpp

--- a/services/util/SerialCommunicationLoopback.cpp
+++ b/services/util/SerialCommunicationLoopback.cpp
@@ -1,0 +1,36 @@
+#include "services/util/SerialCommunicationLoopback.hpp"
+#include "infra/event/EventDispatcher.hpp"
+
+namespace services
+{
+    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other)
+        : other{ other }
+    {}
+
+    void SerialCommunicationLoopbackPeer::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
+    {
+        this->data = data;
+        this->actionOnCompletion = actionOnCompletion;
+
+        infra::EventDispatcher::Instance().Schedule([this]
+            {
+                other.dataReceived(this->data);
+                this->actionOnCompletion();
+            });
+    }
+
+    void SerialCommunicationLoopbackPeer::ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived)
+    {
+        this->dataReceived = dataReceived;
+    }
+
+    SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Server()
+    {
+        return server;
+    }
+
+    SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Client()
+    {
+        return client;
+    }
+}

--- a/services/util/SerialCommunicationLoopback.cpp
+++ b/services/util/SerialCommunicationLoopback.cpp
@@ -3,8 +3,8 @@
 
 namespace services
 {
-    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other)
-        : other{ other }
+    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other)
+        : other{ *other }
     {}
 
     void SerialCommunicationLoopbackPeer::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
@@ -23,6 +23,11 @@ namespace services
     {
         this->dataReceived = dataReceived;
     }
+
+    SerialCommunicationLoopback::SerialCommunicationLoopback()
+        : server(&client)
+        , client(&server)
+    {}
 
     SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Server()
     {

--- a/services/util/SerialCommunicationLoopback.cpp
+++ b/services/util/SerialCommunicationLoopback.cpp
@@ -1,13 +1,29 @@
 #include "services/util/SerialCommunicationLoopback.hpp"
+#include "hal/interfaces/SerialCommunication.hpp"
 #include "infra/event/EventDispatcher.hpp"
 
 namespace services
 {
-    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other)
-        : other{ other }
+    SerialCommunicationLoopback::SerialCommunicationLoopback()
+        : server(&client)
+        , client(&server)
     {}
 
-    void SerialCommunicationLoopbackPeer::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
+    hal::SerialCommunication& SerialCommunicationLoopback::Server()
+    {
+        return server;
+    }
+
+    hal::SerialCommunication& SerialCommunicationLoopback::Client()
+    {
+        return client;
+    }
+
+    SerialCommunicationLoopback::SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other)
+        : other{ *other }
+    {}
+
+    void SerialCommunicationLoopback::SerialCommunicationLoopbackPeer::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
     {
         this->data = data;
         this->actionOnCompletion = actionOnCompletion;
@@ -19,23 +35,8 @@ namespace services
             });
     }
 
-    void SerialCommunicationLoopbackPeer::ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived)
+    void SerialCommunicationLoopback::SerialCommunicationLoopbackPeer::ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived)
     {
         this->dataReceived = dataReceived;
-    }
-
-    SerialCommunicationLoopback::SerialCommunicationLoopback()
-        : server(client)
-        , client(server)
-    {}
-
-    SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Server()
-    {
-        return server;
-    }
-
-    SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Client()
-    {
-        return client;
     }
 }

--- a/services/util/SerialCommunicationLoopback.cpp
+++ b/services/util/SerialCommunicationLoopback.cpp
@@ -3,8 +3,8 @@
 
 namespace services
 {
-    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other)
-        : other{ *other }
+    SerialCommunicationLoopbackPeer::SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other)
+        : other{ other }
     {}
 
     void SerialCommunicationLoopbackPeer::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
@@ -25,8 +25,8 @@ namespace services
     }
 
     SerialCommunicationLoopback::SerialCommunicationLoopback()
-        : server(&client)
-        , client(&server)
+        : server(client)
+        , client(server)
     {}
 
     SerialCommunicationLoopbackPeer& SerialCommunicationLoopback::Server()

--- a/services/util/SerialCommunicationLoopback.hpp
+++ b/services/util/SerialCommunicationLoopback.hpp
@@ -9,7 +9,7 @@ namespace services
         : public hal::SerialCommunication
     {
     public:
-        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other);
+        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other);
 
         void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
         void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
@@ -25,12 +25,14 @@ namespace services
     class SerialCommunicationLoopback
     {
     public:
+        SerialCommunicationLoopback();
+
         SerialCommunicationLoopbackPeer& Server();
         SerialCommunicationLoopbackPeer& Client();
 
     private:
-        SerialCommunicationLoopbackPeer server{ client };
-        SerialCommunicationLoopbackPeer client{ server };
+        SerialCommunicationLoopbackPeer server;
+        SerialCommunicationLoopbackPeer client;
     };
 }
 

--- a/services/util/SerialCommunicationLoopback.hpp
+++ b/services/util/SerialCommunicationLoopback.hpp
@@ -5,30 +5,34 @@
 
 namespace services
 {
-    class SerialCommunicationLoopbackPeer
-        : public hal::SerialCommunication
-    {
-    public:
-        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other);
-
-        void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
-        void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
-
-    private:
-        SerialCommunicationLoopbackPeer& other;
-
-        infra::ConstByteRange data;
-        infra::Function<void()> actionOnCompletion;
-        infra::Function<void(infra::ConstByteRange data)> dataReceived;
-    };
 
     class SerialCommunicationLoopback
     {
     public:
         SerialCommunicationLoopback();
 
-        SerialCommunicationLoopbackPeer& Server();
-        SerialCommunicationLoopbackPeer& Client();
+        hal::SerialCommunication& Server();
+        hal::SerialCommunication& Client();
+
+    private:
+        class SerialCommunicationLoopbackPeer
+            : public hal::SerialCommunication
+        {
+        public:
+            // pointer instead of reference to avoid defining a copy constructor
+            // pass by reference generates a warning with clang and -Wunitialized
+            explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other);
+
+            void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
+            void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
+
+        private:
+            SerialCommunicationLoopbackPeer& other;
+
+            infra::ConstByteRange data;
+            infra::Function<void()> actionOnCompletion;
+            infra::Function<void(infra::ConstByteRange data)> dataReceived;
+        };
 
     private:
         SerialCommunicationLoopbackPeer server;

--- a/services/util/SerialCommunicationLoopback.hpp
+++ b/services/util/SerialCommunicationLoopback.hpp
@@ -1,0 +1,37 @@
+#ifndef SERVICES_SERIAL_COMMUNICATION_LOOPBACK_HPP
+#define SERVICES_SERIAL_COMMUNICATION_LOOPBACK_HPP
+
+#include "hal/interfaces/SerialCommunication.hpp"
+
+namespace services
+{
+    class SerialCommunicationLoopbackPeer
+        : public hal::SerialCommunication
+    {
+    public:
+        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other);
+
+        void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
+        void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
+
+    private:
+        SerialCommunicationLoopbackPeer& other;
+
+        infra::ConstByteRange data;
+        infra::Function<void()> actionOnCompletion;
+        infra::Function<void(infra::ConstByteRange data)> dataReceived;
+    };
+
+    class SerialCommunicationLoopback
+    {
+    public:
+        SerialCommunicationLoopbackPeer& Server();
+        SerialCommunicationLoopbackPeer& Client();
+
+    private:
+        SerialCommunicationLoopbackPeer server{ client };
+        SerialCommunicationLoopbackPeer client{ server };
+    };
+}
+
+#endif

--- a/services/util/SerialCommunicationLoopback.hpp
+++ b/services/util/SerialCommunicationLoopback.hpp
@@ -9,7 +9,7 @@ namespace services
         : public hal::SerialCommunication
     {
     public:
-        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer* other);
+        explicit SerialCommunicationLoopbackPeer(SerialCommunicationLoopbackPeer& other);
 
         void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
         void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(services.util_test PRIVATE
     TestMessageCommunicationSecured.cpp
     TestMessageCommunicationWindowed.cpp
     TestRepeatingButton.cpp
+    TestSerialCommunicationLoopback.cpp
     TestSignalLed.cpp
     TestSpiMasterWithChipSelect.cpp
     TestSpiMultipleAccess.cpp

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(services.util_test PUBLIC
     hal.interfaces_test_doubles
     infra.timer_test_helper
     infra.util_test_helper
+    infra.event_test_helper
 )
 
 target_sources(services.util_test PRIVATE

--- a/services/util/test/TestSerialCommunicationLoopback.cpp
+++ b/services/util/test/TestSerialCommunicationLoopback.cpp
@@ -1,3 +1,4 @@
+#include "hal/interfaces/SerialCommunication.hpp"
 #include "infra/event/test_helper/EventDispatcherFixture.hpp"
 #include "infra/util/ByteRange.hpp"
 #include "infra/util/Function.hpp"
@@ -12,8 +13,8 @@ class SerialCommunicationLoopbackTest
 {
 public:
     services::SerialCommunicationLoopback SerialCommunicationLoopback;
-    services::SerialCommunicationLoopbackPeer& server{ SerialCommunicationLoopback.Server() };
-    services::SerialCommunicationLoopbackPeer& client{ SerialCommunicationLoopback.Client() };
+    hal::SerialCommunication& server{ SerialCommunicationLoopback.Server() };
+    hal::SerialCommunication& client{ SerialCommunicationLoopback.Client() };
 };
 
 TEST_F(SerialCommunicationLoopbackTest, SendFromServerReceiveByClient)

--- a/services/util/test/TestSerialCommunicationLoopback.cpp
+++ b/services/util/test/TestSerialCommunicationLoopback.cpp
@@ -1,0 +1,59 @@
+#include "infra/timer/test_helper/ClockFixture.hpp"
+#include "infra/util/ByteRange.hpp"
+#include "infra/util/Function.hpp"
+#include "infra/util/test_helper/MockCallback.hpp"
+#include "services/util/SerialCommunicationLoopback.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+class SerialCommunicationLoopbackTest
+    : public testing::Test
+    , public infra::ClockFixture
+{
+public:
+    services::SerialCommunicationLoopback SerialCommunicationLoopback;
+    services::SerialCommunicationLoopbackPeer& server{ SerialCommunicationLoopback.Server() };
+    services::SerialCommunicationLoopbackPeer& client{ SerialCommunicationLoopback.Client() };
+};
+
+TEST_F(SerialCommunicationLoopbackTest, SendFromServerReceiveByClient)
+{
+    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> clientReceiveCallback{ infra::MakeStringByteRange("hello") };
+
+    client.ReceiveData(clientReceiveCallback);
+    server.SendData(infra::MakeStringByteRange("hello"), infra::emptyFunction);
+
+    ExecuteAllActions();
+}
+
+TEST_F(SerialCommunicationLoopbackTest, SendFromClientReceiveByServer)
+{
+    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> serverReceiveCallback{ infra::MakeStringByteRange("world") };
+
+    server.ReceiveData(serverReceiveCallback);
+    client.SendData(infra::MakeStringByteRange("world"), infra::emptyFunction);
+
+    ExecuteAllActions();
+}
+
+TEST_F(SerialCommunicationLoopbackTest, ActionOnCompletionAfterDataReceivedByOtherPeer)
+{
+    infra::MockCallback<void(infra::ConstByteRange)> dataReceivedMockCallback;
+    infra::MockCallback<void()> actionOnCompletionMockCallback;
+
+    server.ReceiveData([&dataReceivedMockCallback](infra::ConstByteRange data)
+        {
+            dataReceivedMockCallback.callback(data);
+        });
+
+    client.SendData(infra::MakeStringByteRange("Hello World!"), [&actionOnCompletionMockCallback]
+        {
+            actionOnCompletionMockCallback.callback();
+        });
+
+    testing::InSequence sequence;
+    EXPECT_CALL(dataReceivedMockCallback, callback(infra::MakeStringByteRange("Hello World!")));
+    EXPECT_CALL(actionOnCompletionMockCallback, callback());
+
+    ExecuteAllActions();
+}

--- a/services/util/test/TestSerialCommunicationLoopback.cpp
+++ b/services/util/test/TestSerialCommunicationLoopback.cpp
@@ -18,26 +18,29 @@ public:
 
 TEST_F(SerialCommunicationLoopbackTest, SendFromServerReceiveByClient)
 {
-    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> clientReceiveCallback{ infra::MakeStringByteRange("hello") };
+    infra::ConstByteRange data = infra::MakeStringByteRange("hello");
+    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> clientReceiveCallback{ data };
 
     client.ReceiveData(clientReceiveCallback);
-    server.SendData(infra::MakeStringByteRange("hello"), infra::emptyFunction);
+    server.SendData(data, infra::emptyFunction);
 
     ExecuteAllActions();
 }
 
 TEST_F(SerialCommunicationLoopbackTest, SendFromClientReceiveByServer)
 {
-    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> serverReceiveCallback{ infra::MakeStringByteRange("world") };
+    infra::ConstByteRange data = infra::MakeStringByteRange("world");
+    infra::VerifyingFunctionMock<void(infra::ConstByteRange)> serverReceiveCallback{ data };
 
     server.ReceiveData(serverReceiveCallback);
-    client.SendData(infra::MakeStringByteRange("world"), infra::emptyFunction);
+    client.SendData(data, infra::emptyFunction);
 
     ExecuteAllActions();
 }
 
 TEST_F(SerialCommunicationLoopbackTest, ActionOnCompletionAfterDataReceivedByOtherPeer)
 {
+    infra::ConstByteRange data = infra::MakeStringByteRange("Hello World!");
     infra::MockCallback<void(infra::ConstByteRange)> dataReceivedMockCallback;
     infra::MockCallback<void()> actionOnCompletionMockCallback;
 
@@ -46,13 +49,13 @@ TEST_F(SerialCommunicationLoopbackTest, ActionOnCompletionAfterDataReceivedByOth
             dataReceivedMockCallback.callback(data);
         });
 
-    client.SendData(infra::MakeStringByteRange("Hello World!"), [&actionOnCompletionMockCallback]
+    client.SendData(data, [&actionOnCompletionMockCallback]
         {
             actionOnCompletionMockCallback.callback();
         });
 
     testing::InSequence sequence;
-    EXPECT_CALL(dataReceivedMockCallback, callback(infra::MakeStringByteRange("Hello World!")));
+    EXPECT_CALL(dataReceivedMockCallback, callback(data));
     EXPECT_CALL(actionOnCompletionMockCallback, callback());
 
     ExecuteAllActions();

--- a/services/util/test/TestSerialCommunicationLoopback.cpp
+++ b/services/util/test/TestSerialCommunicationLoopback.cpp
@@ -1,4 +1,4 @@
-#include "infra/timer/test_helper/ClockFixture.hpp"
+#include "infra/event/test_helper/EventDispatcherFixture.hpp"
 #include "infra/util/ByteRange.hpp"
 #include "infra/util/Function.hpp"
 #include "infra/util/test_helper/MockCallback.hpp"
@@ -8,7 +8,7 @@
 
 class SerialCommunicationLoopbackTest
     : public testing::Test
-    , public infra::ClockFixture
+    , public infra::EventDispatcherFixture
 {
 public:
     services::SerialCommunicationLoopback SerialCommunicationLoopback;


### PR DESCRIPTION
Added SerialCommunicationLoopback that can be used to link together two classes depending on `hal::SerialCommuncation`. The SendData from server will send the data to the client's ReceiveData callback and vice versa.

The actual sending is scheduled via the EventDispatcher to mimick the asynchronous behaviour of a serial communication port.