### PR TITLE
fix: remove virtual destructors reducing binary size

### DIFF
--- a/infra/stream/BufferingStreamReader.hpp
+++ b/infra/stream/BufferingStreamReader.hpp
@@ -13,7 +13,7 @@ namespace infra
     {
     public:
         BufferingStreamReader(infra::BoundedDeque<uint8_t>& buffer, infra::StreamReaderWithRewinding& input);
-        ~BufferingStreamReader() override;
+        ~BufferingStreamReader();
 
         // Implementation of StreamReaderWithRewinding
         void Extract(infra::ByteRange range, infra::StreamErrorPolicy& errorPolicy) override;

--- a/infra/stream/InputStream.hpp
+++ b/infra/stream/InputStream.hpp
@@ -19,7 +19,7 @@ namespace infra
         StreamReader() = default;
         StreamReader(const StreamReader& other) = delete;
         StreamReader& operator=(const StreamReader& other) = delete;
-        virtual ~StreamReader() = default;
+        ~StreamReader() = default;
 
     public:
         virtual void Extract(ByteRange range, StreamErrorPolicy& errorPolicy) = 0;

--- a/infra/stream/OutputStream.hpp
+++ b/infra/stream/OutputStream.hpp
@@ -21,7 +21,7 @@ namespace infra
         StreamWriter() = default;
         StreamWriter(const StreamWriter&) = delete;
         StreamWriter& operator=(const StreamWriter&) = delete;
-        virtual ~StreamWriter() = default;
+        ~StreamWriter() = default;
 
     public:
         virtual void Insert(ConstByteRange range, StreamErrorPolicy& errorPolicy) = 0;

--- a/infra/util/Observer.hpp
+++ b/infra/util/Observer.hpp
@@ -26,7 +26,7 @@ namespace infra
     protected:
         Observer(const Observer& other) = delete;
         Observer& operator=(const Observer& other) = delete;
-        virtual ~Observer();
+        ~Observer();
 
     public:
         SubjectType& Subject() const;
@@ -67,7 +67,7 @@ namespace infra
     protected:
         SingleObserver(const SingleObserver& other) = delete;
         SingleObserver& operator=(const SingleObserver& other) = delete;
-        virtual ~SingleObserver();
+        ~SingleObserver();
 
     public:
         SubjectType& Subject() const;
@@ -104,7 +104,7 @@ namespace infra
         Subject() = default;
         Subject(const Subject&) = delete;
         Subject& operator=(const Subject&) = delete;
-        virtual ~Subject();
+        ~Subject();
 
         using SubjectType = typename ObserverType::SubjectType;
         friend class Observer<ObserverType_, SubjectType>;
@@ -136,7 +136,7 @@ namespace infra
         Subject() = default;
         Subject(const Subject&) = delete;
         Subject& operator=(const Subject&) = delete;
-        virtual ~Subject();
+        ~Subject();
 
         friend class SingleObserver<ObserverType_, ObserverSubjectType>;
         virtual void RegisterObserver(SingleObserver<ObserverType_, ObserverSubjectType>* observer);

--- a/protobuf/echo/Echo.hpp
+++ b/protobuf/echo/Echo.hpp
@@ -69,7 +69,7 @@ namespace services
     {
     public:
         explicit EchoOnStreams(services::MethodSerializerFactory& serializerFactory, const EchoErrorPolicy& errorPolicy = echoErrorPolicyAbortOnMessageFormatError);
-        ~EchoOnStreams() override;
+        ~EchoOnStreams();
 
         // Implementation of Echo
         void RequestSend(ServiceProxy& serviceProxy) override;

--- a/protobuf/echo/test_doubles/EchoSingleLoopback.hpp
+++ b/protobuf/echo/test_doubles/EchoSingleLoopback.hpp
@@ -14,7 +14,7 @@ namespace application
     {
     public:
         using services::EchoOnStreams::EchoOnStreams;
-        ~EchoSingleLoopback() override;
+        ~EchoSingleLoopback();
 
     protected:
         // Implementation of services::EchoOnStreams

--- a/services/network/ConnectionFactoryWithNameResolver.hpp
+++ b/services/network/ConnectionFactoryWithNameResolver.hpp
@@ -14,7 +14,7 @@ namespace services
         ClientConnectionObserverFactoryWithNameResolver() = default;
         ClientConnectionObserverFactoryWithNameResolver(const ClientConnectionObserverFactoryWithNameResolver& other) = delete;
         ClientConnectionObserverFactoryWithNameResolver& operator=(const ClientConnectionObserverFactoryWithNameResolver& other) = delete;
-        virtual ~ClientConnectionObserverFactoryWithNameResolver() = default;
+        ~ClientConnectionObserverFactoryWithNameResolver() = default;
 
     public:
         enum ConnectFailReason
@@ -39,7 +39,7 @@ namespace services
         ConnectionFactoryWithNameResolver() = default;
         ConnectionFactoryWithNameResolver(const ConnectionFactoryWithNameResolver& other) = delete;
         ConnectionFactoryWithNameResolver& operator=(const ConnectionFactoryWithNameResolver& other) = delete;
-        virtual ~ConnectionFactoryWithNameResolver() = default;
+        ~ConnectionFactoryWithNameResolver() = default;
 
     public:
         virtual void Connect(ClientConnectionObserverFactoryWithNameResolver& factory) = 0;

--- a/services/network/WebSocketClientConnectionObserver.hpp
+++ b/services/network/WebSocketClientConnectionObserver.hpp
@@ -20,7 +20,7 @@ namespace services
         WebSocketClientObserverFactory() = default;
         WebSocketClientObserverFactory(const WebSocketClientObserverFactory& other) = delete;
         WebSocketClientObserverFactory& operator=(const WebSocketClientObserverFactory& other) = delete;
-        virtual ~WebSocketClientObserverFactory() = default;
+        ~WebSocketClientObserverFactory() = default;
 
     public:
         enum ConnectFailReason
@@ -44,7 +44,7 @@ namespace services
         WebSocketClientConnector() = default;
         WebSocketClientConnector(const WebSocketClientConnector& other) = delete;
         WebSocketClientConnector& operator=(const WebSocketClientConnector& other) = delete;
-        virtual ~WebSocketClientConnector() = default;
+        ~WebSocketClientConnector() = default;
 
     public:
         virtual void Connect(WebSocketClientObserverFactory& factory) = 0;
@@ -147,7 +147,7 @@ namespace services
         HttpClientWebSocketInitiationResult() = default;
         HttpClientWebSocketInitiationResult(const HttpClientWebSocketInitiationResult& other) = delete;
         HttpClientWebSocketInitiationResult& operator=(const HttpClientWebSocketInitiationResult& other) = delete;
-        virtual ~HttpClientWebSocketInitiationResult() = default;
+        ~HttpClientWebSocketInitiationResult() = default;
 
     public:
         virtual void WebSocketInitiationDone(Connection& connection) = 0;
@@ -195,7 +195,7 @@ namespace services
         WebSocketClientInitiationResult() = default;
         WebSocketClientInitiationResult(const WebSocketClientInitiationResult& other) = delete;
         WebSocketClientInitiationResult& operator=(const WebSocketClientInitiationResult& other) = delete;
-        virtual ~WebSocketClientInitiationResult() = default;
+        ~WebSocketClientInitiationResult() = default;
 
     public:
         virtual void InitiationDone(services::Connection& connection) = 0;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,7 +24,7 @@ sonar.coverageReportPaths=coverage.xml
 sonar.coverage.exclusions=**/Tracing*.cpp,**/Main.cpp,hal/generic/*,hal/unix/*,lwip/**/*,services/echo_console/*,**/*_instantiations/*
 
 # Project specific ignored rules
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6
 
 # Access specifiers should not be redundant [cpp:S3539]
 #
@@ -61,3 +61,12 @@ sonar.issue.ignore.multicriteria.e4.resourceKey=**/*.?pp
 # in a non-dangerous way.
 sonar.issue.ignore.multicriteria.e5.ruleKey=cpp:S5912
 sonar.issue.ignore.multicriteria.e5.resourceKey=**/*.?pp
+
+# Polymorphic base class destructor should be either public virtual or protected non-virtual [cpp:S1235]
+#
+# Destructors need only be virtual when 'delete' is applied to a base class of
+# a most-derived object. Since we do not use the heap, and therefore do not use
+# 'delete', there is no danger of having non-virtual destructors.
+# Making destructors virtual increases the size of generated binaries considerably.
+sonar.issue.ignore.multicriteria.e6.ruleKey=cpp:S1235
+sonar.issue.ignore.multicriteria.e6.resourceKey=**/*.?pp


### PR DESCRIPTION
Implementing static analysis recommendations of adding virtual to destructors grew binary sizes of upstream projects.