### PR TITLE
fix: text output stream width not being reset

### DIFF
--- a/infra/stream/OutputStream.cpp
+++ b/infra/stream/OutputStream.cpp
@@ -341,6 +341,7 @@ namespace infra
     {
         for (auto i = size; i < width.width; ++i)
             Writer().Insert(MakeByteRange(width.padding), ErrorPolicy());
+        width = Width(0);
     }
 
     AsAsciiHelper::AsAsciiHelper(ConstByteRange data)

--- a/infra/stream/OutputStream.cpp
+++ b/infra/stream/OutputStream.cpp
@@ -1,5 +1,6 @@
 #include "infra/stream/OutputStream.hpp"
 #include "infra/util/Base64.hpp"
+#include "infra/util/LogAndAbort.hpp"
 #include <cmath>
 #include <limits>
 
@@ -100,6 +101,7 @@ namespace infra
 
     TextOutputStream& TextOutputStream::operator<<(BoundedConstString string)
     {
+        OutputOptionalPadding(string.size());
         Writer().Insert(ReinterpretCastByteRange(MakeRange(string.begin(), string.end())), ErrorPolicy());
 
         return *this;
@@ -107,6 +109,7 @@ namespace infra
 
     TextOutputStream& TextOutputStream::operator<<(const std::string& string)
     {
+        OutputOptionalPadding(string.size());
         Writer().Insert(ReinterpretCastByteRange(MakeRange(string.data(), string.data() + string.size())), ErrorPolicy());
 
         return *this;
@@ -150,6 +153,7 @@ namespace infra
 
     TextOutputStream& TextOutputStream::operator<<(char c)
     {
+        OutputOptionalPadding(1);
         Writer().Insert(MakeByteRange(c), ErrorPolicy());
         return *this;
     }
@@ -201,7 +205,7 @@ namespace infra
                 OutputAsHexadecimal(v, negative);
                 break;
             default:
-                std::abort();
+                LOG_AND_ABORT_ENUM(radix);
         }
 
         return *this;
@@ -221,7 +225,7 @@ namespace infra
                 OutputAsHexadecimal(v, false);
                 break;
             default:
-                std::abort();
+                LOG_AND_ABORT_ENUM(radix);
         }
 
         return *this;
@@ -370,10 +374,8 @@ namespace infra
 
     TextOutputStream& operator<<(TextOutputStream& stream, const AsHexHelper& asHexHelper)
     {
-        TextOutputStream hexStream = stream << hex << Width(2, '0');
-
         for (uint8_t byte : asHexHelper.data)
-            hexStream << byte;
+            stream << hex << Width(2, '0') << byte;
 
         return stream;
     }

--- a/infra/stream/test/TestStringOutputStream.cpp
+++ b/infra/stream/test/TestStringOutputStream.cpp
@@ -236,7 +236,7 @@ TEST(StringOutputStreamTest, stream_hex_with_leading_zeroes)
     EXPECT_EQ("001a", stream.Storage());
 }
 
-TEST(StringOutputStreamTest, stream_with_leading_zeros_followed_by_endl)
+TEST(StringOutputStreamTest, stream_with_leading_zeroes_followed_by_endl)
 {
     infra::StringOutputStream::WithStorage<16> stream;
 
@@ -318,6 +318,39 @@ TEST(StringOutputStreamTest, format_simple_string_width)
 
     stream << infra::Width(10) << "simple";
     EXPECT_EQ("    simple", stream.Storage());
+}
+
+TEST(StringOutputStreamTest, stream_bounded_string_with_width)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+
+    infra::BoundedConstString s = "hi";
+    stream << infra::Width(6) << s;
+    EXPECT_EQ("    hi", stream.Storage());
+}
+
+TEST(StringOutputStreamTest, stream_std_string_with_width)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+
+    stream << infra::Width(6) << std::string("hi");
+    EXPECT_EQ("    hi", stream.Storage());
+}
+
+TEST(StringOutputStreamTest, stream_char_with_width)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+
+    stream << infra::Width(4) << 'x';
+    EXPECT_EQ("   x", stream.Storage());
+}
+
+TEST(StringOutputStreamTest, stream_width_is_reset_after_use)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+
+    stream << infra::Width(4) << 'x' << 'y';
+    EXPECT_EQ("   xy", stream.Storage());
 }
 
 TEST(StringOutputStreamTest, format_string_with_one_parameter)

--- a/infra/stream/test/TestStringOutputStream.cpp
+++ b/infra/stream/test/TestStringOutputStream.cpp
@@ -2,6 +2,7 @@
 #include "infra/stream/SavedMarkerStream.hpp"
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/BoundedString.hpp"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <cstdint>
 #include <limits>
@@ -234,6 +235,14 @@ TEST(StringOutputStreamTest, stream_hex_with_leading_zeroes)
 
     stream << infra::hex << infra::Width(4, '0') << uint8_t(0x1A);
     EXPECT_EQ("001a", stream.Storage());
+}
+
+TEST(StringOutputStreamTest, stream_with_leading_zeros_followed_by_endl)
+{
+    infra::StringOutputStream::WithStorage<16> stream;
+
+    stream << infra::Width(4, '0') << 12 << infra::endl;
+    EXPECT_EQ("0012\r\n", stream.Storage());
 }
 
 TEST(StringOutputStreamTest, stream_short_bin)

--- a/infra/stream/test/TestStringOutputStream.cpp
+++ b/infra/stream/test/TestStringOutputStream.cpp
@@ -240,8 +240,8 @@ TEST(StringOutputStreamTest, stream_with_leading_zeros_followed_by_endl)
 {
     infra::StringOutputStream::WithStorage<16> stream;
 
-    stream << infra::Width(4, '0') << 12 << infra::endl;
-    EXPECT_EQ("0012\r\n", stream.Storage());
+    stream << infra::Width(4, '0') << 12 << "a";
+    EXPECT_EQ("0012a", stream.Storage());
 }
 
 TEST(StringOutputStreamTest, stream_short_bin)

--- a/infra/stream/test/TestStringOutputStream.cpp
+++ b/infra/stream/test/TestStringOutputStream.cpp
@@ -2,7 +2,6 @@
 #include "infra/stream/SavedMarkerStream.hpp"
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/BoundedString.hpp"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <cstdint>
 #include <limits>


### PR DESCRIPTION
This fixes an issue where if width is specified `TextOutputStream` (for example using `infra::Width(4, '0')`), then it's not being reset after being used. 

Example before fix:
```C++
stream << infra::Width(4, '0') << 12 << "a";
// "0012000a"
```

This now also matches how `iostream` handles, where `setw` is not sticky: https://godbolt.org/z/7n7343vqe

boyscout: also applied the padding to some other types which needed it