### PR TITLE
feat: changed `BoundedString::copy` to copy up to `length-pos` characters

### DIFF
--- a/infra/util/BoundedString.hpp
+++ b/infra/util/BoundedString.hpp
@@ -4,7 +4,6 @@
 //  BoundedString is similar to std::string, except that it can contain a maximum number of characters
 
 #include "infra/util/MemoryRange.hpp"
-#include "infra/util/ReallyAssert.hpp"
 #include "infra/util/WithStorage.hpp"
 #include <algorithm>
 #include <cctype>

--- a/infra/util/BoundedString.hpp
+++ b/infra/util/BoundedString.hpp
@@ -4,6 +4,7 @@
 //  BoundedString is similar to std::string, except that it can contain a maximum number of characters
 
 #include "infra/util/MemoryRange.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include "infra/util/WithStorage.hpp"
 #include <algorithm>
 #include <cctype>
@@ -1063,7 +1064,8 @@ namespace infra
     template<class T>
     typename BoundedStringBase<T>::size_type BoundedStringBase<T>::copy(char* dest, size_type count, size_type pos)
     {
-        assert(pos + count <= length);
+        assert(pos <= length);
+        count = std::min(count, length - pos);
         std::copy(begin() + pos, begin() + pos + count, dest);
         return count;
     }

--- a/infra/util/test/TestBoundedString.cpp
+++ b/infra/util/test/TestBoundedString.cpp
@@ -585,6 +585,9 @@ TEST(BoundedStringTest, TestCopy)
     infra::BoundedString::WithStorage<5> string("abcde");
     EXPECT_EQ(3, string.copy(buffer, 3, 1));
     EXPECT_EQ('b', buffer[0]);
+
+    EXPECT_EQ(2, string.copy(buffer, 5, 3));
+    EXPECT_EQ('d', buffer[0]);
 }
 
 TEST(BoundedStringTest, TestResize)


### PR DESCRIPTION
The standard library's `std::string::copy` has the following behaviour:
```
Copies a substring [pos, pos + count) to character string pointed to by dest.
If the requested substring lasts past the end of the string, or if count == npos,
the copied substring is [pos, size()).
```
The current behaviour of `BoundedString::copy` is to error when `pos+count > length` which is different from the standard string copy behaviour.

This change aligns `BoundedString::copy` with the above behaviour.