### PR TITLE
fix: tcp packet fragmentation

### DIFF
--- a/services/network_instantiations/ConnectionBsd.cpp
+++ b/services/network_instantiations/ConnectionBsd.cpp
@@ -118,7 +118,7 @@ namespace services
 
     void ConnectionBsd::Send()
     {
-        int sent = 0;
+        long sent = 0;
 
         do
         {

--- a/services/network_instantiations/ConnectionBsd.cpp
+++ b/services/network_instantiations/ConnectionBsd.cpp
@@ -122,7 +122,8 @@ namespace services
 
         do
         {
-            sent = send(socket, reinterpret_cast<char*>(sendBuffer.contiguous_range(sendBuffer.begin()).begin()), sendBuffer.contiguous_range(sendBuffer.begin()).size(), 0);
+            std::vector<char> tmpBuffer(sendBuffer.begin(), sendBuffer.end());
+            sent = send(socket, tmpBuffer.data(), tmpBuffer.size(), 0);
 
             if (sent == -1)
             {

--- a/services/network_instantiations/ConnectionWin.cpp
+++ b/services/network_instantiations/ConnectionWin.cpp
@@ -120,7 +120,8 @@ namespace services
         do
         {
             UpdateEventFlags(); // If there is something to send, update the flags before calling send, because FD_SEND is an edge-triggered event.
-            sent = send(socket, reinterpret_cast<char*>(sendBuffer.contiguous_range(sendBuffer.begin()).begin()), sendBuffer.contiguous_range(sendBuffer.begin()).size(), 0);
+            std::vector<char> tmpBuffer(sendBuffer.begin(), sendBuffer.end());
+            sent = send(socket, tmpBuffer.data(), tmpBuffer.size(), 0);
 
             if (sent == SOCKET_ERROR)
             {


### PR DESCRIPTION
Due to recent changes on infra::BoundedDeque, an empty container is not necessary at offset zero.
As the begin() keeps moving inside internal storage, a packet could be sliced in chunks smaller than MTU size.
