### PR TITLE
fix: disables tracer tests failing when compiled with EMIL_ENABLE_TRACING

### DIFF
--- a/services/tracer/CMakeLists.txt
+++ b/services/tracer/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_library(services.tracer ${EMIL_EXCLUDE_FROM_ALL} STATIC)
 
 if (EMIL_ENABLE_TRACING)
-    target_compile_definitions(services.tracer PUBLIC EMIL_ENABLE_TRACING=1)
+    target_compile_definitions(services.tracer PUBLIC EMBEDDED_INFRA_SERVICES_TRACER_ENABLED=1)
 else()
-    target_compile_definitions(services.tracer PUBLIC EMIL_DISABLE_TRACING=1)
+    target_compile_definitions(services.tracer PUBLIC EMBEDDED_INFRA_SERVICES_TRACER_DISABLED=1)
 endif()
 
 target_link_libraries(services.tracer PUBLIC

--- a/services/tracer/Tracer.cpp
+++ b/services/tracer/Tracer.cpp
@@ -2,14 +2,14 @@
 
 namespace services
 {
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
     infra::TextOutputStream Tracer::Trace()
     {
         StartTrace();
         InsertHeader();
         return Continue();
     }
-#elif defined(EMIL_DISABLE_TRACING)
+#elif defined(EMBEDDED_INFRA_SERVICES_TRACER_DISABLED)
     Tracer::EmptyTracing Tracer::Trace()
     {
         return emptyTracing;
@@ -33,7 +33,7 @@ namespace services
         : stream(stream)
     {}
 
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
     infra::TextOutputStream TracerToStream::Continue()
     {
         return stream;
@@ -44,7 +44,7 @@ namespace services
         : delegate(delegate)
     {}
 
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
     infra::TextOutputStream TracerToDelegate::Continue()
     {
         return delegate.Continue();

--- a/services/tracer/Tracer.hpp
+++ b/services/tracer/Tracer.hpp
@@ -15,10 +15,10 @@ namespace services
         Tracer& operator=(const Tracer& other) = delete;
         virtual ~Tracer() = default;
 
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
         infra::TextOutputStream Trace();
         virtual infra::TextOutputStream Continue() = 0;
-#elif defined(EMIL_DISABLE_TRACING)
+#elif defined(EMBEDDED_INFRA_SERVICES_TRACER_DISABLED)
         class EmptyTracing
         {
         public:
@@ -65,7 +65,7 @@ namespace services
     public:
         explicit TracerToStream(infra::TextOutputStream& stream);
 
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
         infra::TextOutputStream Continue() override;
 #endif
 
@@ -79,7 +79,7 @@ namespace services
     public:
         explicit TracerToDelegate(Tracer& delegate);
 
-#if defined(EMIL_ENABLE_TRACING)
+#if defined(EMBEDDED_INFRA_SERVICES_TRACER_ENABLED)
         infra::TextOutputStream Continue() override;
 #endif
 

--- a/services/tracer/Tracer.hpp
+++ b/services/tracer/Tracer.hpp
@@ -49,7 +49,7 @@ namespace services
         infra::TextOutputStream::WithErrorPolicy dummyStream{ dummy };
         EmptyTracing emptyTracing{ dummyStream };
 #else
-#error no tracing option defined
+#error no tracing option defined. Are you sure you properly linked the tracer library?
 #endif
 
     protected:

--- a/services/tracer/test/CMakeLists.txt
+++ b/services/tracer/test/CMakeLists.txt
@@ -23,7 +23,7 @@ target_sources(services.tracer_test PRIVATE
 )
 
 add_library(services.tracer_disabled ${EMIL_EXCLUDE_FROM_ALL} STATIC)
-target_compile_definitions(services.tracer_disabled PUBLIC EMIL_DISABLE_TRACING=1)
+target_compile_definitions(services.tracer_disabled PUBLIC EMBEDDED_INFRA_SERVICES_TRACER_DISABLED=1)
 target_link_libraries(services.tracer_disabled PUBLIC
     infra.stream
 )


### PR DESCRIPTION
## What failed:
When the disabled tracer tests was built with `EMIL_ENABLE_TRACING` then that would take precedence in the code. This would happen when EMIL was pulled into some external builds. And cause the tests to fail.

This is a regression after https://github.com/philips-software/amp-embedded-infra-lib/pull/521

## Reasons
It's because the CMake option `EMIL_ENABLE_TRACING` leaks into the code itself. There's two different things that needs to happen, which was combined into a single variable
- CMake should tell the tracer library to enable tracing
- The library should change the code accodingly

This causes issues when not used correctly:
- For example parent library setting `compile_time_target` instead of `set(EMIL_ENABLE_TRACING On)`. This will currently result in unexpected behaviour, but with this fix it will do nothing.
- Some code including the `Tracer.hpp` header without linking the library. Previously this would be unexpected behaviour, but with this fix it won't compile.

## Fix

This PR separates these two things, which should resolve the issue.

It will still conform to the requirement of:
- If `EMIL_ENABLE_TRACING` is defined at all, then it will take precedence and the tracer will be enabled