### PR TITLE
feat: Make I2cAddress constexpr

### DIFF
--- a/hal/interfaces/I2c.cpp
+++ b/hal/interfaces/I2c.cpp
@@ -2,10 +2,6 @@
 
 namespace hal
 {
-    I2cAddress::I2cAddress(uint16_t address)
-        : address(address)
-    {}
-
     bool I2cAddress::operator==(const I2cAddress& other) const
     {
         return other.address == this->address;

--- a/hal/interfaces/I2c.hpp
+++ b/hal/interfaces/I2c.hpp
@@ -29,7 +29,9 @@ namespace hal
     class I2cAddress
     {
     public:
-        explicit I2cAddress(uint16_t address);
+        explicit constexpr I2cAddress(uint16_t address)
+            : address(address)
+        {}
 
         bool operator==(const I2cAddress& other) const;
         bool operator!=(const I2cAddress& other) const;


### PR DESCRIPTION
A constexpr constructor allows the following:
```cpp
static constexpr hal::I2cAddress AssignedSmartBatteryAddress{0x0B << 1};
```