### PR TITLE
Fix platform check

### DIFF
--- a/osal/std_thread_osal/CMakeLists.txt
+++ b/osal/std_thread_osal/CMakeLists.txt
@@ -5,6 +5,6 @@ target_include_directories(osal.std_thread_osal PUBLIC
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-if (TARGET_BUILD_UNIX OR TARGET_BUILD_OSX)
+if (EMIL_BUILD_UNIX OR EMIL_BUILD_DARWIN)
     target_link_libraries(osal.std_thread_osal PUBLIC pthread)
 endif()


### PR DESCRIPTION
`TARGET_BUILD_xxx` seems to be replaced by `EMIL_BUILD_xxx`.