### PR TITLE
feat: add EcSecP256r1PublicKey

### DIFF
--- a/services/util/EchoPolicyDiffieHellman.hpp
+++ b/services/util/EchoPolicyDiffieHellman.hpp
@@ -16,7 +16,7 @@ namespace services
     struct CertificateAndPrivateKey
     {
         infra::BoundedVector<uint8_t>::WithMaxSize<512> certificate;
-        std::array<uint8_t, 121> privateKey;
+        EcSecP256r1PrivateKey::DerEncoded privateKey;
     };
 
     CertificateAndPrivateKey GenerateRootCertificate(hal::SynchronousRandomDataGenerator& randomDataGenerator);

--- a/services/util/SesameCryptoMbedTls.cpp
+++ b/services/util/SesameCryptoMbedTls.cpp
@@ -121,8 +121,32 @@ namespace services
         return { encodedR, encodedS };
     }
 
+    EcSecP256r1DsaVerifierMbedTls::EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaPublicKey)
+        : valid(true) // No verification of root certificate is performed when directly given a public key
+    {
+        mbedtls_ecp_group_init(&group);
+        really_assert(mbedtls_ecp_group_load(&group, MBEDTLS_ECP_DP_SECP256R1) == 0);
+
+        mbedtls_ecp_point_init(&publicKey);
+
+        mbedtls_ecp_group otherGroup;
+        mbedtls_mpi otherDsaPrivateKey;
+        mbedtls_ecp_group_init(&otherGroup);
+        mbedtls_mpi_init(&otherDsaPrivateKey);
+
+        mbedtls_pk_context publicKeyContext;
+        mbedtls_pk_init(&publicKeyContext);
+        really_assert(mbedtls_pk_parse_public_key(&publicKeyContext, dsaPublicKey.begin(), dsaPublicKey.size()) == 0);
+
+        really_assert(mbedtls_ecp_export(mbedtls_pk_ec(publicKeyContext), &otherGroup, &otherDsaPrivateKey, &publicKey) == 0);
+
+        mbedtls_mpi_free(&otherDsaPrivateKey);
+        mbedtls_ecp_group_free(&otherGroup);
+    }
+
     EcSecP256r1DsaVerifierMbedTls::EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaCertificate, infra::ConstByteRange rootCaCertificate)
     {
+        mbedtls_x509_crt rootCertificate;
         mbedtls_x509_crt_init(&rootCertificate);
         really_assert(mbedtls_x509_crt_parse(&rootCertificate, rootCaCertificate.begin(), rootCaCertificate.size()) == 0);
         really_assert(mbedtls_pk_get_type(&rootCertificate.pk) == MBEDTLS_PK_ECKEY);
@@ -154,13 +178,13 @@ namespace services
 
         mbedtls_mpi_free(&otherDsaPrivateKey);
         mbedtls_ecp_group_free(&otherGroup);
+        mbedtls_x509_crt_free(&rootCertificate);
     }
 
     EcSecP256r1DsaVerifierMbedTls::~EcSecP256r1DsaVerifierMbedTls()
     {
         mbedtls_ecp_point_free(&publicKey);
         mbedtls_ecp_group_free(&group);
-        mbedtls_x509_crt_free(&rootCertificate);
     }
 
     bool EcSecP256r1DsaVerifierMbedTls::Verify(infra::ConstByteRange data, infra::ConstByteRange signatureR, infra::ConstByteRange signatureS) const
@@ -317,6 +341,27 @@ namespace services
         infra::BoundedVector<uint8_t>::WithMaxSize<512> result(512, static_cast<uint8_t>(0));
         auto size = mbedtls_x509write_crt_der(&const_cast<mbedtls_x509write_cert&>(dsaCertificate), result.data(), result.size(), &services::MbedTlsRandomDataGeneratorWrapper, &randomDataGenerator);
         result.erase(result.begin(), result.begin() + result.size() - size);
+        return result;
+    }
+
+    EcSecP256r1PublicKey::EcSecP256r1PublicKey(const EcSecP256r1PrivateKey& privateKey, hal::SynchronousRandomDataGenerator& randomDataGenerator)
+    {
+        mbedtls_pk_init(&context);
+        really_assert(mbedtls_pk_setup(&context, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0);
+        auto key = privateKey.Der();
+        really_assert(mbedtls_pk_parse_key(&context, key.data(), key.size(), nullptr, 0, &services::MbedTlsRandomDataGeneratorWrapper, &randomDataGenerator) == 0);
+    }
+
+    EcSecP256r1PublicKey::~EcSecP256r1PublicKey()
+    {
+        mbedtls_pk_free(&context);
+    }
+
+    std::array<uint8_t, 91> EcSecP256r1PublicKey::Der() const
+    {
+        std::array<uint8_t, 91> result{};
+        auto size = mbedtls_pk_write_pubkey_der(&context, result.data(), result.size());
+        really_assert(size == result.size());
         return result;
     }
 }

--- a/services/util/SesameCryptoMbedTls.cpp
+++ b/services/util/SesameCryptoMbedTls.cpp
@@ -292,9 +292,9 @@ namespace services
         return result;
     }
 
-    std::array<uint8_t, 121> EcSecP256r1PrivateKey::Der() const
+    EcSecP256r1PrivateKey::DerEncoded EcSecP256r1PrivateKey::Der() const
     {
-        std::array<uint8_t, 121> result{};
+        DerEncoded result{};
         auto size = mbedtls_pk_write_key_der(&context, result.data(), result.size());
         really_assert(size == result.size());
         return result;
@@ -357,9 +357,9 @@ namespace services
         mbedtls_pk_free(&context);
     }
 
-    std::array<uint8_t, 91> EcSecP256r1PublicKey::Der() const
+    EcSecP256r1PublicKey::DerEncoded EcSecP256r1PublicKey::Der() const
     {
-        std::array<uint8_t, 91> result{};
+        DerEncoded result{};
         auto size = mbedtls_pk_write_pubkey_der(&context, result.data(), result.size());
         really_assert(size == result.size());
         return result;

--- a/services/util/SesameCryptoMbedTls.cpp
+++ b/services/util/SesameCryptoMbedTls.cpp
@@ -129,19 +129,19 @@ namespace services
 
         mbedtls_ecp_point_init(&publicKey);
 
-        mbedtls_ecp_group otherGroup;
-        mbedtls_mpi otherDsaPrivateKey;
-        mbedtls_ecp_group_init(&otherGroup);
-        mbedtls_mpi_init(&otherDsaPrivateKey);
+        mbedtls_ecp_group unusedGroup;
+        mbedtls_mpi unusedDsaPrivateKey;
+        mbedtls_ecp_group_init(&unusedGroup);
+        mbedtls_mpi_init(&unusedDsaPrivateKey);
 
         mbedtls_pk_context publicKeyContext;
         mbedtls_pk_init(&publicKeyContext);
         really_assert(mbedtls_pk_parse_public_key(&publicKeyContext, dsaPublicKey.begin(), dsaPublicKey.size()) == 0);
+        really_assert(mbedtls_ecp_export(mbedtls_pk_ec(publicKeyContext), &unusedGroup, &unusedDsaPrivateKey, &publicKey) == 0);
+        mbedtls_pk_free(&publicKeyContext);
 
-        really_assert(mbedtls_ecp_export(mbedtls_pk_ec(publicKeyContext), &otherGroup, &otherDsaPrivateKey, &publicKey) == 0);
-
-        mbedtls_mpi_free(&otherDsaPrivateKey);
-        mbedtls_ecp_group_free(&otherGroup);
+        mbedtls_mpi_free(&unusedDsaPrivateKey);
+        mbedtls_ecp_group_free(&unusedGroup);
     }
 
     EcSecP256r1DsaVerifierMbedTls::EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaCertificate, infra::ConstByteRange rootCaCertificate)
@@ -156,10 +156,10 @@ namespace services
 
         mbedtls_ecp_point_init(&publicKey);
 
-        mbedtls_ecp_group otherGroup;
-        mbedtls_mpi otherDsaPrivateKey;
-        mbedtls_ecp_group_init(&otherGroup);
-        mbedtls_mpi_init(&otherDsaPrivateKey);
+        mbedtls_ecp_group unusedGroup;
+        mbedtls_mpi unusedDsaPrivateKey;
+        mbedtls_ecp_group_init(&unusedGroup);
+        mbedtls_mpi_init(&unusedDsaPrivateKey);
 
         mbedtls_x509_crt certificate;
         mbedtls_x509_crt_init(&certificate);
@@ -172,12 +172,12 @@ namespace services
         mbedtls_md(mdInfo, certificate.tbs.p, certificate.tbs.len, hash.data());
         valid = mbedtls_pk_verify(&rootCertificate.pk, MBEDTLS_MD_SHA256, hash.data(), hash.size(), certificate.MBEDTLS_PRIVATE(sig).p, certificate.MBEDTLS_PRIVATE(sig).len) == 0;
 
-        really_assert(mbedtls_ecp_export(mbedtls_pk_ec(certificate.pk), &otherGroup, &otherDsaPrivateKey, &publicKey) == 0);
+        really_assert(mbedtls_ecp_export(mbedtls_pk_ec(certificate.pk), &unusedGroup, &unusedDsaPrivateKey, &publicKey) == 0);
 
         mbedtls_x509_crt_free(&certificate);
 
-        mbedtls_mpi_free(&otherDsaPrivateKey);
-        mbedtls_ecp_group_free(&otherGroup);
+        mbedtls_mpi_free(&unusedDsaPrivateKey);
+        mbedtls_ecp_group_free(&unusedGroup);
         mbedtls_x509_crt_free(&rootCertificate);
     }
 

--- a/services/util/SesameCryptoMbedTls.hpp
+++ b/services/util/SesameCryptoMbedTls.hpp
@@ -49,13 +49,13 @@ namespace services
         : public EcSecP256r1DsaVerifier
     {
     public:
+        EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaPublicKey);
         EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaCertificate, infra::ConstByteRange rootCaCertificate);
         ~EcSecP256r1DsaVerifierMbedTls();
 
         bool Verify(infra::ConstByteRange data, infra::ConstByteRange r, infra::ConstByteRange s) const override;
 
     private:
-        mbedtls_x509_crt rootCertificate;
         mbedtls_ecp_group group;
         mbedtls_ecp_point publicKey;
 
@@ -118,6 +118,20 @@ namespace services
     private:
         mbedtls_x509write_cert dsaCertificate;
         hal::SynchronousRandomDataGenerator& randomDataGenerator;
+    };
+
+    class EcSecP256r1PublicKey
+    {
+    public:
+        EcSecP256r1PublicKey(const EcSecP256r1PrivateKey& privateKey, hal::SynchronousRandomDataGenerator& randomDataGenerator);
+        EcSecP256r1PublicKey(const EcSecP256r1PublicKey& other) = delete;
+        EcSecP256r1PublicKey& operator=(const EcSecP256r1PublicKey& other) = delete;
+        ~EcSecP256r1PublicKey();
+
+        std::array<uint8_t, 91> Der() const;
+
+    private:
+        mbedtls_pk_context context;
     };
 }
 

--- a/services/util/SesameCryptoMbedTls.hpp
+++ b/services/util/SesameCryptoMbedTls.hpp
@@ -49,7 +49,7 @@ namespace services
         : public EcSecP256r1DsaVerifier
     {
     public:
-        EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaPublicKey);
+        explicit EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaPublicKey);
         EcSecP256r1DsaVerifierMbedTls(infra::ConstByteRange dsaCertificate, infra::ConstByteRange rootCaCertificate);
         ~EcSecP256r1DsaVerifierMbedTls();
 
@@ -90,6 +90,8 @@ namespace services
     class EcSecP256r1PrivateKey
     {
     public:
+        using DerEncoded = std::array<uint8_t, 121>;
+
         explicit EcSecP256r1PrivateKey(hal::SynchronousRandomDataGenerator& randomDataGenerator);
         explicit EcSecP256r1PrivateKey(infra::ConstByteRange key, hal::SynchronousRandomDataGenerator& randomDataGenerator);
         EcSecP256r1PrivateKey(const EcSecP256r1PrivateKey& other) = delete;
@@ -97,7 +99,7 @@ namespace services
         ~EcSecP256r1PrivateKey();
 
         infra::BoundedString::WithStorage<228> Pem() const;
-        std::array<uint8_t, 121> Der() const;
+        DerEncoded Der() const;
         const mbedtls_pk_context& Context() const;
 
     private:
@@ -123,12 +125,14 @@ namespace services
     class EcSecP256r1PublicKey
     {
     public:
+        using DerEncoded = std::array<uint8_t, 91>;
+
         EcSecP256r1PublicKey(const EcSecP256r1PrivateKey& privateKey, hal::SynchronousRandomDataGenerator& randomDataGenerator);
         EcSecP256r1PublicKey(const EcSecP256r1PublicKey& other) = delete;
         EcSecP256r1PublicKey& operator=(const EcSecP256r1PublicKey& other) = delete;
         ~EcSecP256r1PublicKey();
 
-        std::array<uint8_t, 91> Der() const;
+        DerEncoded Der() const;
 
     private:
         mbedtls_pk_context context;

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(services.util_test PRIVATE
     TestRepeatingButton.cpp
     TestSerialCommunicationLoopback.cpp
     TestSesameCobs.cpp
+    $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameCryptoMbedTls.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestSesameSecured.cpp>
     TestSesameWindowed.cpp
     TestSignalLed.cpp

--- a/services/util/test/TestEchoPolicyDiffieHellman.cpp
+++ b/services/util/test/TestEchoPolicyDiffieHellman.cpp
@@ -120,14 +120,14 @@ public:
     services::CertificateAndPrivateKey deviceCertificateMaterial{ services::GenerateDeviceCertificate(rootCaPrivateKey, randomDataGenerator) };
     services::EcSecP256r1PrivateKey privateKeyLeft{ randomDataGenerator };
     std::string privateKeyLeftPem{ infra::AsStdString(privateKeyLeft.Pem()) };
-    std::array<uint8_t, 121> privateKeyLeftDer{ privateKeyLeft.Der() };
+    services::EcSecP256r1PrivateKey::DerEncoded privateKeyLeftDer{ privateKeyLeft.Der() };
     services::EcSecP256r1Certificate certificateLeft{ privateKeyLeft, "CN=left", rootCaPrivateKey, "CN=Root", randomDataGenerator };
     std::string certificateLeftPem{ infra::AsStdString(certificateLeft.Pem()) };
     infra::BoundedVector<uint8_t>::WithMaxSize<512> certificateLeftDer{ certificateLeft.Der() };
 
     services::EcSecP256r1PrivateKey privateKeyRight{ randomDataGenerator };
     std::string privateKeyRightPem{ infra::AsStdString(privateKeyRight.Pem()) };
-    std::array<uint8_t, 121> privateKeyRightDer{ privateKeyRight.Der() };
+    services::EcSecP256r1PrivateKey::DerEncoded privateKeyRightDer{ privateKeyRight.Der() };
     services::EcSecP256r1Certificate certificateRight{ privateKeyRight, "CN=right", rootCaPrivateKey, "CN=Root", randomDataGenerator };
     std::string certificateRightPem{ infra::AsStdString(certificateRight.Pem()) };
     infra::BoundedVector<uint8_t>::WithMaxSize<512> certificateRightDer{ certificateRight.Der() };

--- a/services/util/test/TestSesameCryptoMbedTls.cpp
+++ b/services/util/test/TestSesameCryptoMbedTls.cpp
@@ -1,0 +1,47 @@
+#include "hal/generic/SynchronousRandomDataGeneratorGeneric.hpp"
+#include "services/util/SesameCryptoMbedTls.hpp"
+#include "gmock/gmock.h"
+
+class SesameCryptoMbedTlsPublicPrivateKeyTest
+    : public testing::Test
+{
+public:
+    hal::SynchronousRandomDataGeneratorGeneric randomDataGenerator;
+
+    services::EcSecP256r1PrivateKey privateKey{ randomDataGenerator };
+    services::EcSecP256r1PublicKey publicKey{ privateKey, randomDataGenerator };
+
+    services::EcSecP256r1DsaSignerMbedTls signer{ privateKey.Der(), randomDataGenerator };
+    services::EcSecP256r1DsaVerifierMbedTls verifier{ publicKey.Der() };
+};
+
+TEST_F(SesameCryptoMbedTlsPublicPrivateKeyTest, sign_and_verify)
+{
+    std::array<uint8_t, 4> data{ 1, 2, 3, 4 };
+    auto signature = signer.Sign(infra::MakeRange(data));
+    EXPECT_TRUE(verifier.Verify(infra::MakeRange(data), infra::MakeRange(signature.first), infra::MakeRange(signature.second)));
+}
+
+class SesameCryptoMbedTlsCertificateTest
+    : public testing::Test
+{
+public:
+    hal::SynchronousRandomDataGeneratorGeneric randomDataGenerator;
+
+    services::EcSecP256r1PrivateKey rootPrivateKey{ randomDataGenerator };
+    services::EcSecP256r1Certificate rootCertificate{ rootPrivateKey, "CN=root", rootPrivateKey, "CN=root", randomDataGenerator };
+    infra::BoundedVector<uint8_t>::WithMaxSize<512> rootCertificateDer{ rootCertificate.Der() };
+    services::EcSecP256r1PrivateKey privateKey{ randomDataGenerator };
+    services::EcSecP256r1Certificate certificate{ privateKey, "CN=subject", rootPrivateKey, "CN=issuer", randomDataGenerator };
+    infra::BoundedVector<uint8_t>::WithMaxSize<512> certificateDer{ certificate.Der() };
+
+    services::EcSecP256r1DsaSignerMbedTls signer{ privateKey.Der(), randomDataGenerator };
+    services::EcSecP256r1DsaVerifierMbedTls verifier{ infra::MakeRange(certificateDer), infra::MakeRange(rootCertificateDer) };
+};
+
+TEST_F(SesameCryptoMbedTlsCertificateTest, sign_and_verify)
+{
+    std::array<uint8_t, 4> data{ 1, 2, 3, 4 };
+    auto signature = signer.Sign(infra::MakeRange(data));
+    EXPECT_TRUE(verifier.Verify(infra::MakeRange(data), infra::MakeRange(signature.first), infra::MakeRange(signature.second)));
+}


### PR DESCRIPTION
## Pull request overview

This PR extends the Sesame Mbed TLS crypto utilities with support for exporting/consuming an EC secp256r1 public key in DER form, and adds unit tests to cover signing/verifying both with raw public keys and with certificates.

**Changes:**
- Added `services::EcSecP256r1PublicKey` for deriving/exporting a secp256r1 public key (DER) from a private key.
- Added an `EcSecP256r1DsaVerifierMbedTls` constructor overload that accepts a DER-encoded public key directly.
- Added Mbed TLS–gated unit tests for sign/verify flows using both a raw public key and a certificate chain.
