### PR TITLE
fix: ConnectionMbedTls no longer calls DataReceived() with 0 bytes

### DIFF
--- a/documents/modules/ROOT/pages/NetworkConnections.adoc
+++ b/documents/modules/ROOT/pages/NetworkConnections.adoc
@@ -69,4 +69,8 @@ copying as possible. By having fully asynchronous behaviour, the need
 for threads and/or blocking waits is completely avoided, and one
 application can easily handle multiple connections, in parallel with SPI
 transfers, UART communication, etc. without the need for locks or
-wasting MCU time on busy waits.
+wasting MCU time on busy waits.The contract between Connection and
+ConnectionObserver must be adhered appropriately and breaking this contract
+may lead to unexpected behaviour. For example; calling DataReceived() on 
+ConnectionObserver without any data being received violates the contract. 
+Implementations of ConnectionObserver and Connection must adhere to this.

--- a/services/network/ConnectionMbedTls.cpp
+++ b/services/network/ConnectionMbedTls.cpp
@@ -157,10 +157,10 @@ namespace services
         if (receiveBuffer.size() != startSize && !dataReceivedScheduled)
         {
             dataReceivedScheduled = true;
-            infra::EventDispatcherWithWeakPtr::Instance().Schedule([](const infra::SharedPtr<ConnectionMbedTls>& object)
+            infra::EventDispatcherWithWeakPtr::Instance().Schedule([this](const infra::SharedPtr<ConnectionMbedTls>& object)
                 {
                     object->dataReceivedScheduled = false;
-                    if (object->Connection::IsAttached())
+                    if (!receiveBuffer.empty() && object->Connection::IsAttached())
                         object->Observer().DataReceived();
                 },
                 SharedFromThis());


### PR DESCRIPTION
# Summary
- MbedTLS implementation of a connection no longer calls DataReceived() when the received buffer has 0 bytes.  This violates the interface contract between a Connection and ConnectionObserver. 
- Documentation updated accordingly to avoid inform users of the intended use of the interface. 


It certainly is unexpected to receive a phantom DataReceived() on the ConnectionObserver when there are no bytes to be read. Violating this results in unexpected behaviours.