### PR TITLE
refactor: enable default constructor for BoundedDequeIterator

### DIFF
--- a/infra/util/BoundedDeque.hpp
+++ b/infra/util/BoundedDeque.hpp
@@ -156,7 +156,7 @@ namespace infra
             using pointer = value_type*;
             using reference = value_type&;
 
-            BoundedDequeIterator() = delete;
+            BoundedDequeIterator() = default;
             BoundedDequeIterator(DequeType* deque, std::size_t offset);
             template<class DequeType2, class T2>
             BoundedDequeIterator(const BoundedDequeIterator<DequeType2, T2>& other);
@@ -195,8 +195,8 @@ namespace infra
             friend class BoundedDequeIterator;
             friend DequeType;
 
-            std::size_t index;
-            DequeType* deque;
+            std::size_t index{};
+            DequeType* deque{};
         };
     }
 

--- a/infra/util/test/TestBoundedDeque.cpp
+++ b/infra/util/test/TestBoundedDeque.cpp
@@ -727,6 +727,27 @@ TEST(BoundedDequeTest, TestEmplaceWrapped)
     EXPECT_EQ(infra::MoveConstructible(3), deque[3]);
 }
 
+TEST(BoundedDequeTest, IteratorDefaultConstruct)
+{
+    infra::BoundedDeque<int>::iterator i;
+
+    EXPECT_EQ(infra::BoundedDeque<int>::iterator(), i);
+}
+
+TEST(BoundedDequeTest, IteratorDefaultConstructDeathOnAccess)
+{
+    struct MyType
+    {
+        int i{ 0 };
+    };
+
+    // Accessing a default-constructed iterator should trigger undefined behavior (death).
+    infra::BoundedDeque<MyType>::iterator i;
+    ASSERT_DEATH({ auto& value = *i; }, "");
+    ASSERT_DEATH({ auto value = i->i; }, "");
+    ASSERT_DEATH({ auto& value = i[0]; }, "");
+}
+
 TEST(BoundedDequeTest, IteratorCopyConstruct)
 {
     infra::BoundedDeque<int>::WithMaxSize<5> list(std::size_t(1), 4);


### PR DESCRIPTION
std::deque defines its iterator as a form of `LegacyForwardIterator` which needs to be default constructable.
In the effort of using `BoundedDeque` with the same semantics as std::deque it is required to enable the default constructor of its iterator.