### PR TITLE
refactor: data loss in QueueForOneReaderOneIrqWriter

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,7 +63,7 @@
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
         "EMIL_ENABLE_MUTATION_TESTING": "On",
-        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--allow-surviving;--timeout;10000;--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
+        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--allow-surviving;--timeout;30000;--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
       },
       "generator": "Ninja"
     },

--- a/infra/event/QueueForOneReaderOneIrqWriter.hpp
+++ b/infra/event/QueueForOneReaderOneIrqWriter.hpp
@@ -36,8 +36,8 @@ namespace infra
         T Get();
         infra::MemoryRange<const T> ContiguousRange(uint32_t offset = 0) const;
         void Consume(uint32_t amount);
-        std::size_t Size() const;
-        std::size_t EmptySize() const;
+        std::size_t QueuedCount() const;
+        std::size_t Capacity() const;
 
         T operator[](size_t position) const;
 
@@ -75,7 +75,7 @@ namespace infra
 
     private:
         QueueForOneReaderOneIrqWriter<T>& queue;
-        std::size_t available{ queue.Size() };
+        std::size_t available{ queue.QueuedCount() };
         std::size_t offset{ 0 };
     };
 
@@ -112,31 +112,32 @@ namespace infra
     template<class T>
     void QueueForOneReaderOneIrqWriter<T>::AddFromInterrupt(infra::MemoryRange<const T> data)
     {
-        really_assert(!Full());
+        really_assert(Capacity() - QueuedCount() >= data.size());
         AddFromInterruptUnchecked(data);
     }
 
     template<class T>
     void QueueForOneReaderOneIrqWriter<T>::AddFromInterruptUnchecked(infra::MemoryRange<const T> data)
     {
-        std::size_t copySize = std::min<std::size_t>(data.size(), buffer.end() - contentsEnd);
+        T* end = contentsEnd.load();
         T* begin = contentsBegin.load();
-        if (!(begin <= contentsEnd.load() || begin > contentsEnd.load() + copySize))
-            return;
+        std::size_t available = (begin <= end) ? (buffer.size() - 1 - (end - begin)) : (begin - end - 1);
+        really_assert(data.size() <= available);
+        
+        std::size_t copySize = std::min<std::size_t>(data.size(), buffer.end() - end);
+        std::copy(data.begin(), data.begin() + copySize, end);
 
-        std::copy(data.begin(), data.begin() + copySize, contentsEnd.load());
-
-        if (contentsEnd == buffer.end() - copySize)
-            contentsEnd = buffer.begin();
+        if (end == buffer.end() - copySize)
+            end = buffer.begin();
         else
-            contentsEnd += copySize;
+            end += copySize;
 
         data.pop_front(copySize);
 
-        assert(begin <= contentsEnd.load() || begin > contentsEnd.load() + data.size());
-        std::copy(data.begin(), data.end(), contentsEnd.load());
-        contentsEnd += data.size();
+        std::copy(data.begin(), data.end(), end);
+        end += data.size();
 
+        contentsEnd = end;
         NotifyDataAvailable();
     }
 
@@ -178,8 +179,8 @@ namespace infra
     template<class T>
     T QueueForOneReaderOneIrqWriter<T>::operator[](size_t position) const
     {
-        assert(Size() > 0);
-        assert(position < Size());
+        assert(QueuedCount() > 0);
+        assert(position < QueuedCount());
 
         T* begin = contentsBegin;
         if (begin + position >= buffer.end())
@@ -226,13 +227,13 @@ namespace infra
     }
 
     template<class T>
-    std::size_t QueueForOneReaderOneIrqWriter<T>::Size() const
+    std::size_t QueueForOneReaderOneIrqWriter<T>::QueuedCount() const
     {
         const T* begin = contentsBegin.load();
         const T* end = contentsEnd.load();
 
         if (Full(begin, end))
-            return EmptySize();
+            return Capacity();
         else if (end >= begin)
             return end - begin;
 
@@ -240,7 +241,7 @@ namespace infra
     }
 
     template<class T>
-    std::size_t QueueForOneReaderOneIrqWriter<T>::EmptySize() const
+    std::size_t QueueForOneReaderOneIrqWriter<T>::Capacity() const
     {
         return buffer.size() - 1;
     }

--- a/infra/event/QueueForOneReaderOneIrqWriter.hpp
+++ b/infra/event/QueueForOneReaderOneIrqWriter.hpp
@@ -36,7 +36,7 @@ namespace infra
         T Get();
         infra::MemoryRange<const T> ContiguousRange(uint32_t offset = 0) const;
         void Consume(uint32_t amount);
-        std::size_t QueuedCount() const;
+        std::size_t Size() const;
         std::size_t Capacity() const;
 
         T operator[](size_t position) const;
@@ -75,7 +75,7 @@ namespace infra
 
     private:
         QueueForOneReaderOneIrqWriter<T>& queue;
-        std::size_t available{ queue.QueuedCount() };
+        std::size_t available{ queue.Size() };
         std::size_t offset{ 0 };
     };
 
@@ -112,7 +112,7 @@ namespace infra
     template<class T>
     void QueueForOneReaderOneIrqWriter<T>::AddFromInterrupt(infra::MemoryRange<const T> data)
     {
-        really_assert(Capacity() - QueuedCount() >= data.size());
+        really_assert(Capacity() - Size() >= data.size());
         AddFromInterruptUnchecked(data);
     }
 
@@ -121,7 +121,7 @@ namespace infra
     {
         T* end = contentsEnd.load();
         T* begin = contentsBegin.load();
-        
+
         std::size_t available = (begin <= end) ? (buffer.size() - 1 - (end - begin)) : (begin - end - 1);
         if (data.size() > available)
             return;
@@ -181,8 +181,8 @@ namespace infra
     template<class T>
     T QueueForOneReaderOneIrqWriter<T>::operator[](size_t position) const
     {
-        assert(QueuedCount() > 0);
-        assert(position < QueuedCount());
+        assert(Size() > 0);
+        assert(position < Size());
 
         T* begin = contentsBegin;
         if (begin + position >= buffer.end())
@@ -229,7 +229,7 @@ namespace infra
     }
 
     template<class T>
-    std::size_t QueueForOneReaderOneIrqWriter<T>::QueuedCount() const
+    std::size_t QueueForOneReaderOneIrqWriter<T>::Size() const
     {
         const T* begin = contentsBegin.load();
         const T* end = contentsEnd.load();

--- a/infra/event/QueueForOneReaderOneIrqWriter.hpp
+++ b/infra/event/QueueForOneReaderOneIrqWriter.hpp
@@ -120,8 +120,10 @@ namespace infra
     void QueueForOneReaderOneIrqWriter<T>::AddFromInterruptUnchecked(infra::MemoryRange<const T> data)
     {
         T* end = contentsEnd.load();
-        T* begin = contentsBegin.load();
-        
+
+        if (data.size() > Capacity() - QueuedCount())
+            return;
+
         std::size_t copySize = std::min<std::size_t>(data.size(), buffer.end() - end);
         std::copy(data.begin(), data.begin() + copySize, end);
 

--- a/infra/event/QueueForOneReaderOneIrqWriter.hpp
+++ b/infra/event/QueueForOneReaderOneIrqWriter.hpp
@@ -121,8 +121,6 @@ namespace infra
     {
         T* end = contentsEnd.load();
         T* begin = contentsBegin.load();
-        std::size_t available = (begin <= end) ? (buffer.size() - 1 - (end - begin)) : (begin - end - 1);
-        really_assert(data.size() <= available);
         
         std::size_t copySize = std::min<std::size_t>(data.size(), buffer.end() - end);
         std::copy(data.begin(), data.begin() + copySize, end);

--- a/infra/event/QueueForOneReaderOneIrqWriter.hpp
+++ b/infra/event/QueueForOneReaderOneIrqWriter.hpp
@@ -120,8 +120,10 @@ namespace infra
     void QueueForOneReaderOneIrqWriter<T>::AddFromInterruptUnchecked(infra::MemoryRange<const T> data)
     {
         T* end = contentsEnd.load();
-
-        if (data.size() > Capacity() - QueuedCount())
+        T* begin = contentsBegin.load();
+        
+        std::size_t available = (begin <= end) ? (buffer.size() - 1 - (end - begin)) : (begin - end - 1);
+        if (data.size() > available)
             return;
 
         std::size_t copySize = std::min<std::size_t>(data.size(), buffer.end() - end);

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -167,7 +167,7 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, Size)
     EXPECT_EQ(4, queue->QueuedCount());
 }
 
-TEST_F(QueueForOneReaderOneIrqWriterTest, EmptySize)
+TEST_F(QueueForOneReaderOneIrqWriterTest, Capacity)
 {
     queue.emplace(buffer, [this]() {});
     EXPECT_EQ(sizeof(buffer) - 1, queue->Capacity());
@@ -200,6 +200,21 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_wrapping_around_buffer)
     EXPECT_EQ(4, queue->Get());
     EXPECT_EQ(5, queue->Get());
     EXPECT_EQ(6, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_does_not_write_out_bounds)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 2> setup = { { 0, 1 } };
+    queue->AddFromInterruptUnchecked(setup);
+
+    std::array<uint8_t, 4> overflow = { { 2, 3, 4, 5 } };
+    queue->AddFromInterruptUnchecked(overflow);
+
+    EXPECT_EQ(2, queue->QueuedCount());
+    EXPECT_EQ(0, queue->Get());
+    EXPECT_EQ(1, queue->Get());
 }
 
 TEST_F(QueueForOneReaderOneIrqWriterTest, StreamReader)

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -149,22 +149,22 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, Size)
 
     EXPECT_TRUE(queue->Empty());
     EXPECT_FALSE(queue->Full());
-    EXPECT_EQ(0, queue->QueuedCount());
+    EXPECT_EQ(0, queue->Size());
 
     queue->AddFromInterrupt(full);
     EXPECT_FALSE(queue->Empty());
     EXPECT_TRUE(queue->Full());
-    EXPECT_EQ(4, queue->QueuedCount());
+    EXPECT_EQ(4, queue->Size());
 
     queue->Consume(2);
-    EXPECT_EQ(2, queue->QueuedCount());
+    EXPECT_EQ(2, queue->Size());
     queue->AddFromInterrupt(data1);
-    EXPECT_EQ(3, queue->QueuedCount());
+    EXPECT_EQ(3, queue->Size());
 
     queue->Consume(1);
-    EXPECT_EQ(2, queue->QueuedCount());
+    EXPECT_EQ(2, queue->Size());
     queue->AddFromInterrupt(data2);
-    EXPECT_EQ(4, queue->QueuedCount());
+    EXPECT_EQ(4, queue->Size());
 }
 
 TEST_F(QueueForOneReaderOneIrqWriterTest, Capacity)
@@ -195,7 +195,7 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_wrapping_around_buffer)
     std::array<uint8_t, 4> wrapData = { { 3, 4, 5, 6 } };
     queue->AddFromInterrupt(wrapData);
 
-    EXPECT_EQ(4, queue->QueuedCount());
+    EXPECT_EQ(4, queue->Size());
     EXPECT_EQ(3, queue->Get());
     EXPECT_EQ(4, queue->Get());
     EXPECT_EQ(5, queue->Get());
@@ -212,7 +212,7 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_does_not_write_out
     std::array<uint8_t, 4> overflow = { { 2, 3, 4, 5 } };
     queue->AddFromInterruptUnchecked(overflow);
 
-    EXPECT_EQ(2, queue->QueuedCount());
+    EXPECT_EQ(2, queue->Size());
     EXPECT_EQ(0, queue->Get());
     EXPECT_EQ(1, queue->Get());
 }

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -170,7 +170,7 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, Size)
 TEST_F(QueueForOneReaderOneIrqWriterTest, Capacity)
 {
     queue.emplace(buffer, [this]() {});
-    EXPECT_EQ(sizeof(buffer) - 1, queue->Capacity());
+    EXPECT_EQ(buffer.size() - 1, queue->Capacity());
 }
 
 TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_asserts_when_insufficient_space)

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -202,17 +202,6 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_wrapping_around_buffer)
     EXPECT_EQ(6, queue->Get());
 }
 
-TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_asserts_when_overflow)
-{
-    queue.emplace(buffer, [this]() {});
-
-    std::array<uint8_t, 3> data = { { 0, 1, 2 } };
-    queue->AddFromInterruptUnchecked(data);
-
-    std::array<uint8_t, 3> moreData = { { 3, 4, 5 } };
-    EXPECT_DEATH(queue->AddFromInterruptUnchecked(moreData), "");
-}
-
 TEST_F(QueueForOneReaderOneIrqWriterTest, StreamReader)
 {
     queue.emplace(buffer, [this]() {});

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -149,28 +149,68 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, Size)
 
     EXPECT_TRUE(queue->Empty());
     EXPECT_FALSE(queue->Full());
-    EXPECT_EQ(0, queue->Size());
+    EXPECT_EQ(0, queue->QueuedCount());
 
     queue->AddFromInterrupt(full);
     EXPECT_FALSE(queue->Empty());
     EXPECT_TRUE(queue->Full());
-    EXPECT_EQ(4, queue->Size());
+    EXPECT_EQ(4, queue->QueuedCount());
 
     queue->Consume(2);
-    EXPECT_EQ(2, queue->Size());
+    EXPECT_EQ(2, queue->QueuedCount());
     queue->AddFromInterrupt(data1);
-    EXPECT_EQ(3, queue->Size());
+    EXPECT_EQ(3, queue->QueuedCount());
 
     queue->Consume(1);
-    EXPECT_EQ(2, queue->Size());
+    EXPECT_EQ(2, queue->QueuedCount());
     queue->AddFromInterrupt(data2);
-    EXPECT_EQ(4, queue->Size());
+    EXPECT_EQ(4, queue->QueuedCount());
 }
 
 TEST_F(QueueForOneReaderOneIrqWriterTest, EmptySize)
 {
     queue.emplace(buffer, [this]() {});
-    EXPECT_EQ(sizeof(buffer) - 1, queue->EmptySize());
+    EXPECT_EQ(sizeof(buffer) - 1, queue->Capacity());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_asserts_when_insufficient_space)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> data = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(data);
+
+    std::array<uint8_t, 3> moreData = { { 3, 4, 5 } };
+    EXPECT_DEATH(queue->AddFromInterrupt(moreData), "");
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_wrapping_around_buffer)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> data = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(data);
+    queue->Consume(3);
+
+    std::array<uint8_t, 4> wrapData = { { 3, 4, 5, 6 } };
+    queue->AddFromInterrupt(wrapData);
+
+    EXPECT_EQ(4, queue->QueuedCount());
+    EXPECT_EQ(3, queue->Get());
+    EXPECT_EQ(4, queue->Get());
+    EXPECT_EQ(5, queue->Get());
+    EXPECT_EQ(6, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_asserts_when_overflow)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> data = { { 0, 1, 2 } };
+    queue->AddFromInterruptUnchecked(data);
+
+    std::array<uint8_t, 3> moreData = { { 3, 4, 5 } };
+    EXPECT_DEATH(queue->AddFromInterruptUnchecked(moreData), "");
 }
 
 TEST_F(QueueForOneReaderOneIrqWriterTest, StreamReader)

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -202,7 +202,7 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_wrapping_around_buffer)
     EXPECT_EQ(6, queue->Get());
 }
 
-TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_does_not_write_out_bounds)
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_does_not_write_out_of_bounds)
 {
     queue.emplace(buffer, [this]() {});
 

--- a/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
+++ b/infra/event/test/TestQueueForOneReaderOneIrqWriter.cpp
@@ -217,6 +217,170 @@ TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_does_not_write_out
     EXPECT_EQ(1, queue->Get());
 }
 
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_single_element_asserts_when_full_linear)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 4> full = { { 0, 1, 2, 3 } };
+    queue->AddFromInterrupt(full);
+    EXPECT_TRUE(queue->Full());
+
+    EXPECT_DEATH(queue->AddFromInterrupt(static_cast<uint8_t>(4)), "");
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_single_element_asserts_when_full_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 4> full = { { 0, 1, 2, 3 } };
+    queue->AddFromInterrupt(full);
+    queue->Consume(2);
+    std::array<uint8_t, 2> more = { { 4, 5 } };
+    queue->AddFromInterrupt(more);
+    EXPECT_TRUE(queue->Full());
+
+    EXPECT_DEATH(queue->AddFromInterrupt(static_cast<uint8_t>(6)), "");
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_single_element_unchecked_when_full_linear)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 4> full = { { 0, 1, 2, 3 } };
+    queue->AddFromInterrupt(full);
+    EXPECT_TRUE(queue->Full());
+
+    queue->AddFromInterruptUnchecked(static_cast<uint8_t>(99));
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_single_element_unchecked_success_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> data = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(data);
+    queue->Consume(3);
+
+    queue->AddFromInterruptUnchecked(static_cast<uint8_t>(10));
+    EXPECT_EQ(1, queue->Size());
+    EXPECT_EQ(10, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_asserts_when_insufficient_space_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> setup = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(setup);
+    queue->Consume(3);
+    std::array<uint8_t, 2> partial = { { 3, 4 } };
+    queue->AddFromInterrupt(partial);
+
+    std::array<uint8_t, 3> tooMuch = { { 5, 6, 7 } };
+    EXPECT_DEATH(queue->AddFromInterrupt(tooMuch), "");
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_exact_fill_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> setup = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(setup);
+    queue->Consume(3);
+    std::array<uint8_t, 1> one = { { 10 } };
+    queue->AddFromInterrupt(one);
+
+    std::array<uint8_t, 3> fill = { { 20, 21, 22 } };
+    queue->AddFromInterrupt(fill);
+
+    EXPECT_TRUE(queue->Full());
+    EXPECT_EQ(4, queue->Size());
+    EXPECT_EQ(10, queue->Get());
+    EXPECT_EQ(20, queue->Get());
+    EXPECT_EQ(21, queue->Get());
+    EXPECT_EQ(22, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_overflow_dropped_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> setup = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(setup);
+    queue->Consume(3);
+    std::array<uint8_t, 2> partial = { { 3, 4 } };
+    queue->AddFromInterrupt(partial);
+
+    std::array<uint8_t, 3> overflow = { { 5, 6, 7 } };
+    queue->AddFromInterruptUnchecked(overflow);
+    EXPECT_EQ(2, queue->Size());
+    EXPECT_EQ(3, queue->Get());
+    EXPECT_EQ(4, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_success_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> setup = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(setup);
+    queue->Consume(3);
+    std::array<uint8_t, 2> partial = { { 3, 4 } };
+    queue->AddFromInterruptUnchecked(partial);
+
+    EXPECT_EQ(2, queue->Size());
+    EXPECT_EQ(3, queue->Get());
+    EXPECT_EQ(4, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_exact_fill_linear)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 4> full = { { 10, 20, 30, 40 } };
+    queue->AddFromInterruptUnchecked(full);
+
+    EXPECT_TRUE(queue->Full());
+    EXPECT_EQ(4, queue->Size());
+    EXPECT_EQ(10, queue->Get());
+    EXPECT_EQ(20, queue->Get());
+    EXPECT_EQ(30, queue->Get());
+    EXPECT_EQ(40, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_exact_fill_wrapped)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 3> setup = { { 0, 1, 2 } };
+    queue->AddFromInterrupt(setup);
+    queue->Consume(3);
+
+    std::array<uint8_t, 4> full = { { 10, 20, 30, 40 } };
+    queue->AddFromInterruptUnchecked(full);
+
+    EXPECT_TRUE(queue->Full());
+    EXPECT_EQ(4, queue->Size());
+    EXPECT_EQ(10, queue->Get());
+    EXPECT_EQ(20, queue->Get());
+    EXPECT_EQ(30, queue->Get());
+    EXPECT_EQ(40, queue->Get());
+}
+
+TEST_F(QueueForOneReaderOneIrqWriterTest, add_range_unchecked_overflow_dropped_would_wrap)
+{
+    queue.emplace(buffer, [this]() {});
+
+    std::array<uint8_t, 2> setup = { { 0, 1 } };
+    queue->AddFromInterrupt(setup);
+    std::array<uint8_t, 3> overflow = { { 5, 6, 7 } };
+    queue->AddFromInterruptUnchecked(overflow);
+
+    EXPECT_EQ(2, queue->Size());
+    EXPECT_EQ(0, queue->Get());
+    EXPECT_EQ(1, queue->Get());
+}
+
 TEST_F(QueueForOneReaderOneIrqWriterTest, StreamReader)
 {
     queue.emplace(buffer, [this]() {});

--- a/services/network/SerialServer.hpp
+++ b/services/network/SerialServer.hpp
@@ -34,7 +34,7 @@ namespace services
     {
     public:
         template<size_t BufferSize>
-        using WithBuffer = infra::WithStorage<SerialServer, std::array<uint8_t, BufferSize>>;
+        using WithBuffer = infra::WithStorage<SerialServer, std::array<uint8_t, BufferSize + 1>>;
 
         SerialServer(const infra::ByteRange receiveBuffer, hal::SerialCommunication& serialCommunication, services::ConnectionFactory& connectionFactory, uint16_t port);
 

--- a/services/util/Terminal.hpp
+++ b/services/util/Terminal.hpp
@@ -17,7 +17,7 @@ namespace services
     public:
         constexpr static std::size_t MaxBuffer = MaxCommandLength;
 
-        template<std::size_t MaxQueueSize = 32, std::size_t MaxHistory = 4>
+        template<std::size_t MaxQueueSize = 128, std::size_t MaxHistory = 4>
         using WithMaxQueueAndMaxHistory = infra::WithStorage<infra::WithStorage<TerminalBase, std::array<uint8_t, MaxQueueSize + 1>>, typename infra::BoundedDeque<infra::BoundedString::WithStorage<MaxBuffer>>::template WithMaxSize<MaxHistory>>;
 
         explicit TerminalBase(infra::MemoryRange<uint8_t> bufferQueue, infra::BoundedDeque<infra::BoundedString::WithStorage<MaxBuffer>>& history, hal::SerialCommunication& communication, services::Tracer& tracer);
@@ -115,7 +115,7 @@ namespace services
         , public TerminalBase<MaxCommandLength>
     {
     public:
-        template<std::size_t MaxQueueSize = 32, std::size_t MaxHistory = 4>
+        template<std::size_t MaxQueueSize = 128, std::size_t MaxHistory = 4>
         using WithMaxQueueAndMaxHistory = infra::WithStorage<infra::WithStorage<TerminalWithCommandsImplBase, std::array<uint8_t, MaxQueueSize + 1>>, typename infra::BoundedDeque<infra::BoundedString::WithStorage<TerminalBase<MaxCommandLength>::MaxBuffer>>::template WithMaxSize<MaxHistory>>;
 
         TerminalWithCommandsImplBase(infra::MemoryRange<uint8_t> bufferQueue, infra::BoundedDeque<infra::BoundedString::WithStorage<TerminalBase<MaxCommandLength>::MaxBuffer>>& history, hal::SerialCommunication& communication, services::Tracer& tracer);


### PR DESCRIPTION
Fixes and enhancements to the queue implementation. 
- Renamed methods to better reflect the intent
- Removed multiple non-atomic loads from AddFromInterruptUnchecked
- Improved boundaries check. If the queue does not have enough space available to hold the data passed, a `really_assert ` check fails. 
- Removed unnecessary `assert` check