### PR TITLE
fix: pad 0xff when add hex and elf to upgrade pack

### DIFF
--- a/upgrade/pack_builder/InputElf.cpp
+++ b/upgrade/pack_builder/InputElf.cpp
@@ -30,7 +30,7 @@ namespace application
         {
             uint32_t address = i.first;
             if (result.size() < address + 1 - startAddress)
-                result.resize(address + 1 - startAddress);
+                result.resize(address + 1 - startAddress, 0xff);
 
             result[address - startAddress] = i.second;
         }

--- a/upgrade/pack_builder/InputHex.cpp
+++ b/upgrade/pack_builder/InputHex.cpp
@@ -29,7 +29,7 @@ namespace application
         {
             uint32_t address = i.first;
             if (result.size() < address + 1 - startAddress)
-                result.resize(address + 1 - startAddress);
+                result.resize(address + 1 - startAddress, 0xff);
 
             result[address - startAddress] = i.second;
         }


### PR DESCRIPTION
When adding hex and elf to upgrade pack using upgrade pack builder, pad 0xff for gap instead of 0.