### PR TITLE
feat: Support independent dual-stack endpoints in BonjourServer

### DIFF
--- a/lwip/lwip_config/lwipopts.h
+++ b/lwip/lwip_config/lwipopts.h
@@ -10,7 +10,6 @@ extern "C"
 
 #define NO_SYS 1
 #define LWIP_IPV6 1
-#define MEMP_NUM_UDP_PCB 6
 #define SYS_LIGHTWEIGHT_PROT 0
 #define LWIP_NETCONN 0
 #define LWIP_SOCKET 0

--- a/lwip/lwip_config/lwipopts.h
+++ b/lwip/lwip_config/lwipopts.h
@@ -10,6 +10,7 @@ extern "C"
 
 #define NO_SYS 1
 #define LWIP_IPV6 1
+#define MEMP_NUM_UDP_PCB 6
 #define SYS_LIGHTWEIGHT_PROT 0
 #define LWIP_NETCONN 0
 #define LWIP_SOCKET 0

--- a/lwip/lwip_cpp/LightweightIp.cpp
+++ b/lwip/lwip_cpp/LightweightIp.cpp
@@ -103,9 +103,10 @@ namespace services
 
     IPv6Address LightweightIp::LinkLocalAddress() const
     {
-        for (const auto& address : netif_default->ip6_addr)
-            if (ip6_addr_islinklocal(&address.u_addr.ip6))
-                return Convert(address.u_addr.ip6);
+        for (s8_t i = 0; i < LWIP_IPV6_NUM_ADDRESSES; ++i)
+            if (ip6_addr_isvalid(netif_ip6_addr_state(netif_default, i)) &&
+                ip6_addr_islinklocal(netif_ip6_addr(netif_default, i)))
+                return Convert(*netif_ip6_addr(netif_default, i));
         return {};
     }
 

--- a/lwip/lwip_cpp/LightweightIpOverEthernet.cpp
+++ b/lwip/lwip_cpp/LightweightIpOverEthernet.cpp
@@ -243,7 +243,7 @@ namespace services
         netInterface.hwaddr[5] = macAddress[5];
 
         netInterface.mtu = 1500;
-        netInterface.flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_IGMP;
+        netInterface.flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_IGMP | NETIF_FLAG_MLD6;
 
         return ERR_OK;
     }

--- a/services/network/BonjourServer.cpp
+++ b/services/network/BonjourServer.cpp
@@ -67,8 +67,6 @@ namespace services
             ipv6Endpoint.emplace(*this, factory, multicast, IPVersions::ipv6, MakeUdpSocket(mdnsMulticastAddressIpv6, mdnsPort));
     }
 
-    BonjourServer::~BonjourServer() = default;
-
     BonjourServer::DatagramEndpoint::DatagramEndpoint(BonjourServer& server, DatagramFactory& factory, Multicast& multicast, IPVersions ipVersion, UdpSocket multicastSocket)
         : server(server)
         , multicast(multicast)

--- a/services/network/BonjourServer.cpp
+++ b/services/network/BonjourServer.cpp
@@ -53,10 +53,7 @@ namespace services
 
     BonjourServer::BonjourServer(DatagramFactory& factory, Multicast& multicast, infra::BoundedConstString instance, infra::BoundedConstString serviceName, infra::BoundedConstString type,
         std::optional<IPv4Address> ipv4Address, std::optional<IPv6Address> ipv6Address, uint16_t port, const DnsHostnameParts& text)
-        : datagramExchangeIpv4(ipv4Address != std::nullopt ? factory.Listen(*this, mdnsPort, IPVersions::ipv4) : nullptr)
-        , datagramExchangeIpv6(ipv6Address != std::nullopt ? factory.Listen(*this, mdnsPort, IPVersions::ipv6) : nullptr)
-        , multicast(multicast)
-        , instance(instance)
+        : instance(instance)
         , serviceName(serviceName)
         , type(type)
         , ipv4Address(ipv4Address)
@@ -65,32 +62,59 @@ namespace services
         , text(text)
     {
         if (ipv4Address != std::nullopt)
-            multicast.JoinMulticastGroup(datagramExchangeIpv4, mdnsMulticastAddressIpv4);
+            ipv4Endpoint.emplace(*this, factory, multicast, IPVersions::ipv4, MakeUdpSocket(mdnsMulticastAddressIpv4, mdnsPort));
         if (ipv6Address != std::nullopt)
-            multicast.JoinMulticastGroup(datagramExchangeIpv6, mdnsMulticastAddressIpv6);
-
-        if (datagramExchangeIpv4 != nullptr)
-            state.Emplace<StateAnnounceIPv4>(*this);
-        else
-            state.Emplace<StateAnnounceIPv6>(*this);
+            ipv6Endpoint.emplace(*this, factory, multicast, IPVersions::ipv6, MakeUdpSocket(mdnsMulticastAddressIpv6, mdnsPort));
     }
 
-    BonjourServer::~BonjourServer()
+    BonjourServer::~BonjourServer() = default;
+
+    BonjourServer::DatagramEndpoint::DatagramEndpoint(BonjourServer& server, DatagramFactory& factory, Multicast& multicast, IPVersions ipVersion, UdpSocket multicastSocket)
+        : server(server)
+        , multicast(multicast)
+        , multicastSocket(multicastSocket)
+        , exchange(factory.Listen(observer, mdnsPort, ipVersion))
+        , state(std::in_place_type_t<StateIdle>(), *this)
     {
-        if (ipv4Address != std::nullopt)
-            multicast.LeaveMulticastGroup(datagramExchangeIpv4, mdnsMulticastAddressIpv4);
-        if (ipv6Address != std::nullopt)
-            multicast.LeaveMulticastGroup(datagramExchangeIpv6, mdnsMulticastAddressIpv6);
+        std::visit([&](const auto& socket)
+            {
+                multicast.JoinMulticastGroup(exchange, socket.first);
+            },
+            this->multicastSocket);
+        state.Emplace<StateAnnounce>(*this);
     }
 
-    void BonjourServer::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
+    BonjourServer::DatagramEndpoint::~DatagramEndpoint()
     {
-        state->DataReceived(std::move(reader), from);
+        std::visit([&](const auto& socket)
+            {
+                multicast.LeaveMulticastGroup(exchange, socket.first);
+            },
+            multicastSocket);
     }
 
-    void BonjourServer::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
+    void BonjourServer::DatagramEndpoint::WriteAnnounceQuery(infra::StreamWriter& writer)
     {
-        state->SendStreamAvailable(std::move(writer));
+        Answer answer(server, 0, writer, 5, 0);
+        answer.AddPtrAnswer();
+        answer.AddSrvAnswer();
+        answer.AddTxtAnswer();
+        answer.AddAAnswer();
+        answer.AddAaaaAnswer();
+    }
+
+    BonjourServer::DatagramEndpoint::Observer::Observer(DatagramEndpoint& endpoint)
+        : endpoint(endpoint)
+    {}
+
+    void BonjourServer::DatagramEndpoint::Observer::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
+    {
+        endpoint.state->DataReceived(std::move(reader), from);
+    }
+
+    void BonjourServer::DatagramEndpoint::Observer::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
+    {
+        endpoint.state->SendStreamAvailable(std::move(writer));
     }
 
     BonjourServer::Answer::Answer(BonjourServer& server, uint16_t queryId, infra::StreamWriter& writer, uint16_t answersCount, uint16_t additionalRecordsCount)
@@ -468,11 +492,29 @@ namespace services
         return parts.Empty() && components.empty();
     }
 
-    BonjourServer::StateIdle::StateIdle(BonjourServer& server)
-        : server(server)
+    BonjourServer::DatagramEndpoint::StateAnnounce::StateAnnounce(DatagramEndpoint& endpoint)
+        : endpoint(endpoint)
+    {
+        infra::CountingStreamWriter countingWriter;
+        endpoint.WriteAnnounceQuery(countingWriter);
+        endpoint.exchange->RequestSendStream(countingWriter.Processed(), endpoint.multicastSocket);
+    }
+
+    void BonjourServer::DatagramEndpoint::StateAnnounce::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
     {}
 
-    void BonjourServer::StateIdle::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
+    void BonjourServer::DatagramEndpoint::StateAnnounce::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
+    {
+        endpoint.WriteAnnounceQuery(*writer);
+        writer = nullptr;
+        endpoint.state.Emplace<StateIdle>(endpoint);
+    }
+
+    BonjourServer::DatagramEndpoint::StateIdle::StateIdle(DatagramEndpoint& endpoint)
+        : endpoint(endpoint)
+    {}
+
+    void BonjourServer::DatagramEndpoint::StateIdle::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
     {
         if (GetPort(from) != mdnsPort)
             return;
@@ -481,78 +523,18 @@ namespace services
             return;
 
         waitingReader = std::move(reader);
-        QuestionParser question(server, *waitingReader);
+        QuestionParser question(endpoint.server, *waitingReader);
         if (question.HasAnswer())
-        {
-            if (std::holds_alternative<services::IPv4Address>(GetAddress(from)))
-                question.RequestSendStream(*server.datagramExchangeIpv4, from, MakeUdpSocket(mdnsMulticastAddressIpv4, mdnsPort));
-            else
-                question.RequestSendStream(*server.datagramExchangeIpv6, from, MakeUdpSocket(mdnsMulticastAddressIpv6, mdnsPort));
-        }
+            question.RequestSendStream(*endpoint.exchange, from, endpoint.multicastSocket);
         else
             waitingReader = nullptr;
     }
 
-    void BonjourServer::StateIdle::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
+    void BonjourServer::DatagramEndpoint::StateIdle::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
     {
         assert(waitingReader != nullptr);
 
-        QuestionParser question(server, *waitingReader, *writer);
-
+        QuestionParser question(endpoint.server, *waitingReader, *writer);
         waitingReader = nullptr;
-    }
-
-    BonjourServer::StateAnnounce::StateAnnounce(BonjourServer& server)
-        : server(server)
-    {}
-
-    void BonjourServer::StateAnnounce::DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from)
-    {}
-
-    void BonjourServer::StateAnnounce::WriteAnnounceQuery(infra::StreamWriter& writer)
-    {
-        Answer answer(server, 0, writer, 5, 0);
-        answer.AddPtrAnswer();
-        answer.AddSrvAnswer();
-        answer.AddTxtAnswer();
-        answer.AddAAnswer();
-        answer.AddAaaaAnswer();
-    }
-
-    BonjourServer::StateAnnounceIPv4::StateAnnounceIPv4(BonjourServer& server)
-        : StateAnnounce(server)
-    {
-        infra::CountingStreamWriter countingWriter;
-        WriteAnnounceQuery(countingWriter);
-
-        server.datagramExchangeIpv4->RequestSendStream(countingWriter.Processed(), MakeUdpSocket(mdnsMulticastAddressIpv4, mdnsPort));
-    }
-
-    void BonjourServer::StateAnnounceIPv4::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
-    {
-        WriteAnnounceQuery(*writer);
-        writer = nullptr;
-
-        if (server.datagramExchangeIpv6 != nullptr)
-            server.state.Emplace<StateAnnounceIPv6>(server);
-        else
-            server.state.Emplace<StateIdle>(server);
-    }
-
-    BonjourServer::StateAnnounceIPv6::StateAnnounceIPv6(BonjourServer& server)
-        : StateAnnounce(server)
-    {
-        infra::CountingStreamWriter countingWriter;
-        WriteAnnounceQuery(countingWriter);
-
-        server.datagramExchangeIpv6->RequestSendStream(countingWriter.Processed(), MakeUdpSocket(mdnsMulticastAddressIpv6, mdnsPort));
-    }
-
-    void BonjourServer::StateAnnounceIPv6::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
-    {
-        WriteAnnounceQuery(*writer);
-        writer = nullptr;
-
-        server.state.Emplace<StateIdle>(server);
     }
 }

--- a/services/network/BonjourServer.hpp
+++ b/services/network/BonjourServer.hpp
@@ -14,7 +14,6 @@ namespace services
     public:
         BonjourServer(DatagramFactory& factory, Multicast& multicast, infra::BoundedConstString instance, infra::BoundedConstString serviceName, infra::BoundedConstString type,
             std::optional<IPv4Address> ipv4Address, std::optional<IPv6Address> ipv6Address, uint16_t port, const DnsHostnameParts& text);
-        ~BonjourServer();
 
     private:
         class Answer

--- a/services/network/BonjourServer.hpp
+++ b/services/network/BonjourServer.hpp
@@ -10,15 +10,11 @@
 namespace services
 {
     class BonjourServer
-        : public DatagramExchangeObserver
     {
     public:
         BonjourServer(DatagramFactory& factory, Multicast& multicast, infra::BoundedConstString instance, infra::BoundedConstString serviceName, infra::BoundedConstString type,
             std::optional<IPv4Address> ipv4Address, std::optional<IPv6Address> ipv6Address, uint16_t port, const DnsHostnameParts& text);
         ~BonjourServer();
-
-        void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
-        void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
 
     private:
         class Answer
@@ -99,66 +95,74 @@ namespace services
             uint16_t additionalRecordsCount = 0;
         };
 
-        class State
+        class DatagramEndpoint
         {
         public:
-            virtual ~State() = default;
+            DatagramEndpoint(BonjourServer& server, DatagramFactory& factory, Multicast& multicast, IPVersions ipVersion, UdpSocket multicastSocket);
+            ~DatagramEndpoint();
 
-            virtual void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) = 0;
-            virtual void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) = 0;
-        };
+        private:
+            void WriteAnnounceQuery(infra::StreamWriter& writer);
 
-        class StateIdle
-            : public State
-        {
-        public:
-            explicit StateIdle(BonjourServer& server);
+            class Observer
+                : public DatagramExchangeObserver
+            {
+            public:
+                explicit Observer(DatagramEndpoint& endpoint);
 
-            void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
-            void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+                void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
+                void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+
+            private:
+                DatagramEndpoint& endpoint;
+            };
+
+            class State
+            {
+            public:
+                virtual ~State() = default;
+
+                virtual void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) = 0;
+                virtual void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) = 0;
+            };
+
+            class StateAnnounce
+                : public State
+            {
+            public:
+                explicit StateAnnounce(DatagramEndpoint& endpoint);
+
+                void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
+                void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+
+            private:
+                DatagramEndpoint& endpoint;
+            };
+
+            class StateIdle
+                : public State
+            {
+            public:
+                explicit StateIdle(DatagramEndpoint& endpoint);
+
+                void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
+                void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+
+            private:
+                DatagramEndpoint& endpoint;
+                infra::SharedPtr<infra::StreamReaderWithRewinding> waitingReader;
+            };
 
         private:
             BonjourServer& server;
-            infra::SharedPtr<infra::StreamReaderWithRewinding> waitingReader;
-        };
-
-        class StateAnnounce
-            : public State
-        {
-        public:
-            explicit StateAnnounce(BonjourServer& server);
-
-            void DataReceived(infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader, UdpSocket from) override;
-
-        protected:
-            void WriteAnnounceQuery(infra::StreamWriter& writer);
-
-        protected:
-            BonjourServer& server;
-        };
-
-        class StateAnnounceIPv4
-            : public StateAnnounce
-        {
-        public:
-            explicit StateAnnounceIPv4(BonjourServer& server);
-
-            void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
-        };
-
-        class StateAnnounceIPv6
-            : public StateAnnounce
-        {
-        public:
-            explicit StateAnnounceIPv6(BonjourServer& server);
-
-            void SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer) override;
+            Multicast& multicast;
+            UdpSocket multicastSocket;
+            Observer observer{ *this };
+            infra::SharedPtr<DatagramExchange> exchange;
+            infra::PolymorphicVariant<State, StateAnnounce, StateIdle> state;
         };
 
     private:
-        infra::SharedPtr<DatagramExchange> datagramExchangeIpv4;
-        infra::SharedPtr<DatagramExchange> datagramExchangeIpv6;
-        Multicast& multicast;
         infra::BoundedConstString instance;
         infra::BoundedConstString serviceName;
         infra::BoundedConstString type;
@@ -166,7 +170,8 @@ namespace services
         std::optional<IPv6Address> ipv6Address;
         uint16_t port;
         const DnsHostnameParts& text;
-        infra::PolymorphicVariant<State, StateIdle, StateAnnounceIPv4, StateAnnounceIPv6> state{ std::in_place_type_t<StateIdle>(), *this };
+        std::optional<DatagramEndpoint> ipv4Endpoint;
+        std::optional<DatagramEndpoint> ipv6Endpoint;
     };
 }
 

--- a/services/network/MdnsClient.cpp
+++ b/services/network/MdnsClient.cpp
@@ -120,7 +120,8 @@ namespace services
 
     void MdnsQueryImpl::CheckAnswer(services::IPVersions ipVersion, infra::BoundedString& hostname, DnsRecordPayload& payload, infra::ConstByteRange data)
     {
-        if (this->ipVersion == ipVersion && hostname == dnsHostname && payload.type == dnsType && payload.class_ == DnsClass::dnsClassIn)
+        const uint16_t dnsClassMask = 0x7fff; // mask off mDNS cache-flush bit (RFC 6762 §11)
+        if (this->ipVersion == ipVersion && hostname == dnsHostname && payload.type == dnsType && (static_cast<uint16_t>(payload.class_) & dnsClassMask) == infra::enum_cast(DnsClass::dnsClassIn))
         {
             processingQuery = true;
             queryHit(data);

--- a/services/network/test/TestBonjourServer.cpp
+++ b/services/network/test/TestBonjourServer.cpp
@@ -85,8 +85,8 @@ public:
     void TooShortQueryReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+                .Vector());
     }
 
     void QueryWithAnswerReceived()
@@ -122,73 +122,73 @@ public:
     void AnswerReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, services::DnsRecordHeader::flagsResponse, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, services::DnsRecordHeader::flagsResponse, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void DifferentOpcodeReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, services::DnsRecordHeader::flagsOpcodeMask, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, services::DnsRecordHeader::flagsOpcodeMask, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void NonInQueryReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassCh })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassCh })
+                .Vector());
     }
 
     void CNameQueryReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeCName, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeCName, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void QueryForDifferentServiceReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("aaaa")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("aaaa")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void QueryForDifferentInstanceReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("aaaaaaaa")(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("aaaaaaaa")(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void QueryForDifferentShortInstanceReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("aaaaaaaa")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeA, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("aaaaaaaa")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeA, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void QueryForEmptyNameReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void QueryForLongNameReceived()
     {
         DataReceived(infra::ConstructBin()
-                         .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(3)("bla")(8)("instance")(7)("service")(4)("type")(5)("local")(0)
-                         .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
-                         .Vector());
+                .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(3)("bla")(8)("instance")(7)("service")(4)("type")(5)("local")(0)
+                .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
+                .Vector());
     }
 
     void SrvQueryReceived(services::IPAddress source = ipv4Source)
@@ -304,14 +304,14 @@ public:
 
     void ExpectListenIpv4()
     {
-        EXPECT_CALL(factory, Listen(testing::Ref(server), 5353, services::IPVersions::ipv4)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t port, services::IPVersions versions)
+        EXPECT_CALL(factory, Listen(testing::_, 5353, services::IPVersions::ipv4)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t port, services::IPVersions versions)
             {
                 auto ptr = datagramExchange.Emplace();
                 observer.Attach(*ptr);
 
                 ExpectResponse(infra::ConstructBin()
-                                   .Value<services::DnsRecordHeader>({ 0x0000, 0x8000, 0, 5, 0, 0 })(PtrAnswer())(SrvAnswer())(TxtAnswer())(AAnswer())(NoAaaaAnswer())
-                                   .Vector());
+                        .Value<services::DnsRecordHeader>({ 0x0000, 0x8000, 0, 5, 0, 0 })(PtrAnswer())(SrvAnswer())(TxtAnswer())(AAnswer())(NoAaaaAnswer())
+                        .Vector());
 
                 return ptr;
             }));
@@ -319,14 +319,14 @@ public:
 
     void ExpectListenIpv6()
     {
-        EXPECT_CALL(factory, Listen(testing::Ref(server), 5353, services::IPVersions::ipv6)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t port, services::IPVersions versions)
+        EXPECT_CALL(factory, Listen(testing::_, 5353, services::IPVersions::ipv6)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t port, services::IPVersions versions)
             {
                 auto ptr = datagramExchange.Emplace();
                 observer.Attach(*ptr);
 
                 ExpectResponse(infra::ConstructBin()
-                                   .Value<services::DnsRecordHeader>({ 0x0000, 0x8000, 0, 5, 0, 0 })(PtrAnswer())(SrvAnswer())(TxtAnswer())(NoAAnswer())(AaaaAnswer())
-                                   .Vector());
+                        .Value<services::DnsRecordHeader>({ 0x0000, 0x8000, 0, 5, 0, 0 })(PtrAnswer())(SrvAnswer())(TxtAnswer())(NoAAnswer())(AaaaAnswer())
+                        .Vector());
 
                 return ptr;
             }));
@@ -400,8 +400,8 @@ TEST_F(BonjourServerTest, nothing_happens_when_receiving_empty_packet)
 TEST_F(BonjourServerTest, ptr_question_has_answers_and_additional_data)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     PtrQueryReceived();
     ExecuteAllActions();
@@ -410,8 +410,8 @@ TEST_F(BonjourServerTest, ptr_question_has_answers_and_additional_data)
 TEST_F(BonjourServerTest, ptr_question_with_two_questions_has_answers_and_additional_data)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     PtrQueryWithTwoQuestionsReceived();
     ExecuteAllActions();
@@ -420,8 +420,8 @@ TEST_F(BonjourServerTest, ptr_question_with_two_questions_has_answers_and_additi
 TEST_F(BonjourServerTest, ptr_question_with_two_equal_questions_has_answers_and_additional_data)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 2, 0, 8 })(PtrAnswer())(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 2, 0, 8 })(PtrAnswer())(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     PtrQueryWithTwoEqualQuestionsReceived();
     ExecuteAllActions();
@@ -430,8 +430,8 @@ TEST_F(BonjourServerTest, ptr_question_with_two_equal_questions_has_answers_and_
 TEST_F(BonjourServerTest, srv_question_has_answers_and_additional_data)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 2 })(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 2 })(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     SrvQueryReceived();
     ExecuteAllActions();
@@ -440,8 +440,8 @@ TEST_F(BonjourServerTest, srv_question_has_answers_and_additional_data)
 TEST_F(BonjourServerTest, txt_question_has_answers)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(TxtAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(TxtAnswer())
+            .Vector());
 
     TxtQueryReceived();
     ExecuteAllActions();
@@ -450,8 +450,8 @@ TEST_F(BonjourServerTest, txt_question_has_answers)
 TEST_F(BonjourServerTest, a_question_has_answers)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AAnswer())
+            .Vector());
 
     AQueryReceived();
     ExecuteAllActions();
@@ -460,8 +460,8 @@ TEST_F(BonjourServerTest, a_question_has_answers)
 TEST_F(BonjourServerTest, second_question_while_first_is_busy_is_ignored)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     PtrQueryReceived();
     PtrQueryReceived();
@@ -471,8 +471,8 @@ TEST_F(BonjourServerTest, second_question_while_first_is_busy_is_ignored)
 TEST_F(BonjourServerTest, aaaa_query_is_declined_when_no_ipv6_address_is_available)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(NoAaaaAnswer())
+            .Vector());
 
     AaaaQueryReceived();
 }
@@ -494,8 +494,8 @@ TEST_F(BonjourServerTest, invalid_questions_are_ignored)
 TEST_F(BonjourServerTest, answer_in_query_is_ignored)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     QueryWithAnswerReceived();
     ExecuteAllActions();
@@ -504,8 +504,8 @@ TEST_F(BonjourServerTest, answer_in_query_is_ignored)
 TEST_F(BonjourServerTest, name_server_in_query_is_ignored)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     QueryWithNameServerReceived();
     ExecuteAllActions();
@@ -514,8 +514,8 @@ TEST_F(BonjourServerTest, name_server_in_query_is_ignored)
 TEST_F(BonjourServerTest, additional_record_in_query_is_ignored)
 {
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(NoAaaaAnswer())
+            .Vector());
 
     QueryWithAdditionalReceived();
     ExecuteAllActions();
@@ -526,8 +526,8 @@ TEST_F(BonjourServerTest, aaaa_query_is_answered_when_ipv6_address_is_available)
     ReConstructIPv6();
 
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AaaaAnswer())
+            .Vector());
 
     AaaaQueryReceived(ipv6Source);
     ExecuteAllActions();
@@ -538,8 +538,8 @@ TEST_F(BonjourServerTest, a_query_is_declined_when_no_ipv4_address_is_available)
     ReConstructIPv6();
 
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(NoAAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(NoAAnswer())
+            .Vector());
 
     AQueryReceived(ipv6Source);
 }
@@ -549,8 +549,8 @@ TEST_F(BonjourServerTest, ptr_query_is_answered_with_ipv6_address_when_ipv6_addr
     ReConstructIPv6();
 
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(NoAAnswer())(AaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(NoAAnswer())(AaaaAnswer())
+            .Vector());
 
     PtrQueryReceived(ipv6Source);
 }
@@ -560,8 +560,234 @@ TEST_F(BonjourServerTest, srv_query_is_answered_with_ipv6_address_when_ipv6_addr
     ReConstructIPv6();
 
     ExpectResponse(infra::ConstructBin()
-                       .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 2 })(SrvAnswer())(NoAAnswer())(AaaaAnswer())
-                       .Vector());
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 2 })(SrvAnswer())(NoAAnswer())(AaaaAnswer())
+            .Vector());
 
     SrvQueryReceived(ipv6Source);
+}
+
+class BonjourServerDualStackTest
+    : public testing::Test
+    , public infra::EventDispatcherFixture
+{
+public:
+    ~BonjourServerDualStackTest() override
+    {
+        EXPECT_CALL(multicast, LeaveMulticastGroup(testing::_, services::IPv4Address{ 224, 0, 0, 251 }));
+        EXPECT_CALL(multicast, LeaveMulticastGroup(testing::_, services::IPv6Address{ 0xff02, 0, 0, 0, 0, 0, 0, 0xfb }));
+    }
+
+    void DataReceivedIpv4(const std::vector<uint8_t>& data, services::IPv4Address address = { 224, 0, 0, 251 }, uint16_t port = 5353)
+    {
+        datagramExchangeIpv4->GetObserver().DataReceived(infra::MakeSharedOnHeap<infra::StdVectorInputStreamReader::WithStorage>(std::in_place, data), services::Udpv4Socket{ address, port });
+    }
+
+    void DataReceivedIpv6(const std::vector<uint8_t>& data, services::IPv6Address address = { 0xff02, 0, 0, 0, 0, 0, 0, 0xfb }, uint16_t port = 5353)
+    {
+        datagramExchangeIpv6->GetObserver().DataReceived(infra::MakeSharedOnHeap<infra::StdVectorInputStreamReader::WithStorage>(std::in_place, data), services::Udpv6Socket{ address, port });
+    }
+
+    std::vector<uint8_t> PtrAnswer()
+    {
+        return infra::ConstructBin()(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsRecordPayload>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn, std::chrono::seconds(5), 0x1d })(8)("instance")(7)("service")(4)("type")(5)("local")(0)
+            .Vector();
+    }
+
+    std::vector<uint8_t> TxtAnswer()
+    {
+        return infra::ConstructBin()(8)("instance")(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsRecordPayload>({ services::DnsType::dnsTypeTxt, services::DnsClass::dnsClassIn, std::chrono::seconds(5), 0x15 })(7)("aa=text")(12)("bb=othertext")
+            .Vector();
+    }
+
+    std::vector<uint8_t> SrvAnswer()
+    {
+        return infra::ConstructBin()(8)("instance")(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsRecordPayload>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn, std::chrono::seconds(5), 0x16 })
+            .Value<infra::BigEndian<uint16_t>>(0)
+            .Value<infra::BigEndian<uint16_t>>(0)
+            .Value<infra::BigEndian<uint16_t>>(1234)(8)("instance")(5)("local")(0)
+            .Vector();
+    }
+
+    std::vector<uint8_t> AAnswer()
+    {
+        return infra::ConstructBin()(8)("instance")(5)("local")(0)
+            .Value<services::DnsRecordPayload>({ services::DnsType::dnsTypeA, services::DnsClass::dnsClassIn, std::chrono::seconds(5), 4 })
+            .Value<services::IPv4Address>({ 1, 2, 3, 4 })
+            .Vector();
+    }
+
+    std::vector<uint8_t> AaaaAnswer()
+    {
+        return infra::ConstructBin()(8)("instance")(5)("local")(0)
+            .Value<services::DnsRecordPayload>({ services::DnsType::dnsTypeAAAA, services::DnsClass::dnsClassIn, std::chrono::seconds(5), 16 })
+            .Value<services::IPv6AddressNetworkOrder>({ 1, 2, 3, 4, 5, 6, 7, 8 })
+            .Vector();
+    }
+
+    void ExpectResponseOnIpv4(const std::vector<uint8_t>& data)
+    {
+        struct Ptr
+        {
+            BonjourServerDualStackTest& self;
+            std::vector<uint8_t> data;
+        };
+
+        auto ptr = std::make_shared<Ptr>(Ptr{ *this, data });
+        EXPECT_CALL(*datagramExchangeIpv4, RequestSendStream(data.size(), testing::_)).WillOnce(testing::Invoke([ptr](std::size_t, services::UdpSocket)
+            {
+                infra::EventDispatcher::Instance().Schedule([ptr]()
+                    {
+                        infra::StdVectorOutputStreamWriter::WithStorage response;
+                        ptr->self.datagramExchangeIpv4->GetObserver().SendStreamAvailable(infra::UnOwnedSharedPtr(response));
+                        EXPECT_EQ(ptr->data, response.Storage());
+                    });
+            }));
+    }
+
+    void ExpectResponseOnIpv6(const std::vector<uint8_t>& data)
+    {
+        struct Ptr
+        {
+            BonjourServerDualStackTest& self;
+            std::vector<uint8_t> data;
+        };
+
+        auto ptr = std::make_shared<Ptr>(Ptr{ *this, data });
+        EXPECT_CALL(*datagramExchangeIpv6, RequestSendStream(data.size(), testing::_)).WillOnce(testing::Invoke([ptr](std::size_t, services::UdpSocket)
+            {
+                infra::EventDispatcher::Instance().Schedule([ptr]()
+                    {
+                        infra::StdVectorOutputStreamWriter::WithStorage response;
+                        ptr->self.datagramExchangeIpv6->GetObserver().SendStreamAvailable(infra::UnOwnedSharedPtr(response));
+                        EXPECT_EQ(ptr->data, response.Storage());
+                    });
+            }));
+    }
+
+    testing::StrictMock<services::MulticastMock> multicast;
+    testing::StrictMock<services::DatagramFactoryMock> factory;
+    infra::SharedOptional<testing::StrictMock<services::DatagramExchangeMock>> datagramExchangeIpv4;
+    infra::SharedOptional<testing::StrictMock<services::DatagramExchangeMock>> datagramExchangeIpv6;
+
+    std::vector<uint8_t> announcePacket{ infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0000, 0x8000, 0, 5, 0, 0 })(PtrAnswer())(SrvAnswer())(TxtAnswer())(AAnswer())(AaaaAnswer())
+            .Vector() };
+
+    infra::Execute setup{ [this]
+        {
+            EXPECT_CALL(factory, Listen(testing::_, 5353, services::IPVersions::ipv4)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t, services::IPVersions)
+                {
+                    auto ptr = datagramExchangeIpv4.Emplace();
+                    observer.Attach(*ptr);
+                    ExpectResponseOnIpv4(announcePacket);
+                    return ptr;
+                }));
+            EXPECT_CALL(factory, Listen(testing::_, 5353, services::IPVersions::ipv6)).WillOnce(testing::Invoke([this](services::DatagramExchangeObserver& observer, uint16_t, services::IPVersions)
+                {
+                    auto ptr = datagramExchangeIpv6.Emplace();
+                    observer.Attach(*ptr);
+                    ExpectResponseOnIpv6(announcePacket);
+                    return ptr;
+                }));
+            EXPECT_CALL(multicast, JoinMulticastGroup(testing::_, services::IPv4Address{ 224, 0, 0, 251 }));
+            EXPECT_CALL(multicast, JoinMulticastGroup(testing::_, services::IPv6Address{ 0xff02, 0, 0, 0, 0, 0, 0, 0xfb }));
+        } };
+
+    services::DnsHostnameInPartsHelper<2> text{ services::DnsHostnameInParts("aa=text")("bb=othertext") };
+    services::BonjourServer server{ factory, multicast, "instance", "service", "type",
+        std::make_optional(services::IPv4Address{ 1, 2, 3, 4 }),
+        std::make_optional(services::IPv6Address{ 1, 2, 3, 4, 5, 6, 7, 8 }),
+        1234, text };
+
+    infra::Execute run{ [this]
+        {
+            ExecuteAllActions();
+        } };
+};
+
+TEST_F(BonjourServerDualStackTest, both_endpoints_announce_on_construction)
+{
+    // Verified by fixture setup: both listen, both join multicast, both announce
+}
+
+TEST_F(BonjourServerDualStackTest, ptr_query_on_ipv4_answered_on_ipv4_with_both_addresses)
+{
+    ExpectResponseOnIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(AaaaAnswer())
+            .Vector());
+
+    DataReceivedIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    ExecuteAllActions();
+}
+
+TEST_F(BonjourServerDualStackTest, ptr_query_on_ipv6_answered_on_ipv6_with_both_addresses)
+{
+    ExpectResponseOnIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(AaaaAnswer())
+            .Vector());
+
+    DataReceivedIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    ExecuteAllActions();
+}
+
+TEST_F(BonjourServerDualStackTest, a_query_on_ipv4_answered_with_real_a_record)
+{
+    ExpectResponseOnIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AAnswer())
+            .Vector());
+
+    DataReceivedIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("instance")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeA, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    ExecuteAllActions();
+}
+
+TEST_F(BonjourServerDualStackTest, aaaa_query_on_ipv6_answered_with_real_aaaa_record)
+{
+    ExpectResponseOnIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 0 })(AaaaAnswer())
+            .Vector());
+
+    DataReceivedIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(8)("instance")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeAAAA, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    ExecuteAllActions();
+}
+
+TEST_F(BonjourServerDualStackTest, concurrent_queries_on_both_endpoints)
+{
+    ExpectResponseOnIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0x8000, 0, 1, 0, 4 })(PtrAnswer())(TxtAnswer())(SrvAnswer())(AAnswer())(AaaaAnswer())
+            .Vector());
+
+    ExpectResponseOnIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0300, 0x8000, 0, 1, 0, 2 })(SrvAnswer())(AAnswer())(AaaaAnswer())
+            .Vector());
+
+    DataReceivedIpv4(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0200, 0, 1, 0, 0, 0 })(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypePtr, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    DataReceivedIpv6(infra::ConstructBin()
+            .Value<services::DnsRecordHeader>({ 0x0300, 0, 1, 0, 0, 0 })(8)("instance")(7)("service")(4)("type")(5)("local")(0)
+            .Value<services::DnsQuestionFooter>({ services::DnsType::dnsTypeSrv, services::DnsClass::dnsClassIn })
+            .Vector());
+
+    ExecuteAllActions();
 }


### PR DESCRIPTION
Refactors `BonjourServer` to support true dual-stack mDNS by giving each IP version its own independent endpoint. Previously, IPv4 and IPv6 shared a single observer and state machine, causing the IPv6 announce to block on IPv4 completion. Each endpoint now manages its own datagram exchange, multicast membership, and state independently.

## Changes

### lwIP infrastructure fixes
- Add `NETIF_FLAG_MLD6` to the ethernet interface to enable IPv6 Multicast Listener Discovery
- Fix `LinkLocalAddress()` to validate IPv6 address state via `netif_ip6_addr_state()` before checking link-local status — the previous implementation iterated raw addresses without validity checks

### MdnsClient fix
- Add DNS class mask to mask off mDNS cache-flush bit (RFC 6762 §11) to not discard queries

### BonjourServer refactor
- Extract `DatagramEndpoint` as a self-contained inner class owning its datagram exchange, multicast group membership, observer adapter, and `StateAnnounce`/`StateIdle` state machine
- Replace single `DatagramExchangeObserver` inheritance with per-endpoint `Observer` adapters
- Use `std::optional<DatagramEndpoint>` for `ipv4Endpoint`/`ipv6Endpoint`, constructed only when the respective address is provided
- Remove `StateAnnounceIPv4`/`StateAnnounceIPv6` — each endpoint now announces independently via a single `StateAnnounce`

### Tests
- Adapt existing `BonjourServerTest` to the new structure
- Add `BonjourServerDualStackTest` fixture covering:
  - Both endpoints announce on construction
  - Queries on IPv4 answered on IPv4 with both address records
  - Queries on IPv6 answered on IPv6 with both address records
  - A/AAAA queries answered with real records on the matching endpoint
  - Concurrent queries on both endpoints handled independently