### PR TITLE
feat!: add support to return resolve MAC address

### DIFF
--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -56,6 +56,11 @@ namespace services
         GapPairingObserver::Subject().NumericComparisonConfirm(accept);
     }
 
+    hal::MacAddress GapPairingDecorator::ResolveDeviceAddress(hal::MacAddress deviceAddress) const
+    {
+        return GapPairingObserver::Subject().ResolveDeviceAddress(deviceAddress);
+    }
+
     void GapBondingDecorator::NumberOfBondsChanged(std::size_t nrBonds)
     {
         GapBonding::NotifyObservers([&nrBonds](auto& obs)

--- a/services/ble/Gap.hpp
+++ b/services/ble/Gap.hpp
@@ -164,6 +164,7 @@ namespace services
 
         virtual void AuthenticateWithPasskey(uint32_t passkey) = 0;
         virtual void NumericComparisonConfirm(bool accept) = 0;
+        virtual hal::MacAddress ResolveDeviceAddress(hal::MacAddress deviceAddress) const = 0;
     };
 
     class GapPairingDecorator
@@ -185,6 +186,7 @@ namespace services
         void SetIoCapabilities(IoCapabilities caps) override;
         void AuthenticateWithPasskey(uint32_t passkey) override;
         void NumericComparisonConfirm(bool accept) override;
+        hal::MacAddress ResolveDeviceAddress(hal::MacAddress deviceAddress) const override;
     };
 
     class GapBonding;

--- a/services/ble/test_doubles/GapPairingMock.hpp
+++ b/services/ble/test_doubles/GapPairingMock.hpp
@@ -16,6 +16,7 @@ namespace services
         MOCK_METHOD(void, SetIoCapabilities, (IoCapabilities caps));
         MOCK_METHOD(void, AuthenticateWithPasskey, (uint32_t passkey));
         MOCK_METHOD(void, NumericComparisonConfirm, (bool accept));
+        MOCK_METHOD(hal::MacAddress, ResolveDeviceAddress, (hal::MacAddress deviceAddress), (const));
     };
 }
 


### PR DESCRIPTION
# Description
Return the resolved MAC address instead of the random one.
All the PRs have to be ready beforehand and merged in sequence. 

# Dependencies
- [amp-hal-st:464](https://github.com/philips-software/amp-hal-st/pull/464)
