### PR TITLE
feat: extend the ble gap advertisement formatter with the option to add the appearance value

### DIFF
--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -288,6 +288,16 @@ namespace services
         return infra::ConstCastMemoryRange<AttAttribute::Uuid128>(infra::ReinterpretCastMemoryRange<const AttAttribute::Uuid128>(uuidData));
     }
 
+    infra::Optional<uint16_t> GapAdvertisingDataParser::Appearance() const
+    {
+        auto appearanceData = ParserAdvertisingData(GapAdvertisementDataType::appearance);
+
+        if (appearanceData.size() != sizeof(uint16_t))
+            return infra::none;
+
+        return infra::MakeOptional(*reinterpret_cast<const uint16_t*>(appearanceData.begin()));
+    }
+
     infra::ConstByteRange GapAdvertisingDataParser::ParserAdvertisingData(GapAdvertisementDataType type) const
     {
         const uint8_t lengthOffset = 0;
@@ -378,6 +388,14 @@ namespace services
 
         AddHeader(payload, sizeof(address), GapAdvertisementDataType::publicTargetAddress);
         AddData(payload, infra::ReinterpretCastMemoryRange<const uint8_t>(infra::MakeRangeFromSingleObject(address)));
+    }
+
+    void GapAdvertisementFormatter::AppendAppearance(uint16_t appearance)
+    {
+        really_assert(sizeof(appearance) + headerSize <= RemainingSpaceAvailable());
+
+        AddHeader(payload, sizeof(appearance), GapAdvertisementDataType::appearance);
+        AddData(payload, infra::ReinterpretCastMemoryRange<const uint8_t>(infra::MakeRangeFromSingleObject(appearance)));
     }
 
     infra::ConstByteRange GapAdvertisementFormatter::FormattedAdvertisementData() const

--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -292,10 +292,13 @@ namespace services
     {
         auto appearanceData = ParserAdvertisingData(GapAdvertisementDataType::appearance);
 
-        if (appearanceData.size() != sizeof(uint16_t))
+        infra::ByteInputStream stream(appearanceData, infra::softFail);
+        auto appearance = stream.Extract<uint16_t>();
+
+        if (stream.Failed())
             return infra::none;
 
-        return infra::MakeOptional(*reinterpret_cast<const uint16_t*>(appearanceData.begin()));
+        return infra::MakeOptional(appearance);
     }
 
     infra::ConstByteRange GapAdvertisingDataParser::ParserAdvertisingData(GapAdvertisementDataType type) const

--- a/services/ble/Gap.hpp
+++ b/services/ble/Gap.hpp
@@ -51,6 +51,7 @@ namespace services
         shortenedLocalName = 0x08u,
         completeLocalName = 0x09u,
         publicTargetAddress = 0x17u,
+        appearance = 0x19u,
         manufacturerSpecificData = 0xffu
     };
 
@@ -296,6 +297,7 @@ namespace services
         infra::Optional<GapPeripheral::AdvertisementFlags> Flags() const;
         infra::MemoryRange<const AttAttribute::Uuid16> CompleteListOf16BitUuids() const;
         infra::MemoryRange<const AttAttribute::Uuid128> CompleteListOf128BitUuids() const;
+        infra::Optional<uint16_t> Appearance() const;
 
     private:
         infra::ConstByteRange data;
@@ -316,6 +318,7 @@ namespace services
         void AppendListOfServicesUuid(infra::MemoryRange<AttAttribute::Uuid16> services);
         void AppendListOfServicesUuid(infra::MemoryRange<AttAttribute::Uuid128> services);
         void AppendPublicTargetAddress(hal::MacAddress address);
+        void AppendAppearance(uint16_t appearance);
 
         infra::ConstByteRange FormattedAdvertisementData() const;
         std::size_t RemainingSpaceAvailable() const;

--- a/services/ble/test/TestGapAdvertisementFormatter.cpp
+++ b/services/ble/test/TestGapAdvertisementFormatter.cpp
@@ -182,4 +182,20 @@ namespace services
         EXPECT_EQ(data[3], 0x00);
         EXPECT_EQ(data[4], 0xFF);
     }
+
+    TEST_F(GapAdvertisementFormatterTest, append_appearance)
+    {
+        uint16_t keyboardAppearance = 0x03C1;
+
+        formatter.AppendAppearance(keyboardAppearance);
+
+        auto data = formatter.FormattedAdvertisementData();
+        EXPECT_EQ(data.size(), 4);
+        EXPECT_EQ(data[0], 3);
+        EXPECT_EQ(data[1], 0x19);
+        EXPECT_EQ(data[2], 0xC1);
+        EXPECT_EQ(data[3], 0x03);
+
+        EXPECT_EQ(formatter.RemainingSpaceAvailable(), GapPeripheral::maxScanResponseDataSize - 4);
+    }
 }

--- a/services/ble/test/TestGapCentral.cpp
+++ b/services/ble/test/TestGapCentral.cpp
@@ -150,6 +150,18 @@ namespace services
         EXPECT_TRUE(infra::ContentsEqual(infra::MakeRange(payloadParser), manufacturerSpecificData->second));
     }
 
+    TEST(GapAdvertisingDataParserTest, get_appearance_value)
+    {
+        const std::array<uint8_t, 4> data = { 0x03, 0x19, 0xC1, 0x03 };
+
+        services::GapAdvertisingDataParser parser(infra::MakeConstByteRange(data));
+
+        auto appearance = parser.Appearance();
+
+        ASSERT_TRUE(appearance);
+        EXPECT_EQ(0x03C1, *appearance);
+    }
+
     TEST(GapAdvertisingDataParserTest, useful_info_after_first_ad_structure)
     {
         const std::array<uint8_t, 21> data{ { 0x02, 0x01, 0x06, 0x08, 0x09, 0x70, 0x68, 0x69, 0x6C, 0x69, 0x70, 0x73, 0x02, 0x0a, 0x08, 0x05, 0xff, 0xaa, 0xbb, 0xcc, 0xdd } };


### PR DESCRIPTION
Extend the GapAdvertisingDataFormatter with the option to add the appearance value.