### PR TITLE
fix: revert again: fix: keep websocket alive while reader or writer is alive

### DIFF
--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -1,6 +1,4 @@
 #include "protobuf/echo/Echo.hpp"
-#include "infra/stream/InputStream.hpp"
-#include "infra/util/Function.hpp"
 
 namespace services
 {
@@ -70,7 +68,7 @@ namespace services
 
     EchoOnStreams::~EchoOnStreams()
     {
-        limitedReaderAccess.SetAction(infra::emptyFunction);
+        limitedReaderAccess.SetAction(nullptr);
     }
 
     void EchoOnStreams::RequestSend(ServiceProxy& serviceProxy)
@@ -117,7 +115,7 @@ namespace services
 
     void EchoOnStreams::ReleaseReader()
     {
-        limitedReaderAccess.SetAction(infra::emptyFunction);
+        limitedReaderAccess.SetAction(nullptr);
         bufferedReader = infra::none;
         readerPtr = nullptr;
     }
@@ -238,16 +236,11 @@ namespace services
         }
     }
 
-    void EchoOnStreams::MethodContents(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
-    {
-        methodDeserializer->MethodContents(std::move(reader));
-    }
-
     void EchoOnStreams::ContinueReceiveMessage()
     {
         limitedReader->SwitchInput(*bufferedReader);
         limitedReaderAccess.SetAction(infra::emptyFunction);
-        MethodContents(limitedReaderAccess.MakeShared(*limitedReader));
+        methodDeserializer->MethodContents(limitedReaderAccess.MakeShared(*limitedReader));
 
         if (limitedReaderAccess.Referenced())
             limitedReaderAccess.SetAction([this]()

--- a/protobuf/echo/Echo.hpp
+++ b/protobuf/echo/Echo.hpp
@@ -67,6 +67,7 @@ namespace services
 
     class EchoOnStreams
         : public Echo
+        , public infra::EnableSharedFromThis<EchoOnStreams>
     {
     public:
         explicit EchoOnStreams(services::MethodSerializerFactory& serializerFactory, const EchoErrorPolicy& errorPolicy = echoErrorPolicyAbortOnMessageFormatError);
@@ -87,7 +88,6 @@ namespace services
         void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader);
         void ReleaseReader();
         void Initialized();
-        virtual void MethodContents(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader);
         virtual void ReleaseDeserializer();
 
     private:

--- a/services/network/EchoOnConnection.cpp
+++ b/services/network/EchoOnConnection.cpp
@@ -1,13 +1,7 @@
 #include "services/network/EchoOnConnection.hpp"
-#include "infra/util/SharedPtr.hpp"
 
 namespace services
 {
-    EchoOnConnection::~EchoOnConnection()
-    {
-        forwarder.OnAllocatable(nullptr);
-    }
-
     void EchoOnConnection::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
     {
         EchoOnStreams::SendStreamAvailable(std::move(writer));
@@ -18,7 +12,6 @@ namespace services
         if (reader.Allocatable())
         {
             auto readerPtr = reader.Emplace(ConnectionObserver::Subject().ReceiveStream(), *this);
-            keepAliveWhileReading = ConnectionObserver::Subject().ObserverPtr();
             EchoOnStreams::DataReceived(infra::MakeContainedSharedObject(readerPtr->limitedReader, readerPtr));
         }
         else
@@ -28,23 +21,6 @@ namespace services
     void EchoOnConnection::RequestSendStream(std::size_t size)
     {
         ConnectionObserver::Subject().RequestSendStream(std::min(size, ConnectionObserver::Subject().MaxSendStreamSize()));
-    }
-
-    void EchoOnConnection::MethodContents(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
-    {
-        if (forwarder.Allocatable())
-        {
-            forwarder.OnAllocatable(nullptr);
-            auto forwarderPtr = forwarder.Emplace(Forwarder{ ConnectionObserver::Subject().ObserverPtr(), std::move(reader) });
-            auto forwardingReader = infra::MakeContainedSharedObject(*forwarderPtr->reader, forwarderPtr);
-            forwarderPtr = nullptr;
-            EchoOnStreams::MethodContents(std::move(forwardingReader));
-        }
-        else
-            forwarder.OnAllocatable([this, reader]()
-                {
-                    MethodContents(infra::SharedPtr<infra::StreamReaderWithRewinding>(reader));
-                });
     }
 
     EchoOnConnection::LimitedReader::LimitedReader(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, EchoOnConnection& connection)

--- a/services/network/WebSocket.cpp
+++ b/services/network/WebSocket.cpp
@@ -2,7 +2,6 @@
 #include "infra/util/BoundedVector.hpp"
 #include "infra/util/Endian.hpp"
 #include "infra/util/EnumCast.hpp"
-#include "services/network/WebSocketServerConnectionObserver.hpp"
 
 namespace
 {
@@ -97,7 +96,7 @@ namespace services
                 {
                     OnAllocatable(connection);
                 });
-            if (webSocketConnectionObserver && (*webSocketConnectionObserver)->IsAttached())
+            if (webSocketConnectionObserver)
                 (*webSocketConnectionObserver)->Close();
         }
     }

--- a/services/network/WebSocketClientConnectionObserver.cpp
+++ b/services/network/WebSocketClientConnectionObserver.cpp
@@ -12,14 +12,7 @@ namespace services
     WebSocketClientConnectionObserver::WebSocketClientConnectionObserver()
         : streamWriter([this]()
               {
-                  infra::WeakPtr<void> checkAlive = keepAliveWhileWriting;
-                  keepAliveWhileWriting = nullptr;
-                  if (checkAlive.lock())
-                      StreamWriterAllocatable();
-              })
-        , streamReader([this]()
-              {
-                  keepAliveWhileReading = nullptr;
+                  StreamWriterAllocatable();
               })
     {}
 
@@ -35,7 +28,6 @@ namespace services
             assert(observerStreamRequested);
             assert(requestedSendSize != infra::none);
             assert(!streamWriter);
-            keepAliveWhileWriting = Subject().ObserverPtr();
             Connection::Observer().SendStreamAvailable(streamWriter.Emplace(std::move(writer), *infra::PostAssign(requestedSendSize, infra::none)));
         }
     }
@@ -68,7 +60,6 @@ namespace services
 
     infra::SharedPtr<infra::StreamReaderWithRewinding> WebSocketClientConnectionObserver::ReceiveStream()
     {
-        keepAliveWhileReading = Subject().ObserverPtr();
         return streamReader.Emplace(*this);
     }
 

--- a/services/network/WebSocketClientConnectionObserver.hpp
+++ b/services/network/WebSocketClientConnectionObserver.hpp
@@ -130,9 +130,7 @@ namespace services
     private:
         infra::Optional<std::size_t> requestedSendSize;
         infra::NotifyingSharedOptional<FrameWriter> streamWriter;
-        infra::SharedPtr<void> keepAliveWhileWriting;
-        infra::NotifyingSharedOptional<FrameReader> streamReader;
-        infra::SharedPtr<void> keepAliveWhileReading;
+        infra::SharedOptional<FrameReader> streamReader;
         std::size_t unackedReadAvailable = 0;
         std::size_t availableInCurrentFrame = 0;
         std::size_t saveAtEndOfDiscovery = 0;

--- a/services/network/WebSocketServerConnectionObserver.hpp
+++ b/services/network/WebSocketServerConnectionObserver.hpp
@@ -194,9 +194,7 @@ namespace services
         infra::BoundedVector<uint8_t>& sendBuffer;
         std::size_t requestedSendSize = 0;
         infra::NotifyingSharedOptional<infra::LimitedStreamReaderWithRewinding::WithInput<infra::BoundedDequeInputStreamReader>> streamReader;
-        infra::SharedPtr<void> keepAliveWhileReading;
         infra::NotifyingSharedOptional<infra::LimitedStreamWriter::WithOutput<infra::BoundedVectorStreamWriter>> streamWriter;
-        infra::SharedPtr<void> keepAliveWhileWriting;
         bool sendBufferReadyForSending = false;
         infra::BoundedVector<uint8_t>::WithMaxSize<8> pongBuffer;
     };

--- a/services/network/test/TestWebSocketClientConnectionObserver.cpp
+++ b/services/network/test/TestWebSocketClientConnectionObserver.cpp
@@ -414,28 +414,3 @@ TEST_F(WebSocketClientConnectionObserverTest, AbortAndDestroy)
     EXPECT_CALL(connection, AbortAndDestroyMock());
     webSocket->AbortAndDestroy();
 }
-
-TEST_F(WebSocketClientConnectionObserverTest, when_reader_is_open_websocket_is_kept_alive_after_connection_close)
-{
-    auto reader = webSocket->ReceiveStream();
-
-    EXPECT_CALL(connection, AbortAndDestroyMock());
-    EXPECT_CALL(connectionObserver, Detaching());
-    webSocket->AbortAndDestroy();
-
-    reader = nullptr;
-}
-
-TEST_F(WebSocketClientConnectionObserverTest, when_writer_is_open_websocket_is_kept_alive_after_connection_close)
-{
-    infra::SharedPtr<infra::StreamWriter> streamWriter;
-    EXPECT_CALL(connectionObserver, SendStreamAvailable(testing::_)).WillOnce(testing::SaveArg<0>(&streamWriter));
-    webSocket->RequestSendStream(1);
-    ExecuteAllActions();
-
-    EXPECT_CALL(connection, AbortAndDestroyMock());
-    EXPECT_CALL(connectionObserver, Detaching());
-    webSocket->AbortAndDestroy();
-
-    streamWriter = nullptr;
-}

--- a/services/network/test/TestWebSocketServerConnectionObserver.cpp
+++ b/services/network/test/TestWebSocketServerConnectionObserver.cpp
@@ -315,27 +315,3 @@ TEST_F(WebSocketServerConnectionObserverTest, dont_use_whole_buffer)
     ExecuteAllActions();
     EXPECT_EQ(sendFrame, connection.sentData);
 }
-
-TEST_F(WebSocketServerConnectionObserverTest, when_reader_is_open_websocket_is_kept_alive_after_connection_close)
-{
-    auto reader = webSocket->ReceiveStream();
-
-    EXPECT_CALL(connection, AbortAndDestroyMock());
-    EXPECT_CALL(connectionObserver, Detaching());
-    webSocket->AbortAndDestroy();
-
-    reader = nullptr;
-}
-
-TEST_F(WebSocketServerConnectionObserverTest, when_writer_is_open_websocket_is_kept_alive_after_connection_close)
-{
-    infra::SharedPtr<infra::StreamWriter> streamWriter;
-    EXPECT_CALL(connectionObserver, SendStreamAvailable(testing::_)).WillOnce(testing::SaveArg<0>(&streamWriter));
-    webSocket->RequestSendStream(1);
-
-    EXPECT_CALL(connection, AbortAndDestroyMock());
-    EXPECT_CALL(connectionObserver, Detaching());
-    webSocket->AbortAndDestroy();
-
-    streamWriter = nullptr;
-}


### PR DESCRIPTION
This change breaks the downstream build and tests