### PR TITLE
fix: release build with ticlang

### DIFF
--- a/external/crypto/micro-ecc/CMakeLists.txt
+++ b/external/crypto/micro-ecc/CMakeLists.txt
@@ -30,4 +30,11 @@ target_sources(crypto.micro_ecc PRIVATE
     ${microecc_SOURCE_DIR}/uECC.h
 )
 
+if(CMAKE_C_COMPILER_ID STREQUAL "TIClang")
+    set_source_files_properties(
+        ${microecc_SOURCE_DIR}/uECC.c
+        PROPERTIES COMPILE_OPTIONS -O0
+    )
+endif()
+
 emil_exclude_from_clang_format(crypto.micro_ecc)


### PR DESCRIPTION
When building crypto.micro_ecc with ticlang for release configurations, compiler outputs: 

asm_arm.inc:116:9: error: inline assembly requires more registers than available
[build]         ".syntax unified \n\t"
[build]         ^
[build] error: register allocation failed: maximum depth for recoloring reached. Use -fexhaustive-register-search to skip cutoffs

Fix proposed is to force the conflicting file to be built without optimizations for ticlang.