### PR TITLE
feat: adding displaypasskey to gapproto

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -429,6 +429,7 @@ service GapCentralResponse {
     rpc ResolvePrivateAddressFailed(Nothing) returns (Nothing) { option (method_id) = 9; }
     rpc DeviceBonded(BoolValue) returns (Nothing) { option (method_id) = 10; }
     rpc OutOfBandDataGenerated(OutOfBandData) returns (Nothing) { option (method_id) = 11; }
+    rpc DisplayPasskey(Passkey) returns (Nothing) { option (method_id) = 12; }
 }
 
 


### PR DESCRIPTION
for authenticated pairing w/ numaric comparison, we should be able to pass passkeys around