### PR TITLE
fix: UartUnix receiveData callback being called after destruction

### DIFF
--- a/hal/unix/UartUnix.cpp
+++ b/hal/unix/UartUnix.cpp
@@ -73,7 +73,7 @@ namespace hal
                 throw std::system_error(EFAULT, std::system_category());
 
             std::unique_lock lock(mutex);
-            if (receivedData)
+            if (receivedData != nullptr)
                 receivedData(infra::ConstByteRange(range.begin(), range.begin() + size));
         }
     }

--- a/hal/unix/UartUnix.cpp
+++ b/hal/unix/UartUnix.cpp
@@ -73,7 +73,8 @@ namespace hal
                 throw std::system_error(EFAULT, std::system_category());
 
             std::unique_lock lock(mutex);
-            receivedData(infra::ConstByteRange(range.begin(), range.begin() + size));
+            if (receivedData)
+                receivedData(infra::ConstByteRange(range.begin(), range.begin() + size));
         }
     }
 }


### PR DESCRIPTION
Due to threading, object might be in destruction while running is true