### PR TITLE
feat: refactor BodyReader handling in HttpClient implementations

### DIFF
--- a/services/network/HttpClientImpl.cpp
+++ b/services/network/HttpClientImpl.cpp
@@ -222,9 +222,11 @@ namespace services
             else
             {
                 bodyReader.Emplace(ConnectionObserver::Subject().ReceiveStream(), *contentLength);
+                auto reader = infra::MakeContainedSharedObject(bodyReader->countingReader, bodyReaderAccess.MakeShared(bodyReader));
+                BodyReaderAvailable(reader);
 
                 if (HttpClient::IsAttached())
-                    Observer().BodyAvailable(infra::MakeContainedSharedObject(bodyReader->countingReader, bodyReaderAccess.MakeShared(bodyReader)));
+                    Observer().BodyAvailable(std::move(reader));
                 repeat = chunkedEncoding && contentLength == 0;
             }
         }

--- a/services/network/HttpClientImpl.cpp
+++ b/services/network/HttpClientImpl.cpp
@@ -223,13 +223,17 @@ namespace services
             {
                 bodyReader.Emplace(ConnectionObserver::Subject().ReceiveStream(), *contentLength);
                 auto reader = infra::MakeContainedSharedObject(bodyReader->countingReader, bodyReaderAccess.MakeShared(bodyReader));
-                BodyReaderAvailable(reader);
+                BodyReaderAvailable(std::move(reader));
 
-                if (HttpClient::IsAttached())
-                    Observer().BodyAvailable(std::move(reader));
                 repeat = chunkedEncoding && contentLength == 0;
             }
         }
+    }
+
+    void HttpClientImpl::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader)
+    {
+        if (HttpClient::IsAttached())
+            Observer().BodyAvailable(std::move(bodyReader));
     }
 
     void HttpClientImpl::BodyReaderDestroyed()

--- a/services/network/HttpClientImpl.hpp
+++ b/services/network/HttpClientImpl.hpp
@@ -55,7 +55,7 @@ namespace services
         void BodyComplete();
 
     protected:
-        virtual void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader){};
+        virtual void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader);
 
     private:
         void ExpectResponse();

--- a/services/network/HttpClientImpl.hpp
+++ b/services/network/HttpClientImpl.hpp
@@ -54,6 +54,9 @@ namespace services
 
         void BodyComplete();
 
+    protected:
+        virtual void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader){};
+
     private:
         void ExpectResponse();
         void HandleData();
@@ -73,8 +76,8 @@ namespace services
             BodyReader(const infra::SharedPtr<infra::StreamReaderWithRewinding>& reader, uint32_t contentLength);
 
             infra::SharedPtr<infra::StreamReaderWithRewinding> reader;
-            infra::LimitedStreamReader limitedReader;
-            infra::CountingStreamReader countingReader{ limitedReader };
+            infra::LimitedStreamReaderWithRewinding limitedReader;
+            infra::CountingStreamReaderWithRewinding countingReader{ limitedReader };
         };
 
         class SendingState

--- a/services/network/TracingHttpClientImpl.cpp
+++ b/services/network/TracingHttpClientImpl.cpp
@@ -7,7 +7,7 @@ namespace services
         , tracer(tracer)
     {}
 
-    void TracingHttpClientImpl::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader)
+    void TracingHttpClientImpl::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader)
     {
         tracer.Trace() << "HttpClientImpl::BodyAvailable; received response:" << infra::endl;
 
@@ -18,7 +18,7 @@ namespace services
             tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
 
         reader->Rewind(marker);
-        reader = nullptr;
+        HttpClientImpl::BodyReaderAvailable(std::move(reader));
     }
 
     void TracingHttpClientImpl::Attached()
@@ -54,7 +54,7 @@ namespace services
         , tracer(tracer)
     {}
 
-    void TracingHttpClientImplWithRedirection::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader)
+    void TracingHttpClientImplWithRedirection::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader)
     {
         tracer.Trace() << "HttpClientImplWithRedirection::BodyAvailable; received response:" << infra::endl;
 
@@ -65,7 +65,7 @@ namespace services
             tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
 
         reader->Rewind(marker);
-        reader = nullptr;
+        HttpClientImplWithRedirection::BodyReaderAvailable(std::move(reader));
     }
 
     void TracingHttpClientImplWithRedirection::Attached()

--- a/services/network/TracingHttpClientImpl.cpp
+++ b/services/network/TracingHttpClientImpl.cpp
@@ -7,19 +7,18 @@ namespace services
         , tracer(tracer)
     {}
 
-    void TracingHttpClientImpl::DataReceived()
+    void TracingHttpClientImpl::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader)
     {
-        tracer.Trace() << "HttpClientImpl::DataReceived; received response:" << infra::endl;
+        tracer.Trace() << "HttpClientImpl::BodyAvailable; received response:" << infra::endl;
 
-        auto reader = ConnectionObserver::Subject().ReceiveStream();
+        auto reader = bodyReader;
         infra::DataInputStream::WithErrorPolicy stream(*reader);
-
+        auto marker = reader->ConstructSaveMarker();
         while (!stream.Empty())
             tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
 
+        reader->Rewind(marker);
         reader = nullptr;
-
-        HttpClientImpl::DataReceived();
     }
 
     void TracingHttpClientImpl::Attached()
@@ -55,19 +54,18 @@ namespace services
         , tracer(tracer)
     {}
 
-    void TracingHttpClientImplWithRedirection::DataReceived()
+    void TracingHttpClientImplWithRedirection::BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader)
     {
-        tracer.Trace() << "HttpClientImplWithRedirection::DataReceived; received response:" << infra::endl;
+        tracer.Trace() << "HttpClientImplWithRedirection::BodyAvailable; received response:" << infra::endl;
 
-        auto reader = ConnectionObserver::Subject().ReceiveStream();
+        auto reader = bodyReader;
         infra::DataInputStream::WithErrorPolicy stream(*reader);
-
+        auto marker = reader->ConstructSaveMarker();
         while (!stream.Empty())
             tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
 
+        reader->Rewind(marker);
         reader = nullptr;
-
-        HttpClientImplWithRedirection::DataReceived();
     }
 
     void TracingHttpClientImplWithRedirection::Attached()

--- a/services/network/TracingHttpClientImpl.hpp
+++ b/services/network/TracingHttpClientImpl.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVICES_TRACING_HTTP_CLIENT_IMPL_HPP
 #define SERVICES_TRACING_HTTP_CLIENT_IMPL_HPP
 
+#include "infra/stream/CountingInputStream.hpp"
 #include "services/network/HttpClientImpl.hpp"
 #include "services/tracer/Tracer.hpp"
 #include "services/tracer/TracingOutputStream.hpp"
@@ -14,10 +15,13 @@ namespace services
         TracingHttpClientImpl(infra::BoundedConstString hostname, Tracer& tracer);
 
         // Implementation of ConnectionObserver
-        void DataReceived() override;
         void Attached() override;
         void Detaching() override;
         void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+
+    protected:
+        // Implementation of HttpClientImplWithRedirection
+        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader) override;
 
     private:
         class TracingWriter
@@ -48,13 +52,16 @@ namespace services
         TracingHttpClientImplWithRedirection(infra::BoundedString redirectedUrlStorage, infra::BoundedConstString hostname, ConnectionFactoryWithNameResolver& connectionFactory, Tracer& tracer);
 
         // Implementation of ConnectionObserver
-        void DataReceived() override;
         void Attached() override;
         void Detaching() override;
         void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
 
         // Implementation of HttpClientImplWithRedirection
         void Redirecting(infra::BoundedConstString url) override;
+
+    protected:
+        // Implementation of HttpClientImplWithRedirection
+        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader) override;
 
     private:
         class TracingWriter

--- a/services/network/TracingHttpClientImpl.hpp
+++ b/services/network/TracingHttpClientImpl.hpp
@@ -21,7 +21,7 @@ namespace services
 
     protected:
         // Implementation of HttpClientImplWithRedirection
-        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader) override;
+        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader) override;
 
     private:
         class TracingWriter
@@ -61,7 +61,7 @@ namespace services
 
     protected:
         // Implementation of HttpClientImplWithRedirection
-        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding> bodyReader) override;
+        void BodyReaderAvailable(infra::SharedPtr<infra::CountingStreamReaderWithRewinding>&& bodyReader) override;
 
     private:
         class TracingWriter


### PR DESCRIPTION
This also fixes crashes when data is consumed asyncronously and TracingHttpClient* is being used to trace the body of the response