### PR TITLE
feat: improve hal::Can::Id

### DIFF
--- a/hal/interfaces/Can.cpp
+++ b/hal/interfaces/Can.cpp
@@ -2,20 +2,6 @@
 
 namespace hal
 {
-    Can::Id::Id(uint32_t id)
-        : id(id)
-    {}
-
-    Can::Id Can::Id::Create11BitId(uint32_t id)
-    {
-        return Can::Id(id);
-    }
-
-    Can::Id Can::Id::Create29BitId(uint32_t id)
-    {
-        return Can::Id(id | indicator29Bit);
-    }
-
     bool Can::Id::Is11BitId() const
     {
         return (id & indicator29Bit) == 0;

--- a/hal/interfaces/Can.cpp
+++ b/hal/interfaces/Can.cpp
@@ -39,4 +39,14 @@ namespace hal
 
         return id ^ indicator29Bit;
     }
+
+    bool Can::Id::operator==(const Id& other) const
+    {
+        return id == other.id;
+    }
+
+    bool Can::Id::operator!=(const Id& other) const
+    {
+        return !(*this == other);
+    }
 }

--- a/hal/interfaces/Can.hpp
+++ b/hal/interfaces/Can.hpp
@@ -13,8 +13,15 @@ namespace hal
         class Id
         {
         public:
-            static Id Create11BitId(uint32_t id);
-            static Id Create29BitId(uint32_t id);
+            static constexpr Id Create11BitId(uint32_t id)
+            {
+                return Can::Id(id);
+            }
+
+            static constexpr Id Create29BitId(uint32_t id)
+            {
+                return Can::Id(id | indicator29Bit);
+            }
 
             bool Is11BitId() const;
             bool Is29BitId() const;
@@ -26,7 +33,9 @@ namespace hal
             bool operator!=(const Id& other) const;
 
         private:
-            explicit Id(uint32_t id);
+            constexpr explicit Id(uint32_t id)
+                : id(id)
+            {}
 
         private:
             static const uint32_t indicator29Bit = static_cast<uint32_t>(1) << 31;

--- a/hal/interfaces/Can.hpp
+++ b/hal/interfaces/Can.hpp
@@ -1,8 +1,8 @@
 #ifndef HAL_CAN_HPP
 #define HAL_CAN_HPP
 
-#include "hal/interfaces/Gpio.hpp"
 #include "infra/util/BoundedVector.hpp"
+#include "infra/util/Function.hpp"
 #include <cstdint>
 
 namespace hal
@@ -21,6 +21,9 @@ namespace hal
 
             uint32_t Get11BitId() const;
             uint32_t Get29BitId() const;
+
+            bool operator==(const Id& other) const;
+            bool operator!=(const Id& other) const;
 
         private:
             explicit Id(uint32_t id);

--- a/hal/interfaces/test/TestCan.cpp
+++ b/hal/interfaces/test/TestCan.cpp
@@ -16,3 +16,31 @@ TEST(CanTest, generate_29_bit_id)
     EXPECT_TRUE(id.Is29BitId());
     EXPECT_EQ(0, id.Get29BitId());
 }
+
+TEST(CanTest, test_equality_mixed)
+{
+    auto id11_0 = hal::Can::Id::Create11BitId(0);
+    auto id11_1 = hal::Can::Id::Create11BitId(1);
+    auto id29_0 = hal::Can::Id::Create29BitId(0);
+    auto id29_1 = hal::Can::Id::Create29BitId(1);
+
+    EXPECT_TRUE(id11_0 == hal::Can::Id::Create11BitId(0));
+    EXPECT_TRUE(id11_0 != id11_1);
+    EXPECT_TRUE(id11_0 != id29_0);
+    EXPECT_TRUE(id11_0 != id29_1);
+
+    EXPECT_TRUE(id11_1 != id11_0);
+    EXPECT_TRUE(id11_1 == hal::Can::Id::Create11BitId(1));
+    EXPECT_TRUE(id11_1 != id29_0);
+    EXPECT_TRUE(id11_1 != id29_1);
+
+    EXPECT_TRUE(id29_0 != id11_0);
+    EXPECT_TRUE(id29_0 != id11_1);
+    EXPECT_TRUE(id29_0 == hal::Can::Id::Create29BitId(0));
+    EXPECT_TRUE(id29_0 != id29_1);
+
+    EXPECT_TRUE(id29_1 != id11_0);
+    EXPECT_TRUE(id29_1 != id11_1);
+    EXPECT_TRUE(id29_1 != id29_0);
+    EXPECT_TRUE(id29_1 == hal::Can::Id::Create29BitId(1));
+}


### PR DESCRIPTION
This PR makes `hal::Can::Id` creation constexpr and adds defaulted equality operators.
C++ 20 is enabled to make use of default equality operators and is already enabled in `amp-hal-st`.