### PR TITLE
feat: changed compile definitions to be compatible with the gnu assembler

### DIFF
--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -35,8 +35,11 @@ set(CMAKE_CXX_COMPILER_ID ${ORIGINAL_CXX_COMPILER_ID})
 
 function(add_mbedtls_target_properties)
     foreach(target ${ARGN})
+        target_compile_definitions(${target} PUBLIC
+            MBEDTLS_CONFIG_FILE="mbedtls/mbedtls_emil_config.h"
+        )
+
         target_compile_options(${target} PUBLIC
-            -DMBEDTLS_CONFIG_FILE="mbedtls/mbedtls_emil_config.h"
             # see https://github.com/Mbed-TLS/mbedtls/pull/6966
             # mbedtls sets the -Wdocumentation flag, which is throwing warnings
             # since clang-15

--- a/services/tracer/CMakeLists.txt
+++ b/services/tracer/CMakeLists.txt
@@ -1,9 +1,15 @@
 add_library(services.tracer ${EMIL_EXCLUDE_FROM_ALL} STATIC)
 
 if (EMIL_ENABLE_TRACING)
-    target_compile_definitions(services.tracer PUBLIC EMIL_ENABLE_TRACING)
+    target_compile_definitions(services.tracer PUBLIC
+        $<$<COMPILE_LANGUAGE:C>:EMIL_ENABLE_TRACING>
+        $<$<COMPILE_LANGUAGE:CXX>:EMIL_ENABLE_TRACING>
+    )
 else()
-    target_compile_definitions(services.tracer PUBLIC EMIL_DISABLE_TRACING)
+    target_compile_definitions(services.tracer PUBLIC
+        $<$<COMPILE_LANGUAGE:C>:EMIL_DISABLE_TRACING>
+        $<$<COMPILE_LANGUAGE:CXX>:EMIL_DISABLE_TRACING>
+    )
 endif()
 
 target_link_libraries(services.tracer PUBLIC

--- a/services/tracer/CMakeLists.txt
+++ b/services/tracer/CMakeLists.txt
@@ -1,15 +1,9 @@
 add_library(services.tracer ${EMIL_EXCLUDE_FROM_ALL} STATIC)
 
 if (EMIL_ENABLE_TRACING)
-    target_compile_definitions(services.tracer PUBLIC
-        $<$<COMPILE_LANGUAGE:C>:EMIL_ENABLE_TRACING>
-        $<$<COMPILE_LANGUAGE:CXX>:EMIL_ENABLE_TRACING>
-    )
+    target_compile_definitions(services.tracer PUBLIC EMIL_ENABLE_TRACING=1)
 else()
-    target_compile_definitions(services.tracer PUBLIC
-        $<$<COMPILE_LANGUAGE:C>:EMIL_DISABLE_TRACING>
-        $<$<COMPILE_LANGUAGE:CXX>:EMIL_DISABLE_TRACING>
-    )
+    target_compile_definitions(services.tracer PUBLIC EMIL_DISABLE_TRACING=1)
 endif()
 
 target_link_libraries(services.tracer PUBLIC


### PR DESCRIPTION
The current behaviour adds the defines to the assembler which is not compatible with how assemblers work with compile definitions