### PR TITLE
feat: disabled documentation warning when compiling with AppleClang

### DIFF
--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -44,6 +44,7 @@ function(add_mbedtls_target_properties)
             # mbedtls sets the -Wdocumentation flag, which is throwing warnings
             # since clang-15
             $<$<CXX_COMPILER_ID:Clang>:-Wno-documentation>
+            $<$<CXX_COMPILER_ID:AppleClang>:-Wno-documentation>
         )
 
         target_include_directories(${target} PUBLIC


### PR DESCRIPTION
AppleClang has updated to Clang15. And since Clang15 there is a warning in mbedtls regarding a doxygen comment.

This pull request disables the documentation warning when compiling with AppleClang for all mbedtls dependencies.