### PR TITLE
fix: when UartUnix is destroyed receivedData is still called on read thread

### DIFF
--- a/hal/unix/UartUnix.hpp
+++ b/hal/unix/UartUnix.hpp
@@ -29,7 +29,6 @@ namespace hal
 
     private:
         void Read();
-        void LockReadThen(const infra::Function<void()>& action);
 
     private:
         uint8_t buffer;

--- a/hal/unix/UartUnix.hpp
+++ b/hal/unix/UartUnix.hpp
@@ -29,6 +29,7 @@ namespace hal
 
     private:
         void Read();
+        void LockReadThen(const infra::Function<void()>& action);
 
     private:
         uint8_t buffer;


### PR DESCRIPTION
- Established partial locks in Read()
- Reset receivedData on destruction