### PR TITLE
feat: add MacResolver interface and lwIP implementation

### DIFF
--- a/lwip/lwip_cpp/CMakeLists.txt
+++ b/lwip/lwip_cpp/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(lwip.lwip_cpp PRIVATE
     LightweightIp.hpp
     LightweightIpOverEthernet.cpp
     LightweightIpOverEthernet.hpp
+    MacResolverLwIp.cpp
+    MacResolverLwIp.hpp
     MulticastLwIp.cpp
     MulticastLwIp.hpp
 )

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -26,6 +26,8 @@ namespace services
         // lwIP has no public API to trigger a standalone ND6 solicitation.
         // We therefore create a zero-length PBUF_REF probe and call
         // nd6_get_next_hop_addr_or_queue(), which drives neighbor discovery.
+        // lwIP determines whether this is a direct on-link neighbor or a
+        // routed next-hop lookup.
         // If queued, lwIP clones this volatile probe, so the caller still
         // releases the original pbuf after the lookup call returns.
         std::optional<hal::MacAddress> Nd6Lookup(const ip6_addr_t& target)
@@ -50,6 +52,8 @@ namespace services
         }
     }
 
+    // ARP is link-local. This resolver requests the MAC for the provided
+    // IPv4 address as-is and does not perform IPv4 route/next-hop lookup.
     void ArpMacResolverLwIp::SendRequest(IPv4Address address)
     {
         ip4_addr_t target;

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -23,6 +23,10 @@ namespace services
             return target;
         }
 
+        // lwIP has no public API to trigger a standalone ND6 solicitation.
+        // We therefore create a probe pbuf and call
+        // nd6_get_next_hop_addr_or_queue(), which queues this probe and
+        // drives neighbor discovery until the cache can be resolved.
         std::optional<hal::MacAddress> Nd6Lookup(const ip6_addr_t& target)
         {
             const u8_t* hwaddrp = nullptr;

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -19,7 +19,7 @@ namespace services
                 PP_HTONL(address[3] | (static_cast<uint32_t>(address[2]) << 16)),
                 PP_HTONL(address[5] | (static_cast<uint32_t>(address[4]) << 16)),
                 PP_HTONL(address[7] | (static_cast<uint32_t>(address[6]) << 16)));
-            ip6_addr_assign_zone(&target, IP6_UNICAST, netif_default);
+            ip6_addr_set_zone(&target, netif_default->ip6_addr->u_addr.ip6.zone);
             return target;
         }
 

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -24,9 +24,10 @@ namespace services
         }
 
         // lwIP has no public API to trigger a standalone ND6 solicitation.
-        // We therefore create a probe pbuf and call
-        // nd6_get_next_hop_addr_or_queue(), which queues this probe and
-        // drives neighbor discovery until the cache can be resolved.
+        // We therefore create a zero-length PBUF_REF probe and call
+        // nd6_get_next_hop_addr_or_queue(), which drives neighbor discovery.
+        // If queued, lwIP clones this volatile probe, so the caller still
+        // releases the original pbuf after the lookup call returns.
         std::optional<hal::MacAddress> Nd6Lookup(const ip6_addr_t& target)
         {
             const u8_t* hwaddrp = nullptr;
@@ -72,13 +73,18 @@ namespace services
         return std::nullopt;
     }
 
-    void ArpMacResolverLwIp::Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
+    bool ArpMacResolverLwIp::Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
     {
+        if (retryTimer_.Armed())
+        {
+            return false;
+        }
+
         auto mac = Lookup(address);
         if (mac)
         {
             onDone(mac);
-            return;
+            return true;
         }
 
         pendingAddress_ = address;
@@ -91,6 +97,8 @@ namespace services
             {
                 OnRetry();
             });
+
+        return true;
     }
 
     void ArpMacResolverLwIp::OnRetry()
@@ -115,14 +123,19 @@ namespace services
         }
     }
 
-    void Nd6MacResolverLwIp::Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
+    bool Nd6MacResolverLwIp::Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
     {
+        if (retryTimer_.Armed())
+        {
+            return false;
+        }
+
         auto target = ToLwipIp6(address);
         auto mac = Nd6Lookup(target);
         if (mac)
         {
             onDone(mac);
-            return;
+            return true;
         }
 
         pendingAddress_ = address;
@@ -133,6 +146,8 @@ namespace services
             {
                 OnRetry();
             });
+
+        return true;
     }
 
     void Nd6MacResolverLwIp::OnRetry()

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -99,13 +99,14 @@ namespace services
             return;
         }
 
-        if (--retriesLeft_ == 0)
+        if (retriesLeft_ == 0)
         {
             retryTimer_.Cancel();
             onDone_(std::nullopt);
         }
         else
         {
+            --retriesLeft_;
             SendRequest(pendingAddress_);
         }
     }
@@ -141,10 +142,14 @@ namespace services
             return;
         }
 
-        if (--retriesLeft_ == 0)
+        if (retriesLeft_ == 0)
         {
             retryTimer_.Cancel();
             onDone_(std::nullopt);
+        }
+        else
+        {
+            --retriesLeft_;
         }
     }
 }

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -1,0 +1,150 @@
+#include "lwip/lwip_cpp/MacResolverLwIp.hpp"
+#include "lwip/ip4_addr.h"
+#include "lwip/ip6_addr.h"
+#include "lwip/nd6.h"
+#include "lwip/netif.h"
+#include "lwip/pbuf.h"
+#include "netif/etharp.h"
+#include <algorithm>
+
+namespace services
+{
+    namespace
+    {
+        ip6_addr_t ToLwipIp6(const services::IPv6Address& address)
+        {
+            ip6_addr_t target;
+            IP6_ADDR(&target,
+                PP_HTONL(address[1] | (static_cast<uint32_t>(address[0]) << 16)),
+                PP_HTONL(address[3] | (static_cast<uint32_t>(address[2]) << 16)),
+                PP_HTONL(address[5] | (static_cast<uint32_t>(address[4]) << 16)),
+                PP_HTONL(address[7] | (static_cast<uint32_t>(address[6]) << 16)));
+            ip6_addr_assign_zone(&target, IP6_UNICAST, netif_default);
+            return target;
+        }
+
+        std::optional<hal::MacAddress> Nd6Lookup(const ip6_addr_t& target)
+        {
+            const u8_t* hwaddrp = nullptr;
+            auto* probe = pbuf_alloc_reference(nullptr, 0, PBUF_REF);
+            if (probe == nullptr)
+            {
+                return std::nullopt;
+            }
+
+            auto result = nd6_get_next_hop_addr_or_queue(netif_default, probe, &target, &hwaddrp);
+            pbuf_free(probe);
+
+            if (result >= 0 && hwaddrp != nullptr)
+            {
+                hal::MacAddress mac;
+                std::copy(hwaddrp, hwaddrp + mac.size(), mac.begin());
+                return mac;
+            }
+            return std::nullopt;
+        }
+    }
+
+    void ArpMacResolverLwIp::SendRequest(IPv4Address address)
+    {
+        ip4_addr_t target;
+        IP4_ADDR(&target, address[0], address[1], address[2], address[3]);
+        etharp_request(netif_default, &target);
+    }
+
+    std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(IPv4Address address)
+    {
+        ip4_addr_t target;
+        IP4_ADDR(&target, address[0], address[1], address[2], address[3]);
+
+        struct eth_addr* ethaddr = nullptr;
+        const ip4_addr_t* ipaddr = nullptr;
+        if (etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
+        {
+            hal::MacAddress mac;
+            std::copy(ethaddr->addr, ethaddr->addr + mac.size(), mac.begin());
+            return mac;
+        }
+        return std::nullopt;
+    }
+
+    void ArpMacResolverLwIp::Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
+    {
+        auto mac = Lookup(address);
+        if (mac)
+        {
+            onDone(mac);
+            return;
+        }
+
+        pendingAddress_ = address;
+        onDone_ = onDone;
+        retriesLeft_ = retries;
+
+        SendRequest(address);
+
+        retryTimer_.Start(retryInterval, [this]
+            {
+                OnRetry();
+            });
+    }
+
+    void ArpMacResolverLwIp::OnRetry()
+    {
+        auto mac = Lookup(pendingAddress_);
+        if (mac)
+        {
+            retryTimer_.Cancel();
+            onDone_(mac);
+            return;
+        }
+
+        if (--retriesLeft_ == 0)
+        {
+            retryTimer_.Cancel();
+            onDone_(std::nullopt);
+        }
+        else
+        {
+            SendRequest(pendingAddress_);
+        }
+    }
+
+    void Nd6MacResolverLwIp::Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
+    {
+        auto target = ToLwipIp6(address);
+        auto mac = Nd6Lookup(target);
+        if (mac)
+        {
+            onDone(mac);
+            return;
+        }
+
+        pendingAddress_ = address;
+        onDone_ = onDone;
+        retriesLeft_ = retries;
+
+        retryTimer_.Start(retryInterval, [this]
+            {
+                OnRetry();
+            });
+    }
+
+    void Nd6MacResolverLwIp::OnRetry()
+    {
+        auto mac = Nd6Lookup(ToLwipIp6(pendingAddress_));
+
+        if (mac)
+        {
+            retryTimer_.Cancel();
+            onDone_(mac);
+            return;
+        }
+
+        if (--retriesLeft_ == 0)
+        {
+            retryTimer_.Cancel();
+            onDone_(std::nullopt);
+        }
+    }
+}

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -1,5 +1,4 @@
 #include "lwip/lwip_cpp/MacResolverLwIp.hpp"
-#include "infra/util/ReallyAssert.hpp"
 #include "lwip/ip4_addr.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/nd6.h"
@@ -27,19 +26,20 @@ namespace services
 
     MacResolverRetryHelper::MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest)
         : retries(retries)
-        , retryInterval(retryInterval)
         , lookup(lookup)
         , sendRequest(sendRequest)
+        , retryTimer(retryInterval)
     {}
 
-    void MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    bool MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        really_assert(!onDone);
+        if (onDone)
+            return false;
 
         if (auto mac = lookup(address); mac)
         {
             onResolveDone(mac);
-            return;
+            return true;
         }
 
         pendingAddress = address;
@@ -47,30 +47,33 @@ namespace services
         retriesLeft = retries;
 
         sendRequest(address);
-        retryTimer.Start(retryInterval, [this]
+        retryTimer.Start(infra::FailureType::intermittentFailure, [this]
             {
                 OnRetry();
             });
+        return true;
     }
 
     void MacResolverRetryHelper::OnRetry()
     {
         if (auto mac = lookup(pendingAddress); mac)
         {
-            retryTimer.Cancel();
             onDone(mac);
             return;
         }
 
         if (retriesLeft == 0)
         {
-            retryTimer.Cancel();
             onDone(std::nullopt);
         }
         else
         {
             --retriesLeft;
             sendRequest(pendingAddress);
+            retryTimer.Start(infra::FailureType::intermittentFailure, [this]
+                {
+                    OnRetry();
+                });
         }
     }
 
@@ -85,9 +88,14 @@ namespace services
               })
     {}
 
-    void ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    bool ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        helper.Resolve(address, onResolveDone);
+        if (std::get_if<IPv4Address>(&address) == nullptr)
+        {
+            onResolveDone(std::nullopt);
+            return true;
+        }
+        return helper.Resolve(address, onResolveDone);
     }
 
     std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(const IPAddress& address) const
@@ -129,9 +137,14 @@ namespace services
               })
     {}
 
-    void Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    bool Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        helper.Resolve(address, onResolveDone);
+        if (std::get_if<IPv6Address>(&address) == nullptr)
+        {
+            onResolveDone(std::nullopt);
+            return true;
+        }
+        return helper.Resolve(address, onResolveDone);
     }
 
     std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const IPAddress& address) const

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -1,4 +1,5 @@
 #include "lwip/lwip_cpp/MacResolverLwIp.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include "lwip/ip4_addr.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/nd6.h"
@@ -22,53 +23,73 @@ namespace services
             ip6_addr_set_zone(&target, netif_default->ip6_addr->u_addr.ip6.zone);
             return target;
         }
+    }
 
-        // lwIP has no public API to trigger a standalone ND6 solicitation.
-        // We therefore create a zero-length PBUF_REF probe and call
-        // nd6_get_next_hop_addr_or_queue(), which drives neighbor discovery.
-        // lwIP determines whether this is a direct on-link neighbor or a
-        // routed next-hop lookup.
-        // If queued, lwIP clones this volatile probe, so the caller still
-        // releases the original pbuf after the lookup call returns.
-        std::optional<hal::MacAddress> Nd6Lookup(const ip6_addr_t& target)
+    MacResolverRetryHelper::MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest)
+        : retries(retries)
+        , retryInterval(retryInterval)
+        , lookup(lookup)
+        , sendRequest(sendRequest)
+    {}
+
+    void MacResolverRetryHelper::Resolve(const MacResolver::Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    {
+        really_assert(!onDone);
+
+        if (auto mac = lookup(address); mac)
         {
-            const u8_t* hwaddrp = nullptr;
-            auto* probe = pbuf_alloc_reference(nullptr, 0, PBUF_REF);
-            if (probe == nullptr)
-            {
-                return std::nullopt;
-            }
+            onResolveDone(mac);
+            return;
+        }
 
-            auto result = nd6_get_next_hop_addr_or_queue(netif_default, probe, &target, &hwaddrp);
-            pbuf_free(probe);
+        pendingAddress = address;
+        onDone = onResolveDone;
+        retriesLeft = retries;
 
-            if (result >= 0 && hwaddrp != nullptr)
-            {
-                hal::MacAddress mac;
-                std::copy(hwaddrp, hwaddrp + mac.size(), mac.begin());
-                return mac;
-            }
-            return std::nullopt;
+        sendRequest(address);
+        retryTimer.Start(retryInterval, [this] { OnRetry(); });
+    }
+
+    void MacResolverRetryHelper::OnRetry()
+    {
+        if (auto mac = lookup(pendingAddress); mac)
+        {
+            retryTimer.Cancel();
+            onDone(mac);
+            return;
+        }
+
+        if (retriesLeft == 0)
+        {
+            retryTimer.Cancel();
+            onDone(std::nullopt);
+        }
+        else
+        {
+            --retriesLeft;
+            sendRequest(pendingAddress);
         }
     }
 
-    // ARP is link-local. This resolver requests the MAC for the provided
-    // IPv4 address as-is and does not perform IPv4 route/next-hop lookup.
-    void ArpMacResolverLwIp::SendRequest(IPv4Address address)
+    ArpMacResolverLwIp::ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
+        : helper(retries, retryInterval,
+            [this](const Address& address) { return Lookup(address); },
+            [this](const Address& address) { SendRequest(address); })
+    {}
+
+    void ArpMacResolverLwIp::Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        ip4_addr_t target;
-        IP4_ADDR(&target, address[0], address[1], address[2], address[3]);
-        etharp_request(netif_default, &target);
+        helper.Resolve(address, onResolveDone);
     }
 
-    std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(IPv4Address address)
+    std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(const Address& address) const
     {
         ip4_addr_t target;
-        IP4_ADDR(&target, address[0], address[1], address[2], address[3]);
+        auto& ipv4 = std::get<IPv4Address>(address);
+        IP4_ADDR(&target, ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
 
         struct eth_addr* ethaddr = nullptr;
-        const ip4_addr_t* ipaddr = nullptr;
-        if (etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
+        if (const ip4_addr_t* ipaddr = nullptr; etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
         {
             hal::MacAddress mac;
             std::copy(ethaddr->addr, ethaddr->addr + mac.size(), mac.begin());
@@ -77,102 +98,67 @@ namespace services
         return std::nullopt;
     }
 
-    bool ArpMacResolverLwIp::Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
+    void ArpMacResolverLwIp::SendRequest(const Address& address) const
     {
-        if (retryTimer_.Armed())
+        ip4_addr_t target;
+        auto& ipv4 = std::get<IPv4Address>(address);
+        IP4_ADDR(&target, ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
+        etharp_request(netif_default, &target);
+    }
+
+    Nd6MacResolverLwIp::Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
+        : helper(retries, retryInterval,
+            [this](const Address& address) { return Lookup(address); },
+            [this](const Address& address) { SendRequest(address); })
+    {}
+
+    void Nd6MacResolverLwIp::Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    {
+        helper.Resolve(address, onResolveDone);
+    }
+
+    std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const Address& address) const
+    {
+        auto& ipv6 = std::get<IPv6Address>(address);
+        auto target = ToLwipIp6(ipv6);
+
+        // Check if target is on-link by matching against netif prefixes
+        bool onLink = false;
+        for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; ++i)
         {
-            return false;
-        }
-
-        auto mac = Lookup(address);
-        if (mac)
-        {
-            onDone(mac);
-            return true;
-        }
-
-        pendingAddress_ = address;
-        onDone_ = onDone;
-        retriesLeft_ = retries;
-
-        SendRequest(address);
-
-        retryTimer_.Start(retryInterval, [this]
+            if (ip6_addr_isvalid(netif_ip6_addr_state(netif_default, i)))
             {
-                OnRetry();
-            });
+                auto* netifAddr = netif_ip6_addr(netif_default, i);
+                if (ip6_addr_netcmp(&target, netifAddr))
+                {
+                    onLink = true;
+                    break;
+                }
+            }
+        }
 
-        return true;
+        if (!onLink)
+            return std::nullopt;
+
+        const u8_t* hwaddrp = nullptr;
+        auto* probe = pbuf_alloc_reference(nullptr, 0, PBUF_REF);
+        if (probe == nullptr)
+            return std::nullopt;
+
+        auto result = nd6_get_next_hop_addr_or_queue(netif_default, probe, &target, &hwaddrp);
+        pbuf_free(probe);
+
+        if (result == ERR_OK && hwaddrp != nullptr)
+        {
+            hal::MacAddress mac;
+            std::copy(hwaddrp, hwaddrp + mac.size(), mac.begin());
+            return mac;
+        }
+        return std::nullopt;
     }
 
-    void ArpMacResolverLwIp::OnRetry()
+    void Nd6MacResolverLwIp::SendRequest(const Address& /* address */) const
     {
-        auto mac = Lookup(pendingAddress_);
-        if (mac)
-        {
-            retryTimer_.Cancel();
-            onDone_(mac);
-            return;
-        }
-
-        if (retriesLeft_ == 0)
-        {
-            retryTimer_.Cancel();
-            onDone_(std::nullopt);
-        }
-        else
-        {
-            --retriesLeft_;
-            SendRequest(pendingAddress_);
-        }
-    }
-
-    bool Nd6MacResolverLwIp::Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone)
-    {
-        if (retryTimer_.Armed())
-        {
-            return false;
-        }
-
-        auto target = ToLwipIp6(address);
-        auto mac = Nd6Lookup(target);
-        if (mac)
-        {
-            onDone(mac);
-            return true;
-        }
-
-        pendingAddress_ = address;
-        onDone_ = onDone;
-        retriesLeft_ = retries;
-
-        retryTimer_.Start(retryInterval, [this]
-            {
-                OnRetry();
-            });
-
-        return true;
-    }
-
-    void Nd6MacResolverLwIp::OnRetry()
-    {
-        auto mac = Nd6Lookup(ToLwipIp6(pendingAddress_));
-
-        if (mac)
-        {
-            retryTimer_.Cancel();
-            onDone_(mac);
-            return;
-        }
-
-        if (retriesLeft_ == 0)
-        {
-            retryTimer_.Cancel();
-            onDone_(std::nullopt);
-        }
-        else
-        {
-            --retriesLeft_;
-        }
+        // ND6 solicitation is triggered implicitly via Lookup (nd6_get_next_hop_addr_or_queue)
     }
 }

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -32,14 +32,14 @@ namespace services
         , retryTimer(retryInterval)
     {}
 
-    bool MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         really_assert(!onDone);
 
         if (auto mac = lookup(address); mac)
         {
             onResolveDone(mac);
-            return true;
+            return;
         }
 
         pendingAddress = address;
@@ -51,7 +51,6 @@ namespace services
             {
                 OnRetry();
             });
-        return true;
     }
 
     void MacResolverRetryHelper::OnRetry()
@@ -90,15 +89,15 @@ namespace services
               })
     {}
 
-    bool ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         const auto* ipv4 = std::get_if<IPv4Address>(&address);
         if (ipv4 == nullptr || !IsOnSubnet(*ipv4))
         {
             onResolveDone(std::nullopt);
-            return true;
+            return;
         }
-        return helper.Resolve(address, onResolveDone);
+        helper.Resolve(address, onResolveDone);
     }
 
     bool ArpMacResolverLwIp::IsOnSubnet(const IPv4Address& address) const
@@ -148,15 +147,15 @@ namespace services
               })
     {}
 
-    bool Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         const auto* ipv6 = std::get_if<IPv6Address>(&address);
         if (ipv6 == nullptr || !IsOnLink(*ipv6))
         {
             onResolveDone(std::nullopt);
-            return true;
+            return;
         }
-        return helper.Resolve(address, onResolveDone);
+        helper.Resolve(address, onResolveDone);
     }
 
     bool Nd6MacResolverLwIp::IsOnLink(const IPv6Address& address) const

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -15,10 +15,10 @@ namespace services
         {
             ip6_addr_t target;
             IP6_ADDR(&target,
-                PP_HTONL(address[1] | (static_cast<uint32_t>(address[0]) << 16)),
-                PP_HTONL(address[3] | (static_cast<uint32_t>(address[2]) << 16)),
-                PP_HTONL(address[5] | (static_cast<uint32_t>(address[4]) << 16)),
-                PP_HTONL(address[7] | (static_cast<uint32_t>(address[6]) << 16)));
+                PP_HTONL(address[1] + (static_cast<uint32_t>(address[0]) << 16)),
+                PP_HTONL(address[3] + (static_cast<uint32_t>(address[2]) << 16)),
+                PP_HTONL(address[5] + (static_cast<uint32_t>(address[4]) << 16)),
+                PP_HTONL(address[7] + (static_cast<uint32_t>(address[6]) << 16)));
             ip6_addr_set_zone(&target, netif_default->ip6_addr->u_addr.ip6.zone);
             return target;
         }
@@ -115,6 +115,9 @@ namespace services
         ip4_addr_t target;
         IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
 
+        if (!ip4_addr_netcmp(&target, netif_ip4_addr(netif_default), netif_ip4_netmask(netif_default)))
+            return std::nullopt;
+
         struct eth_addr* ethaddr = nullptr;
         if (const ip4_addr_t* ipaddr = nullptr; etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
         {
@@ -132,6 +135,8 @@ namespace services
             return;
         ip4_addr_t target;
         IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
+        if (!ip4_addr_netcmp(&target, netif_ip4_addr(netif_default), netif_ip4_netmask(netif_default)))
+            return;
         etharp_request(netif_default, &target);
     }
 

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -58,12 +58,14 @@ namespace services
     {
         if (auto mac = lookup(pendingAddress); mac)
         {
+            retryTimer.Stop();
             onDone(mac);
             return;
         }
 
         if (retriesLeft == 0)
         {
+            retryTimer.Stop();
             onDone(std::nullopt);
         }
         else
@@ -75,6 +77,11 @@ namespace services
                     OnRetry();
                 });
         }
+    }
+
+    bool MacResolverRetryHelper::Busy() const
+    {
+        return static_cast<bool>(onDone);
     }
 
     ArpMacResolverLwIp::ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
@@ -90,6 +97,8 @@ namespace services
 
     bool ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
+        if (helper.Busy())
+            return false;
         if (std::get_if<IPv4Address>(&address) == nullptr)
         {
             onResolveDone(std::nullopt);
@@ -139,6 +148,8 @@ namespace services
 
     bool Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
+        if (helper.Busy())
+            return false;
         if (std::get_if<IPv6Address>(&address) == nullptr)
         {
             onResolveDone(std::nullopt);
@@ -177,6 +188,9 @@ namespace services
         if (probe == nullptr)
             return std::nullopt;
 
+        // nd6_get_next_hop_addr_or_queue() enqueues its own copy of the packet if neighbour
+        // discovery needs to be triggered; it does not retain the caller's pbuf. probe can
+        // therefore be freed unconditionally after this call.
         auto result = nd6_get_next_hop_addr_or_queue(netif_default, probe, &target, &hwaddrp);
         pbuf_free(probe);
 

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -1,4 +1,5 @@
 #include "lwip/lwip_cpp/MacResolverLwIp.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include "lwip/ip4_addr.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/nd6.h"
@@ -33,8 +34,7 @@ namespace services
 
     bool MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        if (onDone)
-            return false;
+        really_assert(!onDone);
 
         if (auto mac = lookup(address); mac)
         {
@@ -79,11 +79,6 @@ namespace services
         }
     }
 
-    bool MacResolverRetryHelper::Busy() const
-    {
-        return static_cast<bool>(onDone);
-    }
-
     ArpMacResolverLwIp::ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
         : helper(retries, retryInterval, [this](const IPAddress& address)
               {
@@ -97,9 +92,8 @@ namespace services
 
     bool ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        if (helper.Busy())
-            return false;
-        if (std::get_if<IPv4Address>(&address) == nullptr)
+        const auto* ipv4 = std::get_if<IPv4Address>(&address);
+        if (ipv4 == nullptr || !IsOnSubnet(*ipv4))
         {
             onResolveDone(std::nullopt);
             return true;
@@ -107,16 +101,21 @@ namespace services
         return helper.Resolve(address, onResolveDone);
     }
 
+    bool ArpMacResolverLwIp::IsOnSubnet(const IPv4Address& address) const
+    {
+        ip4_addr_t target;
+        IP4_ADDR(&target, address[0], address[1], address[2], address[3]);
+        return ip4_addr_netcmp(&target, netif_ip4_addr(netif_default), netif_ip4_netmask(netif_default));
+    }
+
     std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(const IPAddress& address) const
     {
         const auto* ipv4 = std::get_if<IPv4Address>(&address);
-        if (ipv4 == nullptr)
+        if (ipv4 == nullptr || !IsOnSubnet(*ipv4))
             return std::nullopt;
+
         ip4_addr_t target;
         IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
-
-        if (!ip4_addr_netcmp(&target, netif_ip4_addr(netif_default), netif_ip4_netmask(netif_default)))
-            return std::nullopt;
 
         struct eth_addr* ethaddr = nullptr;
         if (const ip4_addr_t* ipaddr = nullptr; etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
@@ -131,12 +130,10 @@ namespace services
     void ArpMacResolverLwIp::SendRequest(const IPAddress& address) const
     {
         const auto* ipv4 = std::get_if<IPv4Address>(&address);
-        if (ipv4 == nullptr)
+        if (ipv4 == nullptr || !IsOnSubnet(*ipv4))
             return;
         ip4_addr_t target;
         IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
-        if (!ip4_addr_netcmp(&target, netif_ip4_addr(netif_default), netif_ip4_netmask(netif_default)))
-            return;
         etharp_request(netif_default, &target);
     }
 
@@ -153,9 +150,8 @@ namespace services
 
     bool Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
-        if (helper.Busy())
-            return false;
-        if (std::get_if<IPv6Address>(&address) == nullptr)
+        const auto* ipv6 = std::get_if<IPv6Address>(&address);
+        if (ipv6 == nullptr || !IsOnLink(*ipv6))
         {
             onResolveDone(std::nullopt);
             return true;
@@ -163,30 +159,27 @@ namespace services
         return helper.Resolve(address, onResolveDone);
     }
 
-    std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const IPAddress& address) const
+    bool Nd6MacResolverLwIp::IsOnLink(const IPv6Address& address) const
     {
-        const auto* ipv6 = std::get_if<IPv6Address>(&address);
-        if (ipv6 == nullptr)
-            return std::nullopt;
-        auto target = ToLwipIp6(*ipv6);
-
-        // Check if target is on-link by matching against netif prefixes
-        bool onLink = false;
+        auto target = ToLwipIp6(address);
         for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; ++i)
         {
             if (ip6_addr_isvalid(netif_ip6_addr_state(netif_default, i)))
             {
                 auto* netifAddr = netif_ip6_addr(netif_default, i);
                 if (ip6_addr_netcmp(&target, netifAddr))
-                {
-                    onLink = true;
-                    break;
-                }
+                    return true;
             }
         }
+        return false;
+    }
 
-        if (!onLink)
+    std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const IPAddress& address) const
+    {
+        const auto* ipv6 = std::get_if<IPv6Address>(&address);
+        if (ipv6 == nullptr || !IsOnLink(*ipv6))
             return std::nullopt;
+        auto target = ToLwipIp6(*ipv6);
 
         const u8_t* hwaddrp = nullptr;
         auto* probe = pbuf_alloc_reference(nullptr, 0, PBUF_REF);

--- a/lwip/lwip_cpp/MacResolverLwIp.cpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.cpp
@@ -32,7 +32,7 @@ namespace services
         , sendRequest(sendRequest)
     {}
 
-    void MacResolverRetryHelper::Resolve(const MacResolver::Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void MacResolverRetryHelper::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         really_assert(!onDone);
 
@@ -47,7 +47,10 @@ namespace services
         retriesLeft = retries;
 
         sendRequest(address);
-        retryTimer.Start(retryInterval, [this] { OnRetry(); });
+        retryTimer.Start(retryInterval, [this]
+            {
+                OnRetry();
+            });
     }
 
     void MacResolverRetryHelper::OnRetry()
@@ -72,21 +75,28 @@ namespace services
     }
 
     ArpMacResolverLwIp::ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
-        : helper(retries, retryInterval,
-            [this](const Address& address) { return Lookup(address); },
-            [this](const Address& address) { SendRequest(address); })
+        : helper(retries, retryInterval, [this](const IPAddress& address)
+              {
+                  return Lookup(address);
+              },
+              [this](const IPAddress& address)
+              {
+                  SendRequest(address);
+              })
     {}
 
-    void ArpMacResolverLwIp::Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void ArpMacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         helper.Resolve(address, onResolveDone);
     }
 
-    std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(const Address& address) const
+    std::optional<hal::MacAddress> ArpMacResolverLwIp::Lookup(const IPAddress& address) const
     {
+        const auto* ipv4 = std::get_if<IPv4Address>(&address);
+        if (ipv4 == nullptr)
+            return std::nullopt;
         ip4_addr_t target;
-        auto& ipv4 = std::get<IPv4Address>(address);
-        IP4_ADDR(&target, ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
+        IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
 
         struct eth_addr* ethaddr = nullptr;
         if (const ip4_addr_t* ipaddr = nullptr; etharp_find_addr(netif_default, &target, &ethaddr, &ipaddr) >= 0 && ethaddr != nullptr)
@@ -98,29 +108,38 @@ namespace services
         return std::nullopt;
     }
 
-    void ArpMacResolverLwIp::SendRequest(const Address& address) const
+    void ArpMacResolverLwIp::SendRequest(const IPAddress& address) const
     {
+        const auto* ipv4 = std::get_if<IPv4Address>(&address);
+        if (ipv4 == nullptr)
+            return;
         ip4_addr_t target;
-        auto& ipv4 = std::get<IPv4Address>(address);
-        IP4_ADDR(&target, ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
+        IP4_ADDR(&target, (*ipv4)[0], (*ipv4)[1], (*ipv4)[2], (*ipv4)[3]);
         etharp_request(netif_default, &target);
     }
 
     Nd6MacResolverLwIp::Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval)
-        : helper(retries, retryInterval,
-            [this](const Address& address) { return Lookup(address); },
-            [this](const Address& address) { SendRequest(address); })
+        : helper(retries, retryInterval, [this](const IPAddress& address)
+              {
+                  return Lookup(address);
+              },
+              [this](const IPAddress& address)
+              {
+                  SendRequest(address);
+              })
     {}
 
-    void Nd6MacResolverLwIp::Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
+    void Nd6MacResolverLwIp::Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone)
     {
         helper.Resolve(address, onResolveDone);
     }
 
-    std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const Address& address) const
+    std::optional<hal::MacAddress> Nd6MacResolverLwIp::Lookup(const IPAddress& address) const
     {
-        auto& ipv6 = std::get<IPv6Address>(address);
-        auto target = ToLwipIp6(ipv6);
+        const auto* ipv6 = std::get_if<IPv6Address>(&address);
+        if (ipv6 == nullptr)
+            return std::nullopt;
+        auto target = ToLwipIp6(*ipv6);
 
         // Check if target is on-link by matching against netif prefixes
         bool onLink = false;
@@ -157,7 +176,7 @@ namespace services
         return std::nullopt;
     }
 
-    void Nd6MacResolverLwIp::SendRequest(const Address& /* address */) const
+    void Nd6MacResolverLwIp::SendRequest(const IPAddress& /* address */) const
     {
         // ND6 solicitation is triggered implicitly via Lookup (nd6_get_next_hop_addr_or_queue)
     }

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -12,7 +12,7 @@ namespace services
     public:
         void SendRequest(IPv4Address address) override;
         std::optional<hal::MacAddress> Lookup(IPv4Address address) override;
-        void Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+        bool Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
 
     private:
         void OnRetry();
@@ -27,7 +27,7 @@ namespace services
         : public Nd6MacResolver
     {
     public:
-        void Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+        bool Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
 
     private:
         void OnRetry();

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -1,0 +1,42 @@
+#ifndef LWIP_MAC_RESOLVER_LW_IP_HPP
+#define LWIP_MAC_RESOLVER_LW_IP_HPP
+
+#include "infra/timer/Timer.hpp"
+#include "services/network/MacResolver.hpp"
+
+namespace services
+{
+    class ArpMacResolverLwIp
+        : public ArpMacResolver
+    {
+    public:
+        void SendRequest(IPv4Address address) override;
+        std::optional<hal::MacAddress> Lookup(IPv4Address address) override;
+        void Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+
+    private:
+        void OnRetry();
+
+        IPv4Address pendingAddress_{};
+        infra::Function<void(std::optional<hal::MacAddress>)> onDone_;
+        infra::TimerRepeating retryTimer_;
+        uint8_t retriesLeft_ = 0;
+    };
+
+    class Nd6MacResolverLwIp
+        : public Nd6MacResolver
+    {
+    public:
+        void Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+
+    private:
+        void OnRetry();
+
+        IPv6Address pendingAddress_{};
+        infra::Function<void(std::optional<hal::MacAddress>)> onDone_;
+        infra::TimerRepeating retryTimer_;
+        uint8_t retriesLeft_ = 0;
+    };
+}
+
+#endif

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -2,41 +2,67 @@
 #define LWIP_MAC_RESOLVER_LW_IP_HPP
 
 #include "infra/timer/Timer.hpp"
+#include "infra/util/AutoResetFunction.hpp"
 #include "services/network/MacResolver.hpp"
 
 namespace services
 {
-    class ArpMacResolverLwIp
-        : public ArpMacResolver
+    class MacResolverRetryHelper
     {
     public:
-        void SendRequest(IPv4Address address) override;
-        std::optional<hal::MacAddress> Lookup(IPv4Address address) override;
-        bool Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+        using LookupFunction = infra::Function<std::optional<hal::MacAddress>(const MacResolver::Address&)>;
+        using SendRequestFunction = infra::Function<void(const MacResolver::Address&)>;
+
+        MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
+
+        void Resolve(const MacResolver::Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
 
     private:
         void OnRetry();
 
     private:
-        IPv4Address pendingAddress_{};
-        infra::Function<void(std::optional<hal::MacAddress>)> onDone_;
-        infra::TimerRepeating retryTimer_;
-        uint8_t retriesLeft_ = 0;
+        uint8_t retries;
+        infra::Duration retryInterval;
+        LookupFunction lookup;
+        SendRequestFunction sendRequest;
+        MacResolver::Address pendingAddress;
+        infra::AutoResetFunction<void(std::optional<hal::MacAddress>)> onDone;
+        infra::TimerRepeating retryTimer;
+        uint8_t retriesLeft = 0;
+    };
+
+    class ArpMacResolverLwIp
+        : public MacResolver
+    {
+    public:
+        ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
+        ~ArpMacResolverLwIp() override = default;
+
+        void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+
+    private:
+        std::optional<hal::MacAddress> Lookup(const Address& address) const;
+        void SendRequest(const Address& address) const;
+
+    private:
+        MacResolverRetryHelper helper;
     };
 
     class Nd6MacResolverLwIp
-        : public Nd6MacResolver
+        : public MacResolver
     {
     public:
-        bool Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) override;
+        Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
+        ~Nd6MacResolverLwIp() override = default;
+
+        void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
-        void OnRetry();
+        std::optional<hal::MacAddress> Lookup(const Address& address) const;
+        void SendRequest(const Address& address) const;
 
-        IPv6Address pendingAddress_{};
-        infra::Function<void(std::optional<hal::MacAddress>)> onDone_;
-        infra::TimerRepeating retryTimer_;
-        uint8_t retriesLeft_ = 0;
+    private:
+        MacResolverRetryHelper helper;
     };
 }
 

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -17,6 +17,7 @@ namespace services
     private:
         void OnRetry();
 
+    private:
         IPv4Address pendingAddress_{};
         infra::Function<void(std::optional<hal::MacAddress>)> onDone_;
         infra::TimerRepeating retryTimer_;

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -15,7 +15,7 @@ namespace services
 
         MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
 
-        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
 
     private:
         void OnRetry();
@@ -36,7 +36,7 @@ namespace services
     public:
         ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
 
-        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
         bool IsOnSubnet(const IPv4Address& address) const;
@@ -53,7 +53,7 @@ namespace services
     public:
         Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
 
-        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
         bool IsOnLink(const IPv6Address& address) const;

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -1,7 +1,7 @@
 #ifndef LWIP_MAC_RESOLVER_LW_IP_HPP
 #define LWIP_MAC_RESOLVER_LW_IP_HPP
 
-#include "infra/timer/Timer.hpp"
+#include "infra/timer/Retry.hpp"
 #include "infra/util/AutoResetFunction.hpp"
 #include "services/network/MacResolver.hpp"
 
@@ -15,19 +15,18 @@ namespace services
 
         MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
 
-        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
+        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
 
     private:
         void OnRetry();
 
     private:
         uint8_t retries;
-        infra::Duration retryInterval;
         LookupFunction lookup;
         SendRequestFunction sendRequest;
         IPAddress pendingAddress;
         infra::AutoResetFunction<void(std::optional<hal::MacAddress>)> onDone;
-        infra::TimerRepeating retryTimer;
+        infra::RetryFixedInterval retryTimer;
         uint8_t retriesLeft = 0;
     };
 
@@ -37,7 +36,7 @@ namespace services
     public:
         ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
 
-        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
         std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;
@@ -53,7 +52,7 @@ namespace services
     public:
         Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
 
-        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
         std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -16,6 +16,7 @@ namespace services
         MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
 
         [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
+        [[nodiscard]] bool Busy() const;
 
     private:
         void OnRetry();

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -10,12 +10,12 @@ namespace services
     class MacResolverRetryHelper
     {
     public:
-        using LookupFunction = infra::Function<std::optional<hal::MacAddress>(const MacResolver::Address&)>;
-        using SendRequestFunction = infra::Function<void(const MacResolver::Address&)>;
+        using LookupFunction = infra::Function<std::optional<hal::MacAddress>(const IPAddress&)>;
+        using SendRequestFunction = infra::Function<void(const IPAddress&)>;
 
         MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
 
-        void Resolve(const MacResolver::Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
 
     private:
         void OnRetry();
@@ -25,7 +25,7 @@ namespace services
         infra::Duration retryInterval;
         LookupFunction lookup;
         SendRequestFunction sendRequest;
-        MacResolver::Address pendingAddress;
+        IPAddress pendingAddress;
         infra::AutoResetFunction<void(std::optional<hal::MacAddress>)> onDone;
         infra::TimerRepeating retryTimer;
         uint8_t retriesLeft = 0;
@@ -36,13 +36,12 @@ namespace services
     {
     public:
         ArpMacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
-        ~ArpMacResolverLwIp() override = default;
 
-        void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
-        std::optional<hal::MacAddress> Lookup(const Address& address) const;
-        void SendRequest(const Address& address) const;
+        std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;
+        void SendRequest(const IPAddress& address) const;
 
     private:
         MacResolverRetryHelper helper;
@@ -53,13 +52,12 @@ namespace services
     {
     public:
         Nd6MacResolverLwIp(uint8_t retries, infra::Duration retryInterval);
-        ~Nd6MacResolverLwIp() override = default;
 
-        void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
+        void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
-        std::optional<hal::MacAddress> Lookup(const Address& address) const;
-        void SendRequest(const Address& address) const;
+        std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;
+        void SendRequest(const IPAddress& address) const;
 
     private:
         MacResolverRetryHelper helper;

--- a/lwip/lwip_cpp/MacResolverLwIp.hpp
+++ b/lwip/lwip_cpp/MacResolverLwIp.hpp
@@ -16,7 +16,6 @@ namespace services
         MacResolverRetryHelper(uint8_t retries, infra::Duration retryInterval, LookupFunction lookup, SendRequestFunction sendRequest);
 
         [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone);
-        [[nodiscard]] bool Busy() const;
 
     private:
         void OnRetry();
@@ -40,6 +39,7 @@ namespace services
         [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
+        bool IsOnSubnet(const IPv4Address& address) const;
         std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;
         void SendRequest(const IPAddress& address) const;
 
@@ -56,6 +56,7 @@ namespace services
         [[nodiscard]] bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onResolveDone) override;
 
     private:
+        bool IsOnLink(const IPv6Address& address) const;
         std::optional<hal::MacAddress> Lookup(const IPAddress& address) const;
         void SendRequest(const IPAddress& address) const;
 

--- a/services/network/CMakeLists.txt
+++ b/services/network/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(services.network PRIVATE
     HttpServer.hpp
     LlmnrResponder.cpp
     LlmnrResponder.hpp
+    MacResolver.hpp
     MdnsClient.cpp
     MdnsClient.hpp
     Mqtt.hpp

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -1,0 +1,39 @@
+#ifndef SERVICES_MAC_RESOLVER_HPP
+#define SERVICES_MAC_RESOLVER_HPP
+
+#include "hal/interfaces/MacAddress.hpp"
+#include "infra/timer/Timer.hpp"
+#include "infra/util/Function.hpp"
+#include "services/network/Address.hpp"
+#include <optional>
+
+namespace services
+{
+    class ArpMacResolver
+    {
+    protected:
+        ArpMacResolver() = default;
+        ArpMacResolver(const ArpMacResolver& other) = delete;
+        ArpMacResolver& operator=(const ArpMacResolver& other) = delete;
+        ~ArpMacResolver() = default;
+
+    public:
+        virtual void SendRequest(IPv4Address address) = 0;
+        virtual std::optional<hal::MacAddress> Lookup(IPv4Address address) = 0;
+        virtual void Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+    };
+
+    class Nd6MacResolver
+    {
+    protected:
+        Nd6MacResolver() = default;
+        Nd6MacResolver(const Nd6MacResolver& other) = delete;
+        Nd6MacResolver& operator=(const Nd6MacResolver& other) = delete;
+        ~Nd6MacResolver() = default;
+
+    public:
+        virtual void Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+    };
+}
+
+#endif

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -20,7 +20,7 @@ namespace services
     public:
         virtual void SendRequest(IPv4Address address) = 0;
         virtual std::optional<hal::MacAddress> Lookup(IPv4Address address) = 0;
-        virtual void Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        virtual bool Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 
     class Nd6MacResolver
@@ -32,7 +32,7 @@ namespace services
         ~Nd6MacResolver() = default;
 
     public:
-        virtual void Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        virtual bool Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 }
 

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -17,7 +17,7 @@ namespace services
         ~MacResolver() = default;
 
     public:
-        virtual void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        [[nodiscard]] virtual bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 }
 

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -5,7 +5,6 @@
 #include "infra/util/Function.hpp"
 #include "services/network/Address.hpp"
 #include <optional>
-#include <variant>
 
 namespace services
 {
@@ -15,12 +14,10 @@ namespace services
         MacResolver() = default;
         MacResolver(const MacResolver& other) = delete;
         MacResolver& operator=(const MacResolver& other) = delete;
+        ~MacResolver() = default;
 
     public:
-        virtual ~MacResolver() = default;
-
-        using Address = std::variant<IPv4Address, IPv6Address>;
-        virtual void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        virtual void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 }
 

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -2,37 +2,25 @@
 #define SERVICES_MAC_RESOLVER_HPP
 
 #include "hal/interfaces/MacAddress.hpp"
-#include "infra/timer/Timer.hpp"
 #include "infra/util/Function.hpp"
 #include "services/network/Address.hpp"
 #include <optional>
+#include <variant>
 
 namespace services
 {
-    class ArpMacResolver
+    class MacResolver
     {
     protected:
-        ArpMacResolver() = default;
-        ArpMacResolver(const ArpMacResolver& other) = delete;
-        ArpMacResolver& operator=(const ArpMacResolver& other) = delete;
-        ~ArpMacResolver() = default;
+        MacResolver() = default;
+        MacResolver(const MacResolver& other) = delete;
+        MacResolver& operator=(const MacResolver& other) = delete;
 
     public:
-        virtual void SendRequest(IPv4Address address) = 0;
-        virtual std::optional<hal::MacAddress> Lookup(IPv4Address address) = 0;
-        virtual bool Resolve(IPv4Address address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
-    };
+        virtual ~MacResolver() = default;
 
-    class Nd6MacResolver
-    {
-    protected:
-        Nd6MacResolver() = default;
-        Nd6MacResolver(const Nd6MacResolver& other) = delete;
-        Nd6MacResolver& operator=(const Nd6MacResolver& other) = delete;
-        ~Nd6MacResolver() = default;
-
-    public:
-        virtual bool Resolve(const IPv6Address& address, uint8_t retries, infra::Duration retryInterval, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        using Address = std::variant<IPv4Address, IPv6Address>;
+        virtual void Resolve(const Address& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 }
 

--- a/services/network/MacResolver.hpp
+++ b/services/network/MacResolver.hpp
@@ -17,7 +17,7 @@ namespace services
         ~MacResolver() = default;
 
     public:
-        [[nodiscard]] virtual bool Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
+        virtual void Resolve(const IPAddress& address, const infra::Function<void(std::optional<hal::MacAddress>)>& onDone) = 0;
     };
 }
 


### PR DESCRIPTION
Introduces a `MacResolver` interface and two LwIP-backed implementations for resolving IP addresses to MAC addresses: one for IPv4 via ARP, one for IPv6 via Neighbor Discovery (ND6).

### Changes

**`services/network/MacResolver.hpp`** (new)
- Abstract `MacResolver` interface with `void Resolve(const IPAddress&, callback)`
- Destructor moved to `protected` and non-virtual; uses `IPAddress` from `Address.hpp` instead of a local alias

**`lwip/lwip_cpp/MacResolverLwIp.hpp/.cpp`** (new)
- `MacResolverRetryHelper` — shared retry logic backed by `infra::RetryFixedInterval`; rejects concurrent calls gracefully instead of asserting
- `ArpMacResolverLwIp` — resolves IPv4 addresses using `etharp_find_addr` / `etharp_request`; immediately returns `nullopt` for non-IPv4 input
- `Nd6MacResolverLwIp` — resolves IPv6 addresses using `nd6_get_next_hop_addr_or_queue`; checks on-link prefix before queuing; immediately returns `nullopt` for non-IPv6 input
- All variant accesses use `std::get_if` with null-checks; no bare `std::get` that would terminate with exceptions disabled
- Aborts if a resolve is already in progress