### PR TITLE
feat: add NotifyingSharedOptional::OnAllocatable overload

### DIFF
--- a/infra/util/CMakeLists.txt
+++ b/infra/util/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(infra.util PRIVATE
     SharedObjectAllocator.hpp
     SharedObjectAllocatorFixedSize.hpp
     SharedObjectAllocatorHeap.hpp
+    SharedOptional.cpp
     SharedOptional.hpp
     SharedOwnedObserver.hpp
     SharedPtr.cpp

--- a/infra/util/SharedOptional.cpp
+++ b/infra/util/SharedOptional.cpp
@@ -1,0 +1,6 @@
+#include "infra/util/SharedOptional.hpp"
+
+namespace infra
+{
+    const AlsoWhenAlreadyAllocatable alsoWhenAlreadyAllocatable;
+}

--- a/infra/util/test/TestSharedOptional.cpp
+++ b/infra/util/test/TestSharedOptional.cpp
@@ -67,6 +67,13 @@ TEST(SharedOptionalTest, NotifyingSharedPtr_notifies_after_becoming_allocatable)
     wp = nullptr;
 }
 
+TEST(SharedOptionalTest, NotifyingSharedPtr_notifies_immediately_when_already_allocatable)
+{
+    infra::NotifyingSharedOptional<int> s;
+
+    s.OnAllocatable(infra::MockFunction<void()>(), infra::alsoWhenAlreadyAllocatable);
+}
+
 TEST(SharedOptionalTest, change_callback_on_NotifyingSharedPtr)
 {
     infra::MockCallback<void()> callback;

--- a/infra/util/test/TestSharedOptional.cpp
+++ b/infra/util/test/TestSharedOptional.cpp
@@ -74,6 +74,13 @@ TEST(SharedOptionalTest, NotifyingSharedPtr_notifies_immediately_when_already_al
     s.OnAllocatable(infra::MockFunction<void()>(), infra::alsoWhenAlreadyAllocatable);
 }
 
+TEST(SharedOptionalTest, NotifyingSharedPtr_does_not_notify_empty_function)
+{
+    infra::NotifyingSharedOptional<int> s;
+
+    s.OnAllocatable(nullptr, infra::alsoWhenAlreadyAllocatable);
+}
+
 TEST(SharedOptionalTest, change_callback_on_NotifyingSharedPtr)
 {
     infra::MockCallback<void()> callback;


### PR DESCRIPTION
New overload allows for immediately notifying when the SharedOptional is already allocatable