### PR TITLE
fix: imbalanced window sizes resulted in a crash

### DIFF
--- a/hal/synchronous_interfaces/test_doubles/SynchronousRandomDataGeneratorMock.hpp
+++ b/hal/synchronous_interfaces/test_doubles/SynchronousRandomDataGeneratorMock.hpp
@@ -3,6 +3,7 @@
 
 #include "hal/synchronous_interfaces/SynchronousRandomDataGenerator.hpp"
 #include "gmock/gmock.h"
+#include <random>
 
 namespace hal
 {
@@ -11,6 +12,22 @@ namespace hal
     {
     public:
         MOCK_METHOD1(GenerateRandomData, void(infra::ByteRange result));
+    };
+
+    class SynchronousRandomDataGeneratorStub
+        : public hal::SynchronousRandomDataGenerator
+    {
+    public:
+        void GenerateRandomData(infra::ByteRange result) override
+        {
+            std::generate(result.begin(), result.end(), [this]()
+                {
+                    return distribution(generator);
+                });
+        }
+
+        std::mt19937 generator;
+        std::uniform_int_distribution<int> distribution{ 0, 255 };
     };
 }
 

--- a/hal/synchronous_interfaces/test_doubles/SynchronousRandomDataGeneratorMock.hpp
+++ b/hal/synchronous_interfaces/test_doubles/SynchronousRandomDataGeneratorMock.hpp
@@ -3,6 +3,7 @@
 
 #include "hal/synchronous_interfaces/SynchronousRandomDataGenerator.hpp"
 #include "gmock/gmock.h"
+#include <algorithm>
 #include <random>
 
 namespace hal

--- a/services/tracer/TracingEchoInstantiation.hpp
+++ b/services/tracer/TracingEchoInstantiation.hpp
@@ -32,7 +32,7 @@ namespace main_
 
     template<std::size_t MessageSize>
     struct TracingEchoOnSesame::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , TracingEchoOnSesame
     {
         WithMessageSize(hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory, services::Tracer& tracer)

--- a/services/tracer/TracingEchoInstantiationSecured.hpp
+++ b/services/tracer/TracingEchoInstantiationSecured.hpp
@@ -47,7 +47,7 @@ namespace main_
 
     template<std::size_t MessageSize>
     struct TracingEchoOnSesameSecuredSymmetricKey::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , private EchoOnSesameSecured::SecuredStorage<MessageSize>
         , TracingEchoOnSesameSecuredSymmetricKey
     {
@@ -70,7 +70,7 @@ namespace main_
 
     template<std::size_t MessageSize>
     struct TracingEchoOnSesameSecuredDiffieHellman::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , private EchoOnSesameSecured::SecuredStorage<MessageSize>
         , TracingEchoOnSesameSecuredDiffieHellman
     {

--- a/services/util/CMakeLists.txt
+++ b/services/util/CMakeLists.txt
@@ -73,6 +73,8 @@ target_sources(services.util PRIVATE
     SesameCobs.cpp
     SesameCobs.hpp
     SesameCrypto.hpp
+    SesameInstantiation.cpp
+    SesameInstantiation.hpp
     SesameSecured.cpp
     SesameSecured.hpp
     SesameWindowed.cpp
@@ -127,6 +129,8 @@ if (EMIL_INCLUDE_MBEDTLS OR NOT EMIL_EXTERNAL_MBEDTLS_TARGET STREQUAL "")
         MbedTlsRandomDataGeneratorWrapper.hpp
         SesameCryptoMbedTls.cpp
         SesameCryptoMbedTls.hpp
+        SesameInstantiationSecured.cpp
+        SesameInstantiationSecured.hpp
         Sha256MbedTls.cpp
         Sha256MbedTls.hpp
     )

--- a/services/util/EchoInstantiation.cpp
+++ b/services/util/EchoInstantiation.cpp
@@ -3,9 +3,8 @@
 namespace main_
 {
     EchoOnSesame::EchoOnSesame(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage, hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory)
-        : cobs(cobsSendStorage, cobsReceivedMessage, serialCommunication)
-        , windowed(windowedReceivedMessage, cobs)
-        , echo(windowed, serializerFactory)
+        : sesame(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, serialCommunication)
+        , echo(sesame.windowed, serializerFactory)
     {}
 
     void EchoOnSesame::Reset()
@@ -15,11 +14,6 @@ namespace main_
 
     void EchoOnSesame::Stop(const infra::Function<void()>& onDone)
     {
-        this->onStopDone = onDone;
-        cobs.Stop([this]()
-            {
-                windowed.ResetReading();
-                this->onStopDone();
-            });
+        sesame.Stop(onDone);
     }
 }

--- a/services/util/EchoInstantiation.hpp
+++ b/services/util/EchoInstantiation.hpp
@@ -11,8 +11,7 @@
 #include "services/util/EchoOnSesame.hpp"
 #include "services/util/MessageCommunicationCobs.hpp"
 #include "services/util/MessageCommunicationWindowed.hpp"
-#include "services/util/SesameCobs.hpp"
-#include "services/util/SesameWindowed.hpp"
+#include "services/util/SesameInstantiation.hpp"
 
 namespace main_
 {
@@ -42,26 +41,13 @@ namespace main_
         // Implementation of Stoppable
         void Stop(const infra::Function<void()>& onDone) override;
 
-        services::SesameCobs cobs;
-        services::SesameWindowed windowed;
+        Sesame sesame;
         services::EchoOnSesame echo;
-
-        infra::AutoResetFunction<void()> onStopDone;
-
-        template<std::size_t MessageSize>
-        struct CobsStorage
-        {
-            static constexpr std::size_t encodedMessageSize = services::SesameWindowed::bufferSizeForMessage<MessageSize, services::SesameCobs::EncodedMessageSize>;
-
-            infra::BoundedVector<uint8_t>::WithMaxSize<services::SesameCobs::sendBufferSize<MessageSize>> cobsSendStorage;
-            infra::BoundedDeque<uint8_t>::WithMaxSize<services::SesameCobs::receiveBufferSize<encodedMessageSize>> cobsReceivedMessage;
-            infra::BoundedDeque<uint8_t>::WithMaxSize<services::SesameCobs::receiveBufferSize<encodedMessageSize>> windowedReceivedMessage;
-        };
     };
 
     template<std::size_t MessageSize>
     struct EchoOnSesame::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , EchoOnSesame
     {
         WithMessageSize(hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory)

--- a/services/util/EchoInstantiationSecured.cpp
+++ b/services/util/EchoInstantiationSecured.cpp
@@ -4,10 +4,8 @@ namespace main_
 {
     EchoOnSesameSecured::EchoOnSesameSecured(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage, infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
         hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory, const services::SesameSecured::KeyMaterial& keyMaterial)
-        : cobs(cobsSendStorage, cobsReceivedMessage, serialCommunication)
-        , windowed(windowedReceivedMessage, cobs)
-        , secured(securedSendBuffer, securedReceiveBuffer, windowed, keyMaterial)
-        , echo(secured, serializerFactory)
+        : sesame(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, securedSendBuffer, securedReceiveBuffer, serialCommunication, keyMaterial)
+        , echo(sesame.secured, serializerFactory)
     {}
 
     void EchoOnSesameSecured::Reset()
@@ -17,24 +15,19 @@ namespace main_
 
     void EchoOnSesameSecured::Stop(const infra::Function<void()>& onDone)
     {
-        this->onStopDone = onDone;
-        cobs.Stop([this]()
-            {
-                windowed.ResetReading();
-                this->onStopDone();
-            });
+        sesame.Stop(onDone);
     }
 
     EchoOnSesameSecuredSymmetricKey::EchoOnSesameSecuredSymmetricKey(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage, infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
         hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory, const services::SesameSecured::KeyMaterial& keyMaterial, hal::SynchronousRandomDataGenerator& randomDataGenerator)
         : EchoOnSesameSecured(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, securedSendBuffer, securedReceiveBuffer, serialCommunication, serializerFactory, keyMaterial)
-        , policy(echo, echo, secured, randomDataGenerator)
+        , policy(echo, echo, sesame.secured, randomDataGenerator)
     {}
 
     EchoOnSesameSecuredDiffieHellman::EchoOnSesameSecuredDiffieHellman(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage, infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
         hal::BufferedSerialCommunication& serialCommunication, services::MethodSerializerFactory& serializerFactory, const services::EchoPolicyDiffieHellman::KeyMaterial& keyMaterial, hal::SynchronousRandomDataGenerator& randomDataGenerator)
         : EchoOnSesameSecured(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, securedSendBuffer, securedReceiveBuffer, serialCommunication, serializerFactory, services::SesameSecured::KeyMaterial{})
         , signer{ keyMaterial.dsaCertificatePrivateKey, randomDataGenerator }
-        , policy(services::EchoPolicyDiffieHellman::Crypto{ keyExchange, signer, verifier, keyExpander }, echo, echo, secured, keyMaterial.dsaCertificate, keyMaterial.rootCaCertificate, randomDataGenerator)
+        , policy(services::EchoPolicyDiffieHellman::Crypto{ keyExchange, signer, verifier, keyExpander }, echo, echo, sesame.secured, keyMaterial.dsaCertificate, keyMaterial.rootCaCertificate, randomDataGenerator)
     {}
 }

--- a/services/util/EchoInstantiationSecured.hpp
+++ b/services/util/EchoInstantiationSecured.hpp
@@ -4,7 +4,7 @@
 #include "services/util/EchoInstantiation.hpp"
 #include "services/util/EchoPolicyDiffieHellman.hpp"
 #include "services/util/EchoPolicySymmetricKey.hpp"
-#include "services/util/SesameSecured.hpp"
+#include "services/util/SesameInstantiationSecured.hpp"
 
 namespace main_
 {
@@ -19,12 +19,8 @@ namespace main_
         // Implementation of Stoppable
         void Stop(const infra::Function<void()>& onDone) override;
 
-        services::SesameCobs cobs;
-        services::SesameWindowed windowed;
-        services::SesameSecured::WithCryptoMbedTls secured;
+        SesameSecured sesame;
         services::EchoOnSesame echo;
-
-        infra::AutoResetFunction<void()> onStopDone;
 
         template<std::size_t MessageSize>
         struct SecuredStorage
@@ -49,7 +45,7 @@ namespace main_
 
     template<std::size_t MessageSize>
     struct EchoOnSesameSecuredSymmetricKey::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , private EchoOnSesameSecured::SecuredStorage<MessageSize>
         , EchoOnSesameSecuredSymmetricKey
     {
@@ -76,7 +72,7 @@ namespace main_
 
     template<std::size_t MessageSize>
     struct EchoOnSesameSecuredDiffieHellman::WithMessageSize
-        : private EchoOnSesame::CobsStorage<MessageSize>
+        : private Sesame::CobsStorage<MessageSize>
         , private EchoOnSesameSecured::SecuredStorage<MessageSize>
         , EchoOnSesameSecuredDiffieHellman
     {

--- a/services/util/SerialCommunicationLoopback.hpp
+++ b/services/util/SerialCommunicationLoopback.hpp
@@ -5,7 +5,6 @@
 
 namespace services
 {
-
     class SerialCommunicationLoopback
     {
     public:

--- a/services/util/SesameInstantiation.cpp
+++ b/services/util/SesameInstantiation.cpp
@@ -1,0 +1,20 @@
+#include "services/util/SesameInstantiation.hpp"
+
+namespace main_
+{
+    Sesame::Sesame(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage,
+        hal::BufferedSerialCommunication& serialCommunication)
+        : cobs(cobsSendStorage, cobsReceivedMessage, serialCommunication)
+        , windowed(windowedReceivedMessage, cobs)
+    {}
+
+    void Sesame::Stop(const infra::Function<void()>& onDone)
+    {
+        this->onStopDone = onDone;
+        cobs.Stop([this]()
+            {
+                windowed.ResetReading();
+                this->onStopDone();
+            });
+    }
+}

--- a/services/util/SesameInstantiation.hpp
+++ b/services/util/SesameInstantiation.hpp
@@ -32,6 +32,16 @@ namespace main_
             infra::BoundedDeque<uint8_t>::WithMaxSize<services::SesameCobs::receiveBufferSize<encodedMessageSize>> windowedReceivedMessage;
         };
     };
+
+    template<std::size_t MessageSize>
+    struct Sesame::WithMessageSize
+        : private Sesame::CobsStorage<MessageSize>
+        , Sesame
+    {
+        WithMessageSize(hal::BufferedSerialCommunication& serialCommunication)
+            : Sesame(this->cobsSendStorage, this->cobsReceivedMessage, this->windowedReceivedMessage, serialCommunication)
+        {}
+    };
 }
 
 #endif

--- a/services/util/SesameInstantiation.hpp
+++ b/services/util/SesameInstantiation.hpp
@@ -1,0 +1,37 @@
+#ifndef SERVICES_UTIL_SESAME_INSTANTIATION_HPP
+#define SERVICES_UTIL_SESAME_INSTANTIATION_HPP
+
+#include "services/util/SesameCobs.hpp"
+#include "services/util/SesameWindowed.hpp"
+
+namespace main_
+{
+    struct Sesame
+    {
+    public:
+        template<std::size_t MessageSize>
+        struct WithMessageSize;
+
+        Sesame(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage,
+            infra::BoundedDeque<uint8_t>& windowedReceivedMessage, hal::BufferedSerialCommunication& serialCommunication);
+
+        void Stop(const infra::Function<void()>& onDone);
+
+        services::SesameCobs cobs;
+        services::SesameWindowed windowed;
+
+        infra::AutoResetFunction<void()> onStopDone;
+
+        template<std::size_t MessageSize>
+        struct CobsStorage
+        {
+            static constexpr std::size_t encodedMessageSize = services::SesameWindowed::bufferSizeForMessage<MessageSize, services::SesameCobs::EncodedMessageSize>;
+
+            infra::BoundedVector<uint8_t>::WithMaxSize<services::SesameCobs::sendBufferSize<MessageSize>> cobsSendStorage;
+            infra::BoundedDeque<uint8_t>::WithMaxSize<services::SesameCobs::receiveBufferSize<encodedMessageSize>> cobsReceivedMessage;
+            infra::BoundedDeque<uint8_t>::WithMaxSize<services::SesameCobs::receiveBufferSize<encodedMessageSize>> windowedReceivedMessage;
+        };
+    };
+}
+
+#endif

--- a/services/util/SesameInstantiationSecured.cpp
+++ b/services/util/SesameInstantiationSecured.cpp
@@ -1,0 +1,20 @@
+#include "services/util/SesameInstantiationSecured.hpp"
+
+namespace main_
+{
+    SesameSecured::SesameSecured(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage, infra::BoundedDeque<uint8_t>& windowedReceivedMessage, infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
+        hal::BufferedSerialCommunication& serialCommunication, const services::SesameSecured::KeyMaterial& keyMaterial)
+        : Sesame(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, serialCommunication)
+        , secured(securedSendBuffer, securedReceiveBuffer, windowed, keyMaterial)
+    {}
+
+    void SesameSecured::Stop(const infra::Function<void()>& onDone)
+    {
+        this->onStopDone = onDone;
+        cobs.Stop([this]()
+            {
+                windowed.ResetReading();
+                this->onStopDone();
+            });
+    }
+}

--- a/services/util/SesameInstantiationSecured.cpp
+++ b/services/util/SesameInstantiationSecured.cpp
@@ -7,14 +7,4 @@ namespace main_
         : Sesame(cobsSendStorage, cobsReceivedMessage, windowedReceivedMessage, serialCommunication)
         , secured(securedSendBuffer, securedReceiveBuffer, windowed, keyMaterial)
     {}
-
-    void SesameSecured::Stop(const infra::Function<void()>& onDone)
-    {
-        this->onStopDone = onDone;
-        cobs.Stop([this]()
-            {
-                windowed.ResetReading();
-                this->onStopDone();
-            });
-    }
 }

--- a/services/util/SesameInstantiationSecured.hpp
+++ b/services/util/SesameInstantiationSecured.hpp
@@ -18,11 +18,7 @@ namespace main_
             infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
             hal::BufferedSerialCommunication& serialCommunication, const services::SesameSecured::KeyMaterial& keyMaterial);
 
-        void Stop(const infra::Function<void()>& onDone);
-
         services::SesameSecured::WithCryptoMbedTls secured;
-
-        infra::AutoResetFunction<void()> onStopDone;
 
         template<std::size_t MessageSize>
         struct SecuredStorage

--- a/services/util/SesameInstantiationSecured.hpp
+++ b/services/util/SesameInstantiationSecured.hpp
@@ -1,0 +1,47 @@
+#ifndef SERVICES_UTIL_SESAME_INSTANTIATION_SECURED_HPP
+#define SERVICES_UTIL_SESAME_INSTANTIATION_SECURED_HPP
+
+#include "services/util/SesameInstantiation.hpp"
+#include "services/util/SesameSecured.hpp"
+
+namespace main_
+{
+    struct SesameSecured
+        : Sesame
+    {
+    public:
+        template<std::size_t MessageSize>
+        struct WithMessageSize;
+
+        SesameSecured(infra::BoundedVector<uint8_t>& cobsSendStorage, infra::BoundedDeque<uint8_t>& cobsReceivedMessage,
+            infra::BoundedDeque<uint8_t>& windowedReceivedMessage,
+            infra::BoundedVector<uint8_t>& securedSendBuffer, infra::BoundedVector<uint8_t>& securedReceiveBuffer,
+            hal::BufferedSerialCommunication& serialCommunication, const services::SesameSecured::KeyMaterial& keyMaterial);
+
+        void Stop(const infra::Function<void()>& onDone);
+
+        services::SesameSecured::WithCryptoMbedTls secured;
+
+        infra::AutoResetFunction<void()> onStopDone;
+
+        template<std::size_t MessageSize>
+        struct SecuredStorage
+        {
+            infra::BoundedVector<uint8_t>::WithMaxSize<services::SesameSecured::encodedMessageSize<MessageSize>> securedSendBuffer;
+            infra::BoundedVector<uint8_t>::WithMaxSize<services::SesameSecured::encodedMessageSize<MessageSize>> securedReceiveBuffer;
+        };
+    };
+
+    template<std::size_t MessageSize>
+    struct SesameSecured::WithMessageSize
+        : private SesameSecured::SecuredStorage<MessageSize>
+        , private Sesame::CobsStorage<MessageSize>
+        , SesameSecured
+    {
+        WithMessageSize(hal::BufferedSerialCommunication& serialCommunication, const services::SesameSecured::KeyMaterial& keyMaterial)
+            : SesameSecured(this->cobsSendStorage, this->cobsReceivedMessage, this->windowedReceivedMessage, this->securedSendBuffer, this->securedReceiveBuffer, serialCommunication, keyMaterial)
+        {}
+    };
+}
+
+#endif

--- a/services/util/SesameWindowed.cpp
+++ b/services/util/SesameWindowed.cpp
@@ -67,6 +67,7 @@ namespace services
 
     void SesameWindowed::RequestSendMessage(std::size_t size)
     {
+        assert(size <= MaxSendMessageSize());
         state->RequestSendMessage(size);
     }
 
@@ -161,7 +162,7 @@ namespace services
 
     void SesameWindowed::ReceivedInitialize()
     {
-        maxUsableBufferSize = otherAvailableWindow;
+        maxUsableBufferSize = std::min<uint16_t>(SesameEncodedObserver::Subject().MaxSendMessageSize(), otherAvailableWindow);
         initialized = true;
         GetObserver().Initialized();
     }

--- a/services/util/SesameWindowed.cpp
+++ b/services/util/SesameWindowed.cpp
@@ -1,5 +1,6 @@
 #include "services/util/SesameWindowed.hpp"
 #include "infra/stream/BoundedDequeOutputStream.hpp"
+#include <algorithm>
 
 namespace services
 {

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(services.util_test PRIVATE
     TestRepeatingButton.cpp
     TestSerialCommunicationLoopback.cpp
     TestSesameCobs.cpp
+    $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameInstantiationSecured.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameSecured.cpp>
     TestSesameWindowed.cpp
     TestSignalLed.cpp

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(services.util_test PRIVATE
     TestRepeatingButton.cpp
     TestSerialCommunicationLoopback.cpp
     TestSesameCobs.cpp
+    $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameInstantiation.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameInstantiationSecured.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameSecured.cpp>
     TestSesameWindowed.cpp

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources(services.util_test PRIVATE
     TestRepeatingButton.cpp
     TestSerialCommunicationLoopback.cpp
     TestSesameCobs.cpp
-    $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameInstantiation.cpp>
+    TestSesameInstantiation.cpp
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameInstantiationSecured.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameSecured.cpp>
     TestSesameWindowed.cpp

--- a/services/util/test/TestSesameInstantiation.cpp
+++ b/services/util/test/TestSesameInstantiation.cpp
@@ -2,42 +2,37 @@
 #include "infra/stream/StdVectorOutputStream.hpp"
 #include "infra/timer/test_helper/ClockFixture.hpp"
 #include "services/util/SerialCommunicationLoopback.hpp"
-#include "services/util/SesameInstantiationSecured.hpp"
-#include "services/util/SesameSecured.hpp"
+#include "services/util/SesameInstantiation.hpp"
 #include "services/util/test_doubles/SesameMock.hpp"
 #include "gmock/gmock.h"
 
 namespace
 {
     template<std::size_t LeftSize, std::size_t RightSize>
-    class SesameInstantiationSecured
+    class SesameInstantiation
     {
     public:
         services::SerialCommunicationLoopback serial;
-        services::SesameSecured::KeyType keyA{ 1, 2 };
-        services::SesameSecured::KeyType keyB{ 3, 4 };
-        services::SesameSecured::IvType ivA{ 5, 6 };
-        services::SesameSecured::IvType ivB{ 7, 8 };
 
         constexpr static std::size_t leftSize = LeftSize;
         hal::BufferedSerialCommunicationOnUnbuffered::WithStorage<leftSize> leftSerial{ serial.Server() };
-        main_::SesameSecured::WithMessageSize<leftSize> leftSesame{ leftSerial, services::SesameSecured::KeyMaterial{ keyA, ivA, keyB, ivB } };
-        testing::StrictMock<services::SesameObserverMock> leftUpper{ leftSesame.secured };
+        main_::Sesame::WithMessageSize<leftSize> leftSesame{ leftSerial };
+        testing::StrictMock<services::SesameObserverMock> leftUpper{ leftSesame.windowed };
 
         constexpr static std::size_t rightSize = RightSize;
         hal::BufferedSerialCommunicationOnUnbuffered::WithStorage<rightSize> rightSerial{ serial.Client() };
-        main_::SesameSecured::WithMessageSize<rightSize> rightSesame{ rightSerial, services::SesameSecured::KeyMaterial{ keyB, ivB, keyA, ivA } };
-        testing::StrictMock<services::SesameObserverMock> rightUpper{ rightSesame.secured };
+        main_::Sesame::WithMessageSize<rightSize> rightSesame{ rightSerial };
+        testing::StrictMock<services::SesameObserverMock> rightUpper{ rightSesame.windowed };
     };
 }
 
-class SesameInstantiationSecuredTest
+class SesameInstantiationTest
     : public testing::Test
     , public infra::ClockFixture
-    , public SesameInstantiationSecured<256, 1024>
+    , public SesameInstantiation<256, 1024>
 {
 public:
-    SesameInstantiationSecuredTest()
+    SesameInstantiationTest()
     {
         EXPECT_CALL(leftUpper, Initialized()).Times(testing::AnyNumber());
         EXPECT_CALL(rightUpper, Initialized()).Times(testing::AnyNumber());
@@ -45,7 +40,7 @@ public:
     }
 };
 
-TEST_F(SesameInstantiationSecuredTest, send_big_message_right)
+TEST_F(SesameInstantiationTest, send_big_message_right)
 {
     std::string sentData;
 
@@ -66,10 +61,10 @@ TEST_F(SesameInstantiationSecuredTest, send_big_message_right)
         }));
     ExecuteAllActions();
 
-    EXPECT_EQ(105, sentData.size());
+    EXPECT_EQ(121, sentData.size());
 }
 
-TEST_F(SesameInstantiationSecuredTest, send_big_message_left)
+TEST_F(SesameInstantiationTest, send_big_message_left)
 {
     std::string sentData;
 
@@ -90,16 +85,16 @@ TEST_F(SesameInstantiationSecuredTest, send_big_message_left)
         }));
     ExecuteAllActions();
 
-    EXPECT_EQ(105, sentData.size());
+    EXPECT_EQ(121, sentData.size());
 }
 
-class SesameInstantiationSecuredTestMessageSize
+class SesameInstantiationTestMessageSize
     : public testing::TestWithParam<std::size_t>
     , public infra::ClockFixture
-    , public SesameInstantiationSecured<2048, 2048>
+    , public SesameInstantiation<2048, 2048>
 {
 public:
-    SesameInstantiationSecuredTestMessageSize()
+    SesameInstantiationTestMessageSize()
     {
         EXPECT_CALL(leftUpper, Initialized()).Times(testing::AnyNumber());
         EXPECT_CALL(rightUpper, Initialized()).Times(testing::AnyNumber());
@@ -109,9 +104,9 @@ public:
     const std::size_t messageSize = GetParam();
 };
 
-TEST_P(SesameInstantiationSecuredTestMessageSize, send_message_of_size_right)
+TEST_P(SesameInstantiationTestMessageSize, send_message_of_size_right)
 {
-    EXPECT_EQ(994, leftUpper.Subject().MaxSendMessageSize());
+    EXPECT_EQ(1010, leftUpper.Subject().MaxSendMessageSize());
 
     std::string sentData1;
     std::string sentData2;
@@ -153,4 +148,4 @@ TEST_P(SesameInstantiationSecuredTestMessageSize, send_message_of_size_right)
     EXPECT_EQ(messageSize, sentData2.size());
 }
 
-INSTANTIATE_TEST_SUITE_P(SesameInstantiationSecuredTestMessageSize, SesameInstantiationSecuredTestMessageSize, testing::Range<std::size_t>(1, 994));
+INSTANTIATE_TEST_SUITE_P(SesameInstantiationTestMessageSize, SesameInstantiationTestMessageSize, testing::Range<std::size_t>(1, 1010));

--- a/services/util/test/TestSesameInstantiation.cpp
+++ b/services/util/test/TestSesameInstantiation.cpp
@@ -152,4 +152,4 @@ TEST_P(SesameInstantiationTestMessageSize, send_message_of_size_right)
     EXPECT_EQ(messageSize, sentData2.size());
 }
 
-INSTANTIATE_TEST_SUITE_P(SesameInstantiationTestMessageSize, SesameInstantiationTestMessageSize, testing::Range<std::size_t>(1, 1010));
+INSTANTIATE_TEST_SUITE_P(SesameInstantiationTestMessageSize, SesameInstantiationTestMessageSize, testing::Range<std::size_t>(1, 1011));

--- a/services/util/test/TestSesameInstantiation.cpp
+++ b/services/util/test/TestSesameInstantiation.cpp
@@ -56,7 +56,8 @@ TEST_F(SesameInstantiationTest, send_big_message_right)
         {
             infra::TextInputStream::WithErrorPolicy stream(*reader);
             std::string text(stream.Available(), ' ');
-            stream >> infra::BoundedString(text);
+            infra::BoundedString textString(text);
+            stream >> textString;
             EXPECT_EQ(sentData, text);
         }));
     ExecuteAllActions();
@@ -80,7 +81,8 @@ TEST_F(SesameInstantiationTest, send_big_message_left)
         {
             infra::TextInputStream::WithErrorPolicy stream(*reader);
             std::string text(stream.Available(), ' ');
-            stream >> infra::BoundedString(text);
+            infra::BoundedString textString(text);
+            stream >> textString;
             EXPECT_EQ(sentData, text);
         }));
     ExecuteAllActions();
@@ -132,14 +134,16 @@ TEST_P(SesameInstantiationTestMessageSize, send_message_of_size_right)
             {
                 infra::TextInputStream::WithErrorPolicy stream(*reader);
                 std::string text(stream.Available(), ' ');
-                stream >> infra::BoundedString(text);
+                infra::BoundedString textString(text);
+                stream >> textString;
                 EXPECT_EQ(sentData1, text);
             }))
         .WillOnce(testing::Invoke([this, &sentData2](infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
             {
                 infra::TextInputStream::WithErrorPolicy stream(*reader);
                 std::string text(stream.Available(), ' ');
-                stream >> infra::BoundedString(text);
+                infra::BoundedString textString(text);
+                stream >> textString;
                 EXPECT_EQ(sentData2, text);
             }));
     ExecuteAllActions();

--- a/services/util/test/TestSesameInstantiationSecured.cpp
+++ b/services/util/test/TestSesameInstantiationSecured.cpp
@@ -1,0 +1,87 @@
+#include "infra/stream/StdVectorInputStream.hpp"
+#include "infra/stream/StdVectorOutputStream.hpp"
+#include "infra/timer/test_helper/ClockFixture.hpp"
+#include "services/util/SesameSecured.hpp"
+#include "services/util/test_doubles/SesameMock.hpp"
+#include "gmock/gmock.h"
+
+#include "infra/timer/test_helper/ClockFixture.hpp"
+#include "services/util/SerialCommunicationLoopback.hpp"
+#include "services/util/SesameInstantiationSecured.hpp"
+
+class SesameInstantiationSecuredTest
+    : public testing::Test
+    , public infra::ClockFixture
+{
+public:
+    SesameInstantiationSecuredTest()
+    {
+        EXPECT_CALL(leftUpper, Initialized()).Times(testing::AnyNumber());
+        EXPECT_CALL(rightUpper, Initialized()).Times(testing::AnyNumber());
+        ExecuteAllActions();
+    }
+
+    services::SerialCommunicationLoopback serial;
+    services::SesameSecured::KeyType keyA{ 1, 2 };
+    services::SesameSecured::KeyType keyB{ 3, 4 };
+    services::SesameSecured::IvType ivA{ 5, 6 };
+    services::SesameSecured::IvType ivB{ 7, 8 };
+
+    constexpr static std::size_t leftSize = 256;
+    hal::BufferedSerialCommunicationOnUnbuffered::WithStorage<leftSize> leftSerial{ serial.Server() };
+    main_::SesameSecured::WithMessageSize<leftSize> leftSesame{ leftSerial, services::SesameSecured::KeyMaterial{ keyA, ivA, keyB, ivB } };
+    testing::StrictMock<services::SesameObserverMock> leftUpper{ leftSesame.secured };
+
+    constexpr static std::size_t rightSize = 1024;
+    hal::BufferedSerialCommunicationOnUnbuffered::WithStorage<rightSize> rightSerial{ serial.Client() };
+    main_::SesameSecured::WithMessageSize<rightSize> rightSesame{ rightSerial, services::SesameSecured::KeyMaterial{ keyB, ivB, keyA, ivA } };
+    testing::StrictMock<services::SesameObserverMock> rightUpper{ rightSesame.secured };
+};
+
+TEST_F(SesameInstantiationSecuredTest, send_big_message_right)
+{
+    std::string sentData;
+
+    EXPECT_CALL(leftUpper, SendMessageStreamAvailable(testing::_)).WillOnce(testing::Invoke([this, &sentData](infra::SharedPtr<infra::StreamWriter>&& writer)
+        {
+            infra::TextOutputStream::WithErrorPolicy stream(*writer);
+            sentData = std::string(stream.Available(), 'a');
+            stream << sentData;
+        }));
+    leftUpper.Subject().RequestSendMessage(leftUpper.Subject().MaxSendMessageSize());
+
+    EXPECT_CALL(rightUpper, ReceivedMessage(testing::_)).WillOnce(testing::Invoke([this, &sentData](infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
+        {
+            infra::TextInputStream::WithErrorPolicy stream(*reader);
+            std::string text(stream.Available(), ' ');
+            stream >> infra::BoundedString(text);
+            EXPECT_EQ(sentData, text);
+        }));
+    ExecuteAllActions();
+
+    EXPECT_EQ(105, sentData.size());
+}
+
+TEST_F(SesameInstantiationSecuredTest, send_big_message_left)
+{
+    std::string sentData;
+
+    EXPECT_CALL(rightUpper, SendMessageStreamAvailable(testing::_)).WillOnce(testing::Invoke([this, &sentData](infra::SharedPtr<infra::StreamWriter>&& writer)
+        {
+            infra::TextOutputStream::WithErrorPolicy stream(*writer);
+            sentData = std::string(stream.Available(), 'a');
+            stream << sentData;
+        }));
+    rightUpper.Subject().RequestSendMessage(rightUpper.Subject().MaxSendMessageSize());
+
+    EXPECT_CALL(leftUpper, ReceivedMessage(testing::_)).WillOnce(testing::Invoke([this, &sentData](infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
+        {
+            infra::TextInputStream::WithErrorPolicy stream(*reader);
+            std::string text(stream.Available(), ' ');
+            stream >> infra::BoundedString(text);
+            EXPECT_EQ(sentData, text);
+        }));
+    ExecuteAllActions();
+
+    EXPECT_EQ(105, sentData.size());
+}

--- a/services/util/test/TestSesameInstantiationSecured.cpp
+++ b/services/util/test/TestSesameInstantiationSecured.cpp
@@ -157,4 +157,4 @@ TEST_P(SesameInstantiationSecuredTestMessageSize, send_message_of_size_right)
     EXPECT_EQ(messageSize, sentData2.size());
 }
 
-INSTANTIATE_TEST_SUITE_P(SesameInstantiationSecuredTestMessageSize, SesameInstantiationSecuredTestMessageSize, testing::Range<std::size_t>(1, 994));
+INSTANTIATE_TEST_SUITE_P(SesameInstantiationSecuredTestMessageSize, SesameInstantiationSecuredTestMessageSize, testing::Range<std::size_t>(1, 995));

--- a/services/util/test/TestSesameInstantiationSecured.cpp
+++ b/services/util/test/TestSesameInstantiationSecured.cpp
@@ -61,7 +61,8 @@ TEST_F(SesameInstantiationSecuredTest, send_big_message_right)
         {
             infra::TextInputStream::WithErrorPolicy stream(*reader);
             std::string text(stream.Available(), ' ');
-            stream >> infra::BoundedString(text);
+            infra::BoundedString textString(text);
+            stream >> textString;
             EXPECT_EQ(sentData, text);
         }));
     ExecuteAllActions();
@@ -85,7 +86,8 @@ TEST_F(SesameInstantiationSecuredTest, send_big_message_left)
         {
             infra::TextInputStream::WithErrorPolicy stream(*reader);
             std::string text(stream.Available(), ' ');
-            stream >> infra::BoundedString(text);
+            infra::BoundedString textString(text);
+            stream >> textString;
             EXPECT_EQ(sentData, text);
         }));
     ExecuteAllActions();
@@ -137,14 +139,16 @@ TEST_P(SesameInstantiationSecuredTestMessageSize, send_message_of_size_right)
             {
                 infra::TextInputStream::WithErrorPolicy stream(*reader);
                 std::string text(stream.Available(), ' ');
-                stream >> infra::BoundedString(text);
+                infra::BoundedString textString(text);
+                stream >> textString;
                 EXPECT_EQ(sentData1, text);
             }))
         .WillOnce(testing::Invoke([this, &sentData2](infra::SharedPtr<infra::StreamReaderWithRewinding>&& reader)
             {
                 infra::TextInputStream::WithErrorPolicy stream(*reader);
                 std::string text(stream.Available(), ' ');
-                stream >> infra::BoundedString(text);
+                infra::BoundedString textString(text);
+                stream >> textString;
                 EXPECT_EQ(sentData2, text);
             }));
     ExecuteAllActions();

--- a/services/util/test/TestSesameWindowed.cpp
+++ b/services/util/test/TestSesameWindowed.cpp
@@ -150,7 +150,7 @@ public:
     infra::NotifyingSharedOptional<infra::StdVectorOutputStreamWriter> writer;
     infra::Execute execute{ [this]()
         {
-            EXPECT_CALL(base, MaxSendMessageSize()).WillOnce(testing::Return(24));
+            EXPECT_CALL(base, MaxSendMessageSize()).WillRepeatedly(testing::Return(24));
             EXPECT_CALL(base, WorstCaseEncodedMessageSize(3)).WillOnce(testing::Return(5));
             ExpectRequestSendMessageForInit(24);
         } };
@@ -193,7 +193,18 @@ TEST_F(SesameWindowedTest, message_waits_until_window_is_freed)
 
 TEST_F(SesameWindowedTest, long_message_waits_until_window_is_freed_taking_into_account_cobs_overhead)
 {
-    ReceiveInitResponse(261);
+    EXPECT_CALL(base, MaxSendMessageSize()).WillRepeatedly(testing::Return(2000));
+    ReceiveInitResponse(519);
+
+    auto fillWindow = std::vector<uint8_t>(251, 1);
+    ExpectRequestSendMessageForMessage(fillWindow.size() + 1, fillWindow);
+    ExpectSendMessageStreamAvailable(fillWindow);
+    communication.RequestSendMessage(fillWindow.size());
+
+    auto fillWindow2 = std::vector<uint8_t>(1, 1);
+    ExpectRequestSendMessageForMessage(fillWindow2.size() + 1, fillWindow2);
+    ExpectSendMessageStreamAvailable(fillWindow2);
+    communication.RequestSendMessage(fillWindow2.size());
 
     // A message of size 253 plus one byte for the operation may consist of 254 zeros, and therefore need one extra COBS overhead byte.
     // Total window available needs therefore to be 254 + 1 (one extra COBS byte) + 2 (normal COBS byte and closing 0) + 5 (safeguard for another window release)
@@ -207,10 +218,11 @@ TEST_F(SesameWindowedTest, long_message_waits_until_window_is_freed_taking_into_
 
 TEST_F(SesameWindowedTest, exact_used_window_size_is_consumed_by_message)
 {
-    auto longMessage = infra::ConstructBin().Repeat(253 * 7, 0).Vector();
+    auto longMessage = infra::ConstructBin().Repeat(253 * 3, 0).Vector();
 
+    EXPECT_CALL(base, MaxSendMessageSize()).WillRepeatedly(testing::Return(4000));
     // Exactly enough for any message of size longMessage plus safeguard for a window release
-    ReceiveInitResponse(254 * 7 + 1 + 7 + 2 + 5);
+    ReceiveInitResponse(254 * 6 + 1 + 7 + 2 + 5);
 
     // Sending longMessage, for which no extra COBS overhead bytes were necessary, results in 7 + 5 window still available
     ExpectRequestSendMessageForMessage(longMessage.size() + 1, longMessage);
@@ -221,15 +233,6 @@ TEST_F(SesameWindowedTest, exact_used_window_size_is_consumed_by_message)
     ExpectRequestSendMessageForMessage(5, { 1, 2, 3, 4 });
     ExpectSendMessageStreamAvailable({ 1, 2, 3, 4 });
     communication.RequestSendMessage(4);
-}
-
-TEST_F(SesameWindowedTest, send_message_while_initializing_waits_for_initialized)
-{
-    communication.RequestSendMessage(4);
-
-    ExpectRequestSendMessageForMessage(5, { 1, 2, 3, 4 });
-    ExpectSendMessageStreamAvailable({ 1, 2, 3, 4 });
-    ReceiveInitResponse(28);
 }
 
 TEST_F(SesameWindowedTest, request_sending_new_message_while_previous_is_still_processing)
@@ -281,16 +284,6 @@ TEST_F(SesameWindowedTest, received_message_before_initialized_is_discarded)
     PretendReceiveMessage("abcd");
 
     ReceiveInitResponse(24);
-}
-
-TEST_F(SesameWindowedTest, received_release_window_before_initialized_is_discarded)
-{
-    communication.RequestSendMessage(4);
-    ReceiveReleaseWindow(6);
-
-    ExpectRequestSendMessageForMessage(5, { 1, 2, 3, 4 });
-    ExpectSendMessageStreamAvailable({ 1, 2, 3, 4 });
-    ReceiveInitResponse(28);
 }
 
 TEST_F(SesameWindowedTest, handle_init_request_after_initialization)
@@ -529,7 +522,6 @@ TEST_F(SesameWindowedTest, hold_initialization_until_initializer_grants)
 {
     observer.Detach();
     services::SesameInitializerMock initializer;
-    EXPECT_CALL(base, MaxSendMessageSize()).WillOnce(testing::Return(24));
     EXPECT_CALL(base, WorstCaseEncodedMessageSize(3)).WillOnce(testing::Return(5));
     ExpectRequestSendMessageForInit(24);
     infra::ReConstruct(communication, base, initializer);


### PR DESCRIPTION
## Pull request overview

Fixes a crash in `SesameWindowed` when peers negotiate imbalanced window sizes by capping the usable window to what the local stack can actually send. Also introduces reusable “instantiation” wrappers (`main_::Sesame` / `main_::SesameSecured`) to reduce duplication in Echo-on-Sesame setup, and adds a secured instantiation test to exercise mismatched message sizes.

**Changes:**
- Cap `SesameWindowed`’s negotiated usable window to `min(localMax, remoteWindow)` to prevent oversize send requests.
- Add `main_::Sesame` / `main_::SesameSecured` instantiation helpers and refactor Echo instantiations to use them.
- Add a new secured instantiation test and update existing SesameWindowed tests for the new sizing behavior.