### PR TITLE
ci: sonarcloud build fixes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,9 +37,11 @@ jobs:
           configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
         env:
           GTEST_OUTPUT: "xml:${{ github.workspace }}/testresults/"
+
       - name: Collect coverage
         run: |
-          gcovr --sonarqube=coverage.xml --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort\(\);' --exclude-unreachable-branches --exclude-throw-branches -j "$(nproc)" --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.*
+          gcovr --sonarqube=coverage.xml --merge-mode-functions=separate --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort\(\);' --exclude-unreachable-branches --exclude-throw-branches -j "$(nproc)" --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.*
+          
       - name: Perform mutation testing
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Collect coverage
         run: |
           gcovr --sonarqube=coverage.xml --merge-mode-functions=separate --exclude-lines-by-pattern '.*assert\(.*\);|.*really_assert\(.*\);|.*std::abort\(\);' --exclude-unreachable-branches --exclude-throw-branches -j "$(nproc)" --exclude=.*/generated/.* --exclude=.*/examples/.* --exclude=.*/external/.* --exclude=.*/lwip/.* --exclude=.*/tracing/.*
-          
       - name: Perform mutation testing
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,7 +63,7 @@
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
         "EMIL_ENABLE_MUTATION_TESTING": "On",
-        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--allow-surviving;--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
+        "EMIL_MUTATION_TESTING_RUNNER_ARGUMENTS": "--allow-surviving;--timeout;10000;--reporters;Elements;--report-dir;${sourceDir}/reports/mull"
       },
       "generator": "Ninja"
     },


### PR DESCRIPTION
1. Use merge mode for coverage

This fixes an issue on SonarCloud build where one cpp file is present in two different libraries/test files

See https://github.com/philips-software/amp-embedded-infra-lib/actions/runs/25471086003/job/74734918361?pr=1190

gcovr.exceptions.GcovrMergeAssertionError: /__w/amp-embedded-infra-lib/amp-embedded-infra-lib/services/tracer/Tracer.cpp:6 Got function services::Tracer::Trace() on multiple lines: 6, 13.
	You can run gcovr with --merge-mode-functions=MERGE_MODE.
	The available values for MERGE_MODE are described in the documentation.

2. Increase timeout for mutation test execution

Default timeout is 3s. 
services.util_test has 2489 tests across 54 test suites and takes ~3.68 seconds to complete


