### PR TITLE
fix: BufferingStreamReader OOB access and Echo segments calculated correctly

### DIFF
--- a/infra/stream/BufferingStreamReader.cpp
+++ b/infra/stream/BufferingStreamReader.cpp
@@ -14,7 +14,7 @@ namespace infra
 
     void BufferingStreamReader::Extract(infra::ByteRange range, infra::StreamErrorPolicy& errorPolicy)
     {
-        if (index != buffer.size())
+        if (index < buffer.size())
         {
             bufferIndex += Read(infra::Head(buffer.contiguous_range(buffer.begin() + index), range.size()), range);
             // Perhaps the deque just wrapped around, try once more

--- a/infra/stream/test/TestBufferingStreamReader.cpp
+++ b/infra/stream/test/TestBufferingStreamReader.cpp
@@ -65,6 +65,30 @@ TEST_F(BufferingStreamReaderTest, Extract_from_wrapped_buffer)
     EXPECT_EQ((std::array<uint8_t, 4>{ 3, 4, 5, 6 }), data);
 }
 
+TEST_F(BufferingStreamReaderTest, Double_extract_from_wrapped_buffer)
+{
+    buffer.push_back(3);
+    buffer.push_back(4);
+    buffer.pop_front();
+    buffer.pop_front();
+    buffer.push_back(5);
+    buffer.push_back(6);
+
+    std::array<uint8_t, 4> data;
+    std::array<uint8_t, 3> data2;
+    reader.Extract(data, errorPolicy);
+    EXPECT_EQ((std::array<uint8_t, 4>{ 3, 4, 5, 6 }), data);
+
+    EXPECT_CALL(input, ExtractContiguousRange(3)).WillOnce(testing::Return(infra::Head(infra::ConstByteRange(data), 3)));
+    reader.Extract(data2, errorPolicy);
+    EXPECT_EQ((std::array<uint8_t, 3>{ 3, 4, 5 }), data2);
+
+    data.fill(0);
+    EXPECT_CALL(input, ExtractContiguousRange(4)).WillOnce(testing::Return(infra::ConstByteRange(data)));
+    reader.Extract(data, errorPolicy);
+    EXPECT_EQ((std::array<uint8_t, 4>{ 0, 0, 0, 0 }), data);
+}
+
 TEST_F(BufferingStreamReaderTest, Extract_from_buffer_and_input)
 {
     std::array<uint8_t, 4> data;

--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -163,6 +163,7 @@ namespace services
     void EchoOnStreams::StartReceiveMessage()
     {
         auto start = bufferedReader->ConstructSaveMarker();
+        auto readerStart = readerPtr->ConstructSaveMarker();
         infra::DataInputStream::WithErrorPolicy stream(*bufferedReader, infra::softFail);
         infra::StreamErrorPolicy formatErrorPolicy(infra::softFail);
         infra::ProtoParser parser(stream, formatErrorPolicy);
@@ -173,6 +174,8 @@ namespace services
         {
             bufferedReader->Rewind(start);
             bufferedReader = infra::none;
+            readerPtr->Rewind(readerStart + receiveBuffer.size());
+            AckReceived();
             readerPtr = nullptr;
         }
         else if (formatErrorPolicy.Failed() || !contents.Is<infra::PartialProtoLengthDelimited>())

--- a/services/network/test/TestEchoOnConnection.cpp
+++ b/services/network/test/TestEchoOnConnection.cpp
@@ -52,7 +52,7 @@ TEST_F(EchoOnConnectionTest, service_method_is_invoked)
         {
             service.MethodDone();
         }));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -70,7 +70,7 @@ TEST_F(EchoOnConnectionTest, service_method_is_invoked_twice)
         {
             service.MethodDone();
         }));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     service.MethodDone();
 }
 
@@ -81,7 +81,7 @@ TEST_F(EchoOnConnectionTest, MessageFormatError_is_reported_when_message_is_not_
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(errorPolicy, MessageFormatError());
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -92,7 +92,7 @@ TEST_F(EchoOnConnectionTest, MessageFormatError_is_reported_when_message_is_of_u
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(errorPolicy, MessageFormatError());
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -103,7 +103,7 @@ TEST_F(EchoOnConnectionTest, MessageFormatError_is_reported_when_parameter_in_me
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(errorPolicy, MessageFormatError());
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -114,7 +114,7 @@ TEST_F(EchoOnConnectionTest, ServiceNotFound_is_reported)
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(errorPolicy, ServiceNotFound(2));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -125,7 +125,7 @@ TEST_F(EchoOnConnectionTest, MethodNotFound_is_reported)
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(errorPolicy, MethodNotFound(1, 2));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     connection.Observer().DataReceived();
 }
 
@@ -135,7 +135,7 @@ TEST_F(EchoOnConnectionTest, DataReceived_while_service_method_is_executing)
     auto readerPtr = infra::UnOwnedSharedPtr(stream.Reader());
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
     EXPECT_CALL(service, Method(5));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(3);
     connection.Observer().DataReceived();
 
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
@@ -155,7 +155,7 @@ TEST_F(EchoOnConnectionTest, DataReceived_to_complete_service_method)
     infra::StdVectorInputStream::WithStorage stream2(infra::inPlace, std::vector<uint8_t>{ 5 });
     readerPtr = infra::UnOwnedSharedPtr(stream2.Reader());
     EXPECT_CALL(connection, ReceiveStream()).WillOnce(testing::Return(readerPtr));
-    EXPECT_CALL(connection, AckReceived());
+    EXPECT_CALL(connection, AckReceived()).Times(2);
     EXPECT_CALL(service, Method(5));
     connection.Observer().DataReceived();
 


### PR DESCRIPTION
# Summary
- Fixed BufferingStreamReader accessing further then it should
- Offset reader in Echo correctly so the ECHO packets are parsed correctly.