### PR TITLE
fix: add nullptr check for netif_default in LightweightIp ExtCallback

### DIFF
--- a/lwip/lwip_cpp/LightweightIp.cpp
+++ b/lwip/lwip_cpp/LightweightIp.cpp
@@ -97,6 +97,9 @@ namespace services
 
     void LightweightIp::ExtCallback(netif_nsc_reason_t reason, const netif_ext_callback_args_t* args)
     {
+        if (netif_default == nullptr)
+            return;
+
         bool linkUp = (netif_default->flags & NETIF_FLAG_LINK_UP) != 0;
 
         auto newIpv4Address = GetIPv4Address();


### PR DESCRIPTION
The `ExtCallback` will be called when the `LightweightIpOverEthernetFactory` is being created and `netif_add()` is called. `netif_default` interface will be `nullptr` at this point in time.
Add this check to avoid `nullptr` access.