### PR TITLE
fix: repeated proto message incorrect maxMessageSize calculation

### DIFF
--- a/protobuf/protoc_echo_plugin/EchoObjects.cpp
+++ b/protobuf/protoc_echo_plugin/EchoObjects.cpp
@@ -359,7 +359,7 @@ namespace application
                 uint32_t max = 0;
                 GenerateMaxMessageSizeVisitor visitor(max);
                 field.type->Accept(visitor);
-                maxMessageSize = field.maxArraySize * max;
+                maxMessageSize += field.maxArraySize * max;
             }
 
             void VisitUnboundedRepeated(const EchoFieldUnboundedRepeated& field) override


### PR DESCRIPTION
# Summary

- When re-using a proto message in a repeated format with an array size, then the encapsulating message maxMessageSize is calculated incorrectly. 

"+" Was missed causing the calculated size to be reset 