### PR TITLE
Revert "build(deps): bump google-github-actions/release-please-action from 3.7.13 to 4.0.1"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,9 +26,10 @@ jobs:
           app_id: ${{ secrets.FOREST_RELEASER_APP_ID }}
           app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
           auth_type: installation
-      - uses: google-github-actions/release-please-action@a2d8d683f209466ee8c695cd994ae2cf08b1642d # v4.0.1
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         id: release
         with:
+          command: manifest
           #token: ${{ steps.token.outputs.token }}
           token: ${{ secrets.AUTOMATIC_RELEASE_TOKEN }}
   build_upload_packages:


### PR DESCRIPTION
Reverts philips-software/amp-embedded-infra-lib#494

The changes in this PR break our release build on main. It looks like the outputs of the release-please action are not properly propagated to the next workflow.