### PR TITLE
feat: log and aborting with enum now supports integers

### DIFF
--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -6,6 +6,24 @@
 #include <cstdlib>
 #include <type_traits>
 
+namespace
+{
+    template<class T, bool = std::is_enum_v<T>>
+    struct LogAndAbortEnumOrIntegralType
+    {
+        using Type = T;
+    };
+
+    template<class T>
+    struct LogAndAbortEnumOrIntegralType<T, true>
+    {
+        using Type = std::underlying_type_t<T>;
+    };
+
+    template<class T>
+    using LogAndAbortEnumOrIntegralTypeT = typename LogAndAbortEnumOrIntegralType<T>::Type;
+}
+
 namespace infra
 {
     using LogAndAbortHook = infra::Function<void(const char* reason, const char* file, int line, const char* format, va_list* args)>;
@@ -57,19 +75,33 @@ namespace infra
     } while (0)
 
 #define LOG_AND_ABORT_NOT_IMPLEMENTED() LOG_AND_ABORT("Not implemented")
-#define LOG_AND_ABORT_ENUM(value)                                                                                                       \
-    do                                                                                                                                  \
-    {                                                                                                                                   \
-        static_assert(std::is_enum_v<std::decay_t<decltype(value)>>, "LOG_AND_ABORT_ENUM can only be used with enum types");            \
-        using LogAndAbortEnumUnderlyingType = std::underlying_type_t<std::decay_t<decltype(value)>>;                                    \
-        if constexpr (std::is_signed_v<LogAndAbortEnumUnderlyingType>)                                                                  \
-        {                                                                                                                               \
-            LOG_AND_ABORT("Unexpected enum: %lld", static_cast<long long>(static_cast<LogAndAbortEnumUnderlyingType>(value)));          \
-        }                                                                                                                               \
-        else                                                                                                                            \
-        {                                                                                                                               \
-            LOG_AND_ABORT("Unexpected enum: %llu", static_cast<unsigned long long>(static_cast<LogAndAbortEnumUnderlyingType>(value))); \
-        }                                                                                                                               \
+#define LOG_AND_ABORT_ENUM(value)                                                                                                                                                             \
+    do                                                                                                                                                                                        \
+    {                                                                                                                                                                                         \
+        static_assert(std::is_enum_v<std::decay_t<decltype(value)>> || std::is_integral_v<std::decay_t<decltype(value)>>, "LOG_AND_ABORT_ENUM can only be used with enum or integral types"); \
+        using LogAndAbortValueType = LogAndAbortEnumOrIntegralTypeT<std::decay_t<decltype(value)>>;                                                                                           \
+        if constexpr (std::is_enum_v<std::decay_t<decltype(value)>>)                                                                                                                          \
+        {                                                                                                                                                                                     \
+            if constexpr (std::is_signed_v<LogAndAbortValueType>)                                                                                                                             \
+            {                                                                                                                                                                                 \
+                LOG_AND_ABORT("Unexpected enum: %lld", static_cast<long long>(static_cast<LogAndAbortValueType>(value)));                                                                     \
+            }                                                                                                                                                                                 \
+            else                                                                                                                                                                              \
+            {                                                                                                                                                                                 \
+                LOG_AND_ABORT("Unexpected enum: %llu", static_cast<unsigned long long>(static_cast<LogAndAbortValueType>(value)));                                                            \
+            }                                                                                                                                                                                 \
+        }                                                                                                                                                                                     \
+        else if constexpr (std::is_integral_v<std::decay_t<decltype(value)>>)                                                                                                                 \
+        {                                                                                                                                                                                     \
+            if constexpr (std::is_signed_v<LogAndAbortValueType>)                                                                                                                             \
+            {                                                                                                                                                                                 \
+                LOG_AND_ABORT("Unexpected integral: %lld", static_cast<long long>(value));                                                                                                    \
+            }                                                                                                                                                                                 \
+            else                                                                                                                                                                              \
+            {                                                                                                                                                                                 \
+                LOG_AND_ABORT("Unexpected integral: %llu", static_cast<unsigned long long>(value));                                                                                           \
+            }                                                                                                                                                                                 \
+        }                                                                                                                                                                                     \
     } while (0)
 
 #endif // INFRA_UTIL_LOGANDABORT_HPP

--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -6,7 +6,7 @@
 #include <cstdlib>
 #include <type_traits>
 
-namespace
+namespace infra::detail
 {
     template<class T, bool = std::is_enum_v<T>>
     struct LogAndAbortEnumOrIntegralType

--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -11,22 +11,22 @@ namespace infra::detail
     template<class T, bool = std::is_enum_v<T>>
     struct LogAndAbortEnumOrIntegralType
     {
-        using Type = T;
+        static_assert(std::is_integral_v<T>, "T must be an integral type");
 
-        static Type ToUnderlying(T value)
+        static T ToUnderlying(T value)
         {
-            return static_cast<Type>(value);
+            return static_cast<T>(value);
         }
     };
 
     template<class T>
     struct LogAndAbortEnumOrIntegralType<T, true>
     {
-        using Type = std::underlying_type_t<T>;
+        static_assert(std::is_enum_v<std::decay_t<T>>, "T must be an enum type");
 
-        static Type ToUnderlying(T value)
+        static std::underlying_type_t<T> ToUnderlying(T value)
         {
-            return static_cast<Type>(value);
+            return static_cast<std::underlying_type_t<T>>(value);
         }
     };
 }
@@ -86,7 +86,7 @@ namespace infra
     do                                                                                                                                                                                        \
     {                                                                                                                                                                                         \
         static_assert(std::is_enum_v<std::decay_t<decltype(value)>> || std::is_integral_v<std::decay_t<decltype(value)>>, "LOG_AND_ABORT_ENUM can only be used with enum or integral types"); \
-        auto underlyingValue = LogAndAbortEnumOrIntegralType<std::decay_t<decltype(value)>>::ToUnderlying(value);                                                                             \
+        auto underlyingValue = infra::detail::LogAndAbortEnumOrIntegralType<std::decay_t<decltype(value)>>::ToUnderlying(value);                                                              \
         if constexpr (std::is_signed_v<decltype(underlyingValue)>)                                                                                                                            \
         {                                                                                                                                                                                     \
             LOG_AND_ABORT("Unexpected enum: %lld", static_cast<long long>(underlyingValue));                                                                                                  \

--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -14,7 +14,7 @@ namespace infra::detail
         using Type = std::decay_t<T>;
         static_assert(std::is_integral_v<Type>, "T must be an integral type");
 
-        static Type ToUnderlying(T value)
+        constexpr static Type ToUnderlying(T value)
         {
             return static_cast<Type>(value);
         }
@@ -26,7 +26,7 @@ namespace infra::detail
         using Type = std::underlying_type_t<std::decay_t<T>>;
         static_assert(std::is_enum_v<std::decay_t<T>>, "T must be an enum type");
 
-        static Type ToUnderlying(T value)
+        constexpr static Type ToUnderlying(T value)
         {
             return static_cast<Type>(value);
         }

--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -8,25 +8,27 @@
 
 namespace infra::detail
 {
-    template<class T, bool = std::is_enum_v<T>>
+    template<class T, bool = std::is_enum_v<std::decay_t<T>>>
     struct LogAndAbortEnumOrIntegralType
     {
-        static_assert(std::is_integral_v<T>, "T must be an integral type");
+        using Type = std::decay_t<T>;
+        static_assert(std::is_integral_v<Type>, "T must be an integral type");
 
-        static T ToUnderlying(T value)
+        static Type ToUnderlying(T value)
         {
-            return static_cast<T>(value);
+            return static_cast<Type>(value);
         }
     };
 
     template<class T>
     struct LogAndAbortEnumOrIntegralType<T, true>
     {
+        using Type = std::underlying_type_t<std::decay_t<T>>;
         static_assert(std::is_enum_v<std::decay_t<T>>, "T must be an enum type");
 
-        static std::underlying_type_t<T> ToUnderlying(T value)
+        static Type ToUnderlying(T value)
         {
-            return static_cast<std::underlying_type_t<T>>(value);
+            return static_cast<Type>(value);
         }
     };
 }

--- a/infra/util/LogAndAbort.hpp
+++ b/infra/util/LogAndAbort.hpp
@@ -12,16 +12,23 @@ namespace
     struct LogAndAbortEnumOrIntegralType
     {
         using Type = T;
+
+        static Type ToUnderlying(T value)
+        {
+            return static_cast<Type>(value);
+        }
     };
 
     template<class T>
     struct LogAndAbortEnumOrIntegralType<T, true>
     {
         using Type = std::underlying_type_t<T>;
-    };
 
-    template<class T>
-    using LogAndAbortEnumOrIntegralTypeT = typename LogAndAbortEnumOrIntegralType<T>::Type;
+        static Type ToUnderlying(T value)
+        {
+            return static_cast<Type>(value);
+        }
+    };
 }
 
 namespace infra
@@ -79,28 +86,14 @@ namespace infra
     do                                                                                                                                                                                        \
     {                                                                                                                                                                                         \
         static_assert(std::is_enum_v<std::decay_t<decltype(value)>> || std::is_integral_v<std::decay_t<decltype(value)>>, "LOG_AND_ABORT_ENUM can only be used with enum or integral types"); \
-        using LogAndAbortValueType = LogAndAbortEnumOrIntegralTypeT<std::decay_t<decltype(value)>>;                                                                                           \
-        if constexpr (std::is_enum_v<std::decay_t<decltype(value)>>)                                                                                                                          \
+        auto underlyingValue = LogAndAbortEnumOrIntegralType<std::decay_t<decltype(value)>>::ToUnderlying(value);                                                                             \
+        if constexpr (std::is_signed_v<decltype(underlyingValue)>)                                                                                                                            \
         {                                                                                                                                                                                     \
-            if constexpr (std::is_signed_v<LogAndAbortValueType>)                                                                                                                             \
-            {                                                                                                                                                                                 \
-                LOG_AND_ABORT("Unexpected enum: %lld", static_cast<long long>(static_cast<LogAndAbortValueType>(value)));                                                                     \
-            }                                                                                                                                                                                 \
-            else                                                                                                                                                                              \
-            {                                                                                                                                                                                 \
-                LOG_AND_ABORT("Unexpected enum: %llu", static_cast<unsigned long long>(static_cast<LogAndAbortValueType>(value)));                                                            \
-            }                                                                                                                                                                                 \
+            LOG_AND_ABORT("Unexpected enum: %lld", static_cast<long long>(underlyingValue));                                                                                                  \
         }                                                                                                                                                                                     \
-        else if constexpr (std::is_integral_v<std::decay_t<decltype(value)>>)                                                                                                                 \
+        else                                                                                                                                                                                  \
         {                                                                                                                                                                                     \
-            if constexpr (std::is_signed_v<LogAndAbortValueType>)                                                                                                                             \
-            {                                                                                                                                                                                 \
-                LOG_AND_ABORT("Unexpected integral: %lld", static_cast<long long>(value));                                                                                                    \
-            }                                                                                                                                                                                 \
-            else                                                                                                                                                                              \
-            {                                                                                                                                                                                 \
-                LOG_AND_ABORT("Unexpected integral: %llu", static_cast<unsigned long long>(value));                                                                                           \
-            }                                                                                                                                                                                 \
+            LOG_AND_ABORT("Unexpected enum: %llu", static_cast<unsigned long long>(underlyingValue));                                                                                         \
         }                                                                                                                                                                                     \
     } while (0)
 

--- a/infra/util/test/TestLogAndAbort.cpp
+++ b/infra/util/test/TestLogAndAbort.cpp
@@ -105,3 +105,12 @@ TEST_F(LogAndAbortTest, log_and_abort_enum)
     };
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(TestEnumUnsigned::Value1), "");
 }
+
+TEST_F(LogAndAbortTest, log_and_abort_enum_accepts_integral_types)
+{
+    int foo = 42;
+    EXPECT_DEATH(LOG_AND_ABORT_ENUM(foo), "");
+
+    uint64_t bar = 99;
+    EXPECT_DEATH(LOG_AND_ABORT_ENUM(bar), "");
+}

--- a/infra/util/test/TestLogAndAbort.cpp
+++ b/infra/util/test/TestLogAndAbort.cpp
@@ -93,7 +93,7 @@ TEST_F(LogAndAbortTest, log_and_abort_enum)
 {
     enum class TestEnumSigned : int
     {
-        Value1,
+        Value1 = -1,
         Value2
     };
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(TestEnumSigned::Value1), "");

--- a/infra/util/test/TestLogAndAbort.cpp
+++ b/infra/util/test/TestLogAndAbort.cpp
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 #include <array>
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 
 namespace

--- a/infra/util/test/TestLogAndAbort.cpp
+++ b/infra/util/test/TestLogAndAbort.cpp
@@ -95,7 +95,7 @@ TEST_F(LogAndAbortTest, log_and_abort_enum)
     enum class TestEnumSigned : int
     {
         Value1 = -1,
-        Value2
+        Value2 = 1
     };
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(TestEnumSigned::Value1), "");
 
@@ -105,6 +105,8 @@ TEST_F(LogAndAbortTest, log_and_abort_enum)
         Value2
     };
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(TestEnumUnsigned::Value1), "");
+
+    static_assert(infra::detail::LogAndAbortEnumOrIntegralType<TestEnumUnsigned>::ToUnderlying(TestEnumUnsigned::Value1) == uint32_t(0));
 
     auto foo = TestEnumSigned::Value2;
     auto& bar = foo;
@@ -121,4 +123,6 @@ TEST_F(LogAndAbortTest, log_and_abort_enum_accepts_integral_types)
 
     uint64_t& baz = bar;
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(baz), "");
+
+    static_assert(infra::detail::LogAndAbortEnumOrIntegralType<std::decay_t<int>>::ToUnderlying(42) == int(42));
 }

--- a/infra/util/test/TestLogAndAbort.cpp
+++ b/infra/util/test/TestLogAndAbort.cpp
@@ -1,11 +1,11 @@
 #include "infra/util/LogAndAbort.hpp"
-#include "infra/util/test_helper/MockCallback.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <array>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <iostream>
 
 namespace
 {
@@ -105,6 +105,10 @@ TEST_F(LogAndAbortTest, log_and_abort_enum)
         Value2
     };
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(TestEnumUnsigned::Value1), "");
+
+    auto foo = TestEnumSigned::Value2;
+    auto& bar = foo;
+    EXPECT_DEATH(LOG_AND_ABORT_ENUM(bar), "");
 }
 
 TEST_F(LogAndAbortTest, log_and_abort_enum_accepts_integral_types)
@@ -114,4 +118,7 @@ TEST_F(LogAndAbortTest, log_and_abort_enum_accepts_integral_types)
 
     uint64_t bar = 99;
     EXPECT_DEATH(LOG_AND_ABORT_ENUM(bar), "");
+
+    uint64_t& baz = bar;
+    EXPECT_DEATH(LOG_AND_ABORT_ENUM(baz), "");
 }


### PR DESCRIPTION
We have the option to `LOG_AND_ABORT_ENUM` which previously only compiled for enums. However, many times the C drivers we are using don't use enum types and instead store the enums as integer types. In these case we could not use this abort, even though it would make sense.

So this PR changes the `LOG_AND_ABORT_ENUM` to also support integer types. It doesn't compile if a different type is given than enum or integer. And it deduces the underlying value during compilation using some template magic.