### PR TITLE
fix: timer jumped will trigger next trigger time update

### DIFF
--- a/infra/timer/Timer.cpp
+++ b/infra/timer/Timer.cpp
@@ -40,7 +40,7 @@ namespace infra
     void Timer::Jumped(TimePoint from, TimePoint to)
     {
         // Default behaviour: Just pretend that during the jump no actual time passed
-        nextTriggerTime = Convert(Convert(nextTriggerTime) + (to - from));
+        SetNextTriggerTime(Convert(nextTriggerTime) + (to - from), Action());
     }
 
     TimePoint Timer::NextTrigger() const


### PR DESCRIPTION
timer jumped from a timepoint to a new timepoint shall trigger calculation of next trigger time and notify the timerservice