### PR TITLE
chore: enable link group rescan

### DIFF
--- a/cmake/toolchain-arm-gcc.cmake
+++ b/cmake/toolchain-arm-gcc.cmake
@@ -60,6 +60,12 @@ set(CMAKE_ASM_FLAGS_RELEASE "-g" CACHE STRING "" FORCE)
 set(CMAKE_ASM_FLAGS_RELWITHDEBINFO "-g" CACHE STRING "" FORCE)
 set(CMAKE_ASM_FLAGS_MINSIZEREL "" CACHE STRING "" FORCE)
 
+# Features for LINK_GROUP generator expression
+## RESCAN: request the linker to rescan static libraries until there is
+## no pending undefined symbols
+set(CMAKE_LINK_GROUP_USING_RESCAN "LINKER:--start-group" "LINKER:--end-group")
+set(CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED TRUE)
+
 add_link_options(LINKER:--gc-sections,--print-memory-usage)
 add_link_options(-specs=nano.specs -nostartfiles -mthumb)
 


### PR DESCRIPTION
Feature link group rescan is not enabled for arm none eabi gcc toolchain, so this PR enables it.

Use case:
On amp-hal-st there is a new microcontroller that uses static library and triggers a circular dependency. And that can be fixed by using link groups.