### PR TITLE
fix: fixed race condition in EchoOnStreams

### DIFF
--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -145,7 +145,7 @@ namespace services
 
     void EchoOnStreams::TryGrantSend()
     {
-        if (sendingProxy == nullptr && !sendRequesters.empty())
+        if (!skipNextStream && sendingProxy == nullptr && !sendRequesters.empty())
         {
             sendingProxy = &sendRequesters.front();
             sendRequesters.pop_front();


### PR DESCRIPTION
This change fixes an issue in EchoOnStreams when a new request to send is issued while a previous request is cancelled while the StreamAvailable has not been called yet.

What was happening in detail: (the **bold** part indicates where the error occurs)
- A proxy does a RequestSend
- The proxy is pushed on the sendRequesters queue
- TryGrandSend checks if sendingProxy is null (it is) and the sendRequesters queue is empty (it isn't)
- the front of the sendRequesters is assigned to sendingProxy and a request for send stream is send
- The proxy is destroyed, before the send stream is returned via SendStreamAvailable
- This cancels the request via CancelRequestSend
- The sendingProxy is not in the queue, so it must be the current serviceProxy
- sendingProxy is set to nullptr
- skipNextStream is set to true.
  - This flag is to ignore the next SendStreamAvailable callback, because that send stream is cancelled.
- A new proxy does a RequestSend
- The proxy is pushed on the sendRequesters queue
- **TryGrandSend checks if sendingProxy is null (it is) and the sendRequesters queue is empty (it isn't)**
- the front of the sendRequesters is assigned to sendingProxy and a request for send stream is send
- Now we get a SendStreamAvailable callback, since skipNextStream is true it'll be ignored
- TryGrandSend is called
- sendingProxy is _not_ null this time, so no new request for a send stream is send and the EchoOnStream is in a deadlock state which it can never recover from.

What this change does:
- Any calls to TryGrandSend should be ignored as long as the previous SendStreamAvailable has not been called.
- Therefor an additional check in TryGrandSend suffices to cover this use case, as long as skipNextStream is true any calls to TryGrandSend should not succeed.
