### PR TITLE
chore: make tx_application_define a weak definition

### DIFF
--- a/osal/threadx/Osal.cpp
+++ b/osal/threadx/Osal.cpp
@@ -6,7 +6,7 @@ extern "C"
 #include "tx_initialize.h"
 #include "tx_thread.h"
 
-    VOID tx_application_define(VOID* first_unused_memory)
+    [[gnu::weak]] VOID tx_application_define(VOID* first_unused_memory)
     {}
 }
 


### PR DESCRIPTION
User applications may have defined this function and expect it to be used.