### PR TITLE
fix: HttpClientBasic reporting error for reestablished connections

### DIFF
--- a/services/network/HttpClientBasic.cpp
+++ b/services/network/HttpClientBasic.cpp
@@ -126,6 +126,10 @@ namespace services
         state = State::connected;
         StartTimeout();
         Established();
+        sharedAccess.SetAction([this]()
+        {
+            Expire();
+        });
         createdClientObserver(sharedAccess.MakeShared(static_cast<services::HttpClientObserver&>(*this)));
     }
 


### PR DESCRIPTION
# Summary
- Connection is created by a request of the HttpClientBasic and then the connection is lost. When a new connection is provided to the HttpClientBasic, regardless of the result of the transaction an error is reported. This is due to the sharedAccess action that is not reset to it's original state.

