### PR TITLE
fix: timerService recompute of next trigger on timer update

### DIFF
--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -44,7 +44,7 @@ namespace infra
 
     void TimerService::UpdateTriggerTime(Timer& timer, TimePoint oldTriggerTime)
     {
-        if (nextTrigger == oldTriggerTime)
+        if (nextTrigger == oldTriggerTime || timer.NextTrigger() < nextTrigger)
             ComputeNextTrigger();
     }
 

--- a/infra/timer/test/TestTimer.cpp
+++ b/infra/timer/test/TestTimer.cpp
@@ -94,6 +94,27 @@ TEST_F(TimerTest, TwoTimersTriggerInOrder)
     ForwardTime(std::chrono::seconds(5));
 };
 
+TEST_F(TimerTest, UpdatingArmedTimerToEarlierTimeTriggersAtUpdatedTime)
+{
+    infra::MockCallback<void()> earlyCallback;
+    infra::MockCallback<void()> lateCallback;
+    EXPECT_CALL(earlyCallback, callback()).With(After(std::chrono::seconds(1)));
+    EXPECT_CALL(lateCallback, callback()).With(After(std::chrono::seconds(10)));
+
+    infra::TimerSingleShot firstTimer(std::chrono::seconds(10), [&lateCallback]()
+        {
+            lateCallback.callback();
+        });
+    infra::TimerSingleShot secondTimer(std::chrono::seconds(20), []() {});
+
+    secondTimer.Start(std::chrono::seconds(1), [&earlyCallback]()
+        {
+            earlyCallback.callback();
+        });
+
+    ForwardTime(std::chrono::seconds(10));
+}
+
 TEST_F(TimerTest, RepeatingTimerTriggersRepeatedly)
 {
     infra::MockCallback<void()> callback;


### PR DESCRIPTION
This pull request improves the timer service by fixing trigger time calculations and adds a new test to verify correct behavior when updating an armed timer to an earlier time. The changes ensure that timers will trigger at the correct updated time if rescheduled.

**Timer service logic improvement:**

* Updated the `TimerService::UpdateTriggerTime` method in `TimerService.cpp` to recompute the next trigger not only if the old trigger time matches the current next trigger, but also if the timer's new trigger time is earlier than the current next trigger. This ensures the timer service always triggers at the correct time when a timer is rescheduled to an earlier moment.

**Testing enhancements:**

* Added a new test `UpdatingArmedTimerToEarlierTimeTriggersAtUpdatedTime` in `TestTimer.cpp` to verify that updating a timer to an earlier time causes it to trigger at the updated time, ensuring correct timer behavior.