### PR TITLE
fix: duplicate header guard HAL_UART_HOST_HPP

### DIFF
--- a/hal/generic/SynchronousUartGeneric.hpp
+++ b/hal/generic/SynchronousUartGeneric.hpp
@@ -1,5 +1,5 @@
-#ifndef HAL_UART_HOST_HPP
-#define HAL_UART_HOST_HPP
+#ifndef HAL_SYNCHRONOUS_UART_HOST_HPP
+#define HAL_SYNCHRONOUS_UART_HOST_HPP
 
 #include "hal/synchronous_interfaces/SynchronousSerialCommunication.hpp"
 #include <cstdint>


### PR DESCRIPTION
# Summary
- Renamed SynchronousUartGeneric header guard to HAL_SYNCHRONOUS_UART_HOST_HPP