### PR TITLE
feat: enable SHA384 and SHA512 on mbedtls

### DIFF
--- a/external/crypto/mbedtls/mbedtls_emil_config.h
+++ b/external/crypto/mbedtls/mbedtls_emil_config.h
@@ -2787,7 +2787,7 @@
  *
  * Comment to disable SHA-384
  */
-//#define MBEDTLS_SHA384_C
+#define MBEDTLS_SHA384_C
 
 /**
  * \def MBEDTLS_SHA512_C
@@ -2802,7 +2802,7 @@
  *
  * This module adds support for SHA-512.
  */
-//#define MBEDTLS_SHA512_C
+#define MBEDTLS_SHA512_C
 
 /**
  * \def MBEDTLS_SSL_CACHE_C


### PR DESCRIPTION
Next to the already supported SHA256 algorithm, it is also common to sign certificates based on SHA384 and SHA512. These algorithms were not yet enabled. As a result, certificate validation would fail when any of the certificates in the chain was signed based on one of these hash algorithms. 

Enabling these algorithms as I am running into these issues right now. Since we are only enabling new features, this change is not expected to break existing functionality.