### PR TITLE
feat: add SmiBus interface, SmiPhy, and SmiPhyLinkMonitor

### DIFF
--- a/hal/interfaces/CMakeLists.txt
+++ b/hal/interfaces/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(hal.interfaces PRIVATE
     SerialCommunication.cpp
     SerialCommunication.hpp
     Sleepable.hpp
+    SmiBus.hpp
     Spi.cpp
     Spi.hpp
     UsbCustomHid.hpp

--- a/hal/interfaces/SmiBus.hpp
+++ b/hal/interfaces/SmiBus.hpp
@@ -1,0 +1,21 @@
+#ifndef HAL_SMI_BUS_HPP
+#define HAL_SMI_BUS_HPP
+
+#include <cstdint>
+
+namespace hal
+{
+    class SmiBus
+    {
+    public:
+        SmiBus() = default;
+        SmiBus(const SmiBus&) = delete;
+        SmiBus& operator=(const SmiBus&) = delete;
+        virtual ~SmiBus() = default;
+
+        virtual uint16_t Read(uint8_t phyAddress, uint16_t reg) const = 0;
+        virtual void Write(uint8_t phyAddress, uint16_t reg, uint16_t value) = 0;
+    };
+}
+
+#endif

--- a/hal/interfaces/SmiBus.hpp
+++ b/hal/interfaces/SmiBus.hpp
@@ -11,7 +11,7 @@ namespace hal
         SmiBus() = default;
         SmiBus(const SmiBus&) = delete;
         SmiBus& operator=(const SmiBus&) = delete;
-        SmiBus() = default;
+        ~SmiBus() = default;
 
     public:
         virtual uint16_t Read(uint8_t phyAddress, uint16_t reg) const = 0;

--- a/hal/interfaces/SmiBus.hpp
+++ b/hal/interfaces/SmiBus.hpp
@@ -7,12 +7,13 @@ namespace hal
 {
     class SmiBus
     {
-    public:
+    protected:
         SmiBus() = default;
         SmiBus(const SmiBus&) = delete;
         SmiBus& operator=(const SmiBus&) = delete;
-        virtual ~SmiBus() = default;
+        SmiBus() = default;
 
+    public:
         virtual uint16_t Read(uint8_t phyAddress, uint16_t reg) const = 0;
         virtual void Write(uint8_t phyAddress, uint16_t reg, uint16_t value) = 0;
     };

--- a/hal/interfaces/test_doubles/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(hal.interfaces_test_doubles PRIVATE
     SerialCommunicationStub.cpp
     SerialCommunicationStub.hpp
     SleepableMock.hpp
+    SmiBusMock.hpp
     SpiMock.cpp
     SpiMock.hpp
 )

--- a/hal/interfaces/test_doubles/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(hal.interfaces_test_doubles PRIVATE
     SerialCommunicationStub.hpp
     SleepableMock.hpp
     SmiBusMock.hpp
+    EthernetSmiObserverMock.hpp
     SpiMock.cpp
     SpiMock.hpp
 )

--- a/hal/interfaces/test_doubles/EthernetSmiObserverMock.hpp
+++ b/hal/interfaces/test_doubles/EthernetSmiObserverMock.hpp
@@ -10,9 +10,7 @@ namespace hal
         : public EthernetSmiObserver
     {
     public:
-        explicit EthernetSmiObserverMock(EthernetSmi& smi)
-            : EthernetSmiObserver(smi)
-        {}
+        using EthernetSmiObserver::EthernetSmiObserver;
 
         MOCK_METHOD(void, LinkUp, (LinkSpeed linkSpeed), (override));
         MOCK_METHOD(void, LinkDown, (), (override));

--- a/hal/interfaces/test_doubles/EthernetSmiObserverMock.hpp
+++ b/hal/interfaces/test_doubles/EthernetSmiObserverMock.hpp
@@ -1,0 +1,22 @@
+#ifndef HAL_ETHERNET_SMI_OBSERVER_MOCK_HPP
+#define HAL_ETHERNET_SMI_OBSERVER_MOCK_HPP
+
+#include "hal/interfaces/Ethernet.hpp"
+#include <gmock/gmock.h>
+
+namespace hal
+{
+    class EthernetSmiObserverMock
+        : public EthernetSmiObserver
+    {
+    public:
+        explicit EthernetSmiObserverMock(EthernetSmi& smi)
+            : EthernetSmiObserver(smi)
+        {}
+
+        MOCK_METHOD(void, LinkUp, (LinkSpeed linkSpeed), (override));
+        MOCK_METHOD(void, LinkDown, (), (override));
+    };
+}
+
+#endif

--- a/hal/interfaces/test_doubles/SmiBusMock.hpp
+++ b/hal/interfaces/test_doubles/SmiBusMock.hpp
@@ -1,0 +1,18 @@
+#ifndef HAL_SMI_BUS_MOCK_HPP
+#define HAL_SMI_BUS_MOCK_HPP
+
+#include "hal/interfaces/SmiBus.hpp"
+#include <gmock/gmock.h>
+
+namespace hal
+{
+    class SmiBusMock
+        : public SmiBus
+    {
+    public:
+        MOCK_METHOD(uint16_t, Read, (uint8_t phyAddress, uint16_t reg), (const override));
+        MOCK_METHOD(void, Write, (uint8_t phyAddress, uint16_t reg, uint16_t value), (override));
+    };
+}
+
+#endif

--- a/services/util/CMakeLists.txt
+++ b/services/util/CMakeLists.txt
@@ -84,6 +84,10 @@ target_sources(services.util PRIVATE
     SleepableFlashSpi.hpp
     SleepOnInactivityFlashDecorator.cpp
     SleepOnInactivityFlashDecorator.hpp
+    SmiPhy.cpp
+    SmiPhy.hpp
+    SmiPhyLinkMonitor.cpp
+    SmiPhyLinkMonitor.hpp
     SpiMasterWithChipSelect.cpp
     SpiMasterWithChipSelect.hpp
     SpiMultipleAccess.cpp

--- a/services/util/SmiPhy.cpp
+++ b/services/util/SmiPhy.cpp
@@ -1,0 +1,137 @@
+#include "services/util/SmiPhy.hpp"
+#include "infra/util/BitLogic.hpp"
+
+namespace services
+{
+    // BasicControlRegister
+
+    bool SmiPhy::BasicControlRegister::IsResetting(uint16_t bcr)
+    {
+        return infra::IsBitSet(bcr, ResetBit);
+    }
+
+    // BasicStatusRegister
+
+    bool SmiPhy::BasicStatusRegister::IsLinked(uint16_t bsr)
+    {
+        return (bsr & LinkStatusMask) != 0;
+    }
+
+    bool SmiPhy::BasicStatusRegister::IsResponding(uint16_t bsr)
+    {
+        return bsr != NotPresentValue;
+    }
+
+    bool SmiPhy::BasicStatusRegister::IsAutoNegCapable(uint16_t bsr)
+    {
+        return (bsr & AutoNegAbilityMask) != 0;
+    }
+
+    bool SmiPhy::BasicStatusRegister::IsAutoNegComplete(uint16_t bsr)
+    {
+        return (bsr & AutoNegCompleteMask) != 0;
+    }
+
+    bool SmiPhy::BasicStatusRegister::HasRemoteFault(uint16_t bsr)
+    {
+        return (bsr & RemoteFaultMask) != 0;
+    }
+
+    // SmiPhy
+
+    SmiPhy::SmiPhy(hal::SmiBus& smiBus, uint8_t phyAddress)
+        : smiBus_(smiBus)
+        , phyAddress_(phyAddress)
+    {}
+
+    uint16_t SmiPhy::ReadBcr() const
+    {
+        return Read(BasicControlRegister::Address);
+    }
+
+    void SmiPhy::WriteBcr(uint16_t value)
+    {
+        Write(BasicControlRegister::Address, value);
+    }
+
+    uint16_t SmiPhy::ReadBsr() const
+    {
+        return Read(BasicStatusRegister::Address);
+    }
+
+    hal::LinkSpeed SmiPhy::NegotiatedLinkSpeed() const
+    {
+        const uint16_t advertisement = Read(AutoNegRegister::AdvertisementAddress);
+        const uint16_t linkPartner = Read(AutoNegRegister::LinkPartnerAddress);
+        const uint16_t common = advertisement & linkPartner;
+
+        if (infra::IsBitSet(common, AutoNegRegister::FullDuplex100MHzBit))
+            return hal::LinkSpeed::fullDuplex100MHz;
+        else if (infra::IsBitSet(common, AutoNegRegister::HalfDuplex100MHzBit))
+            return hal::LinkSpeed::halfDuplex100MHz;
+        else if (infra::IsBitSet(common, AutoNegRegister::FullDuplex10MHzBit))
+            return hal::LinkSpeed::fullDuplex10MHz;
+        else
+            return hal::LinkSpeed::halfDuplex10MHz;
+    }
+
+    hal::LinkSpeed SmiPhy::LocalLinkSpeed(uint16_t bcr) const
+    {
+        const bool fast = infra::IsBitSet(bcr, BasicControlRegister::SpeedSelectLsbBit);
+        const bool full = infra::IsBitSet(bcr, BasicControlRegister::DuplexModeBit);
+
+        if (fast && full)
+            return hal::LinkSpeed::fullDuplex100MHz;
+        else if (fast && !full)
+            return hal::LinkSpeed::halfDuplex100MHz;
+        else if (!fast && full)
+            return hal::LinkSpeed::fullDuplex10MHz;
+        else
+            return hal::LinkSpeed::halfDuplex10MHz;
+    }
+
+    std::optional<SmiPhy::LinkState> SmiPhy::ReadLinkState()
+    {
+        const uint16_t bsr = ReadBsr();
+        if (!BasicStatusRegister::IsResponding(bsr))
+            return UpdateLinkState(false);
+        const uint16_t bcr = ReadBcr();
+        const bool autoNegEnabled = infra::IsBitSet(bcr, BasicControlRegister::AutoNegEnableBit);
+        const bool autoNegComplete = autoNegEnabled ? BasicStatusRegister::IsAutoNegComplete(bsr) : true;
+        const bool linked = BasicStatusRegister::IsLinked(bsr) && autoNegComplete;
+        return UpdateLinkState(linked);
+    }
+
+    void SmiPhy::EnableAutoNegIfCapable()
+    {
+        if (BasicStatusRegister::IsAutoNegCapable(ReadBsr()))
+            WriteBcr(infra::Bit<uint16_t>(BasicControlRegister::AutoNegEnableBit));
+    }
+
+    hal::LinkSpeed SmiPhy::LinkSpeed() const
+    {
+        const uint16_t bcr = ReadBcr();
+        if (infra::IsBitSet(bcr, BasicControlRegister::AutoNegEnableBit))
+            return NegotiatedLinkSpeed();
+        else
+            return LocalLinkSpeed(bcr);
+    }
+
+    std::optional<SmiPhy::LinkState> SmiPhy::UpdateLinkState(bool isLinked)
+    {
+        if (isLinked == linkUp_)
+            return std::nullopt;
+        linkUp_ = isLinked;
+        return isLinked ? LinkState::Up : LinkState::Down;
+    }
+
+    uint16_t SmiPhy::Read(uint16_t reg) const
+    {
+        return smiBus_.Read(phyAddress_, reg);
+    }
+
+    void SmiPhy::Write(uint16_t reg, uint16_t value)
+    {
+        smiBus_.Write(phyAddress_, reg, value);
+    }
+}

--- a/services/util/SmiPhy.cpp
+++ b/services/util/SmiPhy.cpp
@@ -40,8 +40,8 @@ namespace services
     // SmiPhy
 
     SmiPhy::SmiPhy(hal::SmiBus& smiBus, uint8_t phyAddress)
-        : smiBus_(smiBus)
-        , phyAddress_(phyAddress)
+        : smiBus(smiBus)
+        , phyAddress(phyAddress)
     {}
 
     uint16_t SmiPhy::ReadBcr() const
@@ -94,12 +94,12 @@ namespace services
     {
         const uint16_t bsr = ReadBsr();
         if (!BasicStatusRegister::IsResponding(bsr))
-            return UpdateLinkState(false);
+            return std::nullopt;
         const uint16_t bcr = ReadBcr();
         const bool autoNegEnabled = infra::IsBitSet(bcr, BasicControlRegister::AutoNegEnableBit);
         const bool autoNegComplete = autoNegEnabled ? BasicStatusRegister::IsAutoNegComplete(bsr) : true;
         const bool linked = BasicStatusRegister::IsLinked(bsr) && autoNegComplete;
-        return UpdateLinkState(linked);
+        return linked ? std::optional<LinkState>(LinkState::Up) : std::optional<LinkState>(LinkState::Down);
     }
 
     void SmiPhy::EnableAutoNegIfCapable()
@@ -120,21 +120,13 @@ namespace services
             return LocalLinkSpeed(bcr);
     }
 
-    std::optional<SmiPhy::LinkState> SmiPhy::UpdateLinkState(bool isLinked)
-    {
-        if (isLinked == linkUp_)
-            return std::nullopt;
-        linkUp_ = isLinked;
-        return isLinked ? LinkState::Up : LinkState::Down;
-    }
-
     uint16_t SmiPhy::Read(uint16_t reg) const
     {
-        return smiBus_.Read(phyAddress_, reg);
+        return smiBus.Read(phyAddress, reg);
     }
 
     void SmiPhy::Write(uint16_t reg, uint16_t value)
     {
-        smiBus_.Write(phyAddress_, reg, value);
+        smiBus.Write(phyAddress, reg, value);
     }
 }

--- a/services/util/SmiPhy.cpp
+++ b/services/util/SmiPhy.cpp
@@ -90,16 +90,16 @@ namespace services
             return hal::LinkSpeed::halfDuplex10MHz;
     }
 
-    std::optional<SmiPhy::LinkState> SmiPhy::ReadLinkState()
+    SmiPhy::LinkState SmiPhy::ReadLinkState()
     {
         const uint16_t bsr = ReadBsr();
         if (!BasicStatusRegister::IsResponding(bsr))
-            return std::nullopt;
+            return LinkState::Down;
+
         const uint16_t bcr = ReadBcr();
         const bool autoNegEnabled = infra::IsBitSet(bcr, BasicControlRegister::AutoNegEnableBit);
         const bool autoNegComplete = autoNegEnabled ? BasicStatusRegister::IsAutoNegComplete(bsr) : true;
-        const bool linked = BasicStatusRegister::IsLinked(bsr) && autoNegComplete;
-        return linked ? std::optional<LinkState>(LinkState::Up) : std::optional<LinkState>(LinkState::Down);
+        return BasicStatusRegister::IsLinked(bsr) && autoNegComplete ? LinkState::Up : LinkState::Down;
     }
 
     void SmiPhy::EnableAutoNegIfCapable()

--- a/services/util/SmiPhy.cpp
+++ b/services/util/SmiPhy.cpp
@@ -104,7 +104,11 @@ namespace services
 
     void SmiPhy::EnableAutoNegIfCapable()
     {
-        if (BasicStatusRegister::IsAutoNegCapable(ReadBsr()))
+        const uint16_t bsr = ReadBsr();
+        if (!BasicStatusRegister::IsResponding(bsr))
+            return;
+
+        if (BasicStatusRegister::IsAutoNegCapable(bsr))
         {
             const uint16_t bcr = ReadBcr();
             WriteBcr(bcr | infra::Bit<uint16_t>(BasicControlRegister::AutoNegEnableBit));

--- a/services/util/SmiPhy.cpp
+++ b/services/util/SmiPhy.cpp
@@ -105,7 +105,10 @@ namespace services
     void SmiPhy::EnableAutoNegIfCapable()
     {
         if (BasicStatusRegister::IsAutoNegCapable(ReadBsr()))
-            WriteBcr(infra::Bit<uint16_t>(BasicControlRegister::AutoNegEnableBit));
+        {
+            const uint16_t bcr = ReadBcr();
+            WriteBcr(bcr | infra::Bit<uint16_t>(BasicControlRegister::AutoNegEnableBit));
+        }
     }
 
     hal::LinkSpeed SmiPhy::LinkSpeed() const

--- a/services/util/SmiPhy.hpp
+++ b/services/util/SmiPhy.hpp
@@ -82,13 +82,13 @@ namespace services
     private:
         hal::LinkSpeed NegotiatedLinkSpeed() const;
         hal::LinkSpeed LocalLinkSpeed(uint16_t bcr) const;
-        std::optional<LinkState> UpdateLinkState(bool isLinked);
         uint16_t Read(uint16_t reg) const;
         void Write(uint16_t reg, uint16_t value);
 
-        hal::SmiBus& smiBus_;
-        uint8_t phyAddress_;
-        bool linkUp_ = false;
+    private:
+        hal::SmiBus& smiBus;
+        uint8_t phyAddress;
+        bool linkUp = false;
     };
 }
 

--- a/services/util/SmiPhy.hpp
+++ b/services/util/SmiPhy.hpp
@@ -9,7 +9,8 @@ namespace services
 {
     // Wraps a single IEEE 802.3 PHY accessible over a SmiBus.
     // Owns all register address and bit-field knowledge for standard PHY
-    // registers (BCR, BSR, ANLPA, ANLPAR) and tracks link state changes.
+    // registers (BCR, BSR, Advertisement, Link Partner Ability) and tracks
+    // link state changes.
     class SmiPhy
     {
     public:

--- a/services/util/SmiPhy.hpp
+++ b/services/util/SmiPhy.hpp
@@ -9,8 +9,8 @@ namespace services
 {
     // Wraps a single IEEE 802.3 PHY accessible over a SmiBus.
     // Owns all register address and bit-field knowledge for standard PHY
-    // registers (BCR, BSR, Advertisement, Link Partner Ability) and tracks
-    // link state changes.
+    // registers (BCR, BSR, Advertisement, Link Partner Ability), and reads
+    // and derives the current link state from those registers.
     class SmiPhy
     {
     public:

--- a/services/util/SmiPhy.hpp
+++ b/services/util/SmiPhy.hpp
@@ -1,0 +1,95 @@
+#ifndef SERVICES_SMI_PHY_HPP
+#define SERVICES_SMI_PHY_HPP
+
+#include "hal/interfaces/Ethernet.hpp"
+#include "hal/interfaces/SmiBus.hpp"
+#include <cstdint>
+#include <optional>
+
+namespace services
+{
+    // Wraps a single IEEE 802.3 PHY accessible over a SmiBus.
+    // Owns all register address and bit-field knowledge for standard PHY
+    // registers (BCR, BSR, ANLPA, ANLPAR) and tracks link state changes.
+    class SmiPhy
+    {
+    public:
+        // IEEE 802.3 Basic Control Register (register 0) bit positions.
+        struct BasicControlRegister
+        {
+            static constexpr uint16_t Address = 0u;
+            static constexpr uint16_t DuplexModeBit = 8u;
+            static constexpr uint16_t RestartAutoNegBit = 9u;
+            static constexpr uint16_t AutoNegEnableBit = 12u;
+            static constexpr uint16_t SpeedSelectLsbBit = 13u;
+            static constexpr uint16_t ResetBit = 15u;
+
+            static bool IsResetting(uint16_t bcr);
+        };
+
+        // IEEE 802.3 Basic Status Register (register 1) bit masks.
+        struct BasicStatusRegister
+        {
+            static constexpr uint16_t Address = 1u;
+            static constexpr uint16_t LinkStatusMask = 0x0004u;      // bit 2
+            static constexpr uint16_t AutoNegAbilityMask = 0x0008u;  // bit 3
+            static constexpr uint16_t RemoteFaultMask = 0x0010u;     // bit 4
+            static constexpr uint16_t AutoNegCompleteMask = 0x0020u; // bit 5
+            static constexpr uint16_t NotPresentValue = 0xFFFFu;
+
+            static bool IsLinked(uint16_t bsr);
+            static bool IsResponding(uint16_t bsr);
+            static bool IsAutoNegCapable(uint16_t bsr);
+            static bool IsAutoNegComplete(uint16_t bsr);
+            static bool HasRemoteFault(uint16_t bsr);
+        };
+
+        // IEEE 802.3 Auto-Negotiation Advertisement / Link Partner Ability
+        // registers (4 and 5) share the same bit layout.
+        struct AutoNegRegister
+        {
+            static constexpr uint16_t AdvertisementAddress = 4u;
+            static constexpr uint16_t LinkPartnerAddress = 5u;
+            static constexpr uint16_t HalfDuplex10MHzBit = 5u;
+            static constexpr uint16_t FullDuplex10MHzBit = 6u;
+            static constexpr uint16_t HalfDuplex100MHzBit = 7u;
+            static constexpr uint16_t FullDuplex100MHzBit = 8u;
+        };
+
+        enum class LinkState
+        {
+            Up,
+            Down,
+        };
+
+        SmiPhy(hal::SmiBus& smiBus, uint8_t phyAddress);
+
+        uint16_t ReadBcr() const;
+        void WriteBcr(uint16_t value);
+        uint16_t ReadBsr() const;
+
+        // Read BSR, check whether autoneg has completed (via BCR), and return
+        // the link state transition if any. Returns nullopt when unchanged.
+        std::optional<LinkState> ReadLinkState();
+
+        // If the PHY advertises autoneg capability, enable it via BCR.
+        void EnableAutoNegIfCapable();
+
+        // Returns the current link speed, reading BCR to decide between
+        // negotiated and locally-configured speed.
+        hal::LinkSpeed LinkSpeed() const;
+
+    private:
+        hal::LinkSpeed NegotiatedLinkSpeed() const;
+        hal::LinkSpeed LocalLinkSpeed(uint16_t bcr) const;
+        std::optional<LinkState> UpdateLinkState(bool isLinked);
+        uint16_t Read(uint16_t reg) const;
+        void Write(uint16_t reg, uint16_t value);
+
+        hal::SmiBus& smiBus_;
+        uint8_t phyAddress_;
+        bool linkUp_ = false;
+    };
+}
+
+#endif

--- a/services/util/SmiPhy.hpp
+++ b/services/util/SmiPhy.hpp
@@ -4,7 +4,6 @@
 #include "hal/interfaces/Ethernet.hpp"
 #include "hal/interfaces/SmiBus.hpp"
 #include <cstdint>
-#include <optional>
 
 namespace services
 {
@@ -69,8 +68,8 @@ namespace services
         uint16_t ReadBsr() const;
 
         // Read BSR, check whether autoneg has completed (via BCR), and return
-        // the link state transition if any. Returns nullopt when unchanged.
-        std::optional<LinkState> ReadLinkState();
+        // the current link state.
+        LinkState ReadLinkState();
 
         // If the PHY advertises autoneg capability, enable it via BCR.
         void EnableAutoNegIfCapable();
@@ -88,7 +87,6 @@ namespace services
     private:
         hal::SmiBus& smiBus;
         uint8_t phyAddress;
-        bool linkUp = false;
     };
 }
 

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -20,9 +20,16 @@ namespace services
     void SmiPhyLinkMonitor::PollPort()
     {
         const auto linkState = phy.ReadLinkState();
-        if (linkState == SmiPhy::LinkState::Up && HasObserver())
+        if (linkState == lastReportedState)
+            return;
+
+        lastReportedState = linkState;
+        if (!HasObserver())
+            return;
+
+        if (linkState == SmiPhy::LinkState::Up)
             GetObserver().LinkUp(phy.LinkSpeed());
-        else if (linkState == SmiPhy::LinkState::Down && HasObserver())
+        else
             GetObserver().LinkDown();
     }
 }

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -3,10 +3,10 @@
 namespace services
 {
     SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t phyAddress, infra::Duration pollInterval)
-        : phyAddress_(phyAddress)
-        , phy_(smi, phyAddress_)
+        : phyAddress(phyAddress)
+        , phy(smi, phyAddress)
     {
-        pollingTimer_.Start(pollInterval, [this]
+        pollingTimer.Start(pollInterval, [this]
             {
                 PollPort();
             });
@@ -14,14 +14,14 @@ namespace services
 
     uint16_t SmiPhyLinkMonitor::PhyAddress() const
     {
-        return phyAddress_;
+        return phyAddress;
     }
 
     void SmiPhyLinkMonitor::PollPort()
     {
-        const auto linkState = phy_.ReadLinkState();
+        const auto linkState = phy.ReadLinkState();
         if (linkState == SmiPhy::LinkState::Up && HasObserver())
-            GetObserver().LinkUp(phy_.LinkSpeed());
+            GetObserver().LinkUp(phy.LinkSpeed());
         else if (linkState == SmiPhy::LinkState::Down && HasObserver())
             GetObserver().LinkDown();
     }

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -2,9 +2,9 @@
 
 namespace services
 {
-    SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t vphyAddress, uint8_t portPhyAddress, infra::Duration pollInterval)
-        : vphyAddress_(vphyAddress)
-        , phy_(smi, portPhyAddress)
+    SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t portPhyAddress, infra::Duration pollInterval)
+        : phyAddress_(portPhyAddress)
+        , phy_(smi, phyAddress_)
     {
         pollingTimer_.Start(pollInterval, [this]
             {
@@ -14,7 +14,7 @@ namespace services
 
     uint16_t SmiPhyLinkMonitor::PhyAddress() const
     {
-        return vphyAddress_;
+        return phyAddress_;
     }
 
     void SmiPhyLinkMonitor::PollPort()

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -1,4 +1,5 @@
 #include "services/util/SmiPhyLinkMonitor.hpp"
+#include "infra/util/ReallyAssert.hpp"
 
 namespace services
 {
@@ -6,6 +7,7 @@ namespace services
         : phyAddress(phyAddress)
         , phy(smi, phyAddress)
     {
+        really_assert(pollInterval > infra::Duration{});
         pollingTimer.Start(pollInterval, [this]
             {
                 PollPort();

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -2,8 +2,8 @@
 
 namespace services
 {
-    SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t portPhyAddress, infra::Duration pollInterval)
-        : phyAddress_(portPhyAddress)
+    SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t phyAddress, infra::Duration pollInterval)
+        : phyAddress_(phyAddress)
         , phy_(smi, phyAddress_)
     {
         pollingTimer_.Start(pollInterval, [this]
@@ -21,7 +21,7 @@ namespace services
     {
         const auto linkState = phy_.ReadLinkState();
         if (linkState == SmiPhy::LinkState::Up && HasObserver())
-            GetObserver().LinkUp(hal::LinkSpeed::fullDuplex100MHz);
+            GetObserver().LinkUp(phy_.LinkSpeed());
         else if (linkState == SmiPhy::LinkState::Down && HasObserver())
             GetObserver().LinkDown();
     }

--- a/services/util/SmiPhyLinkMonitor.cpp
+++ b/services/util/SmiPhyLinkMonitor.cpp
@@ -1,0 +1,28 @@
+#include "services/util/SmiPhyLinkMonitor.hpp"
+
+namespace services
+{
+    SmiPhyLinkMonitor::SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t vphyAddress, uint8_t portPhyAddress, infra::Duration pollInterval)
+        : vphyAddress_(vphyAddress)
+        , phy_(smi, portPhyAddress)
+    {
+        pollingTimer_.Start(pollInterval, [this]
+            {
+                PollPort();
+            });
+    }
+
+    uint16_t SmiPhyLinkMonitor::PhyAddress() const
+    {
+        return vphyAddress_;
+    }
+
+    void SmiPhyLinkMonitor::PollPort()
+    {
+        const auto linkState = phy_.ReadLinkState();
+        if (linkState == SmiPhy::LinkState::Up && HasObserver())
+            GetObserver().LinkUp(hal::LinkSpeed::fullDuplex100MHz);
+        else if (linkState == SmiPhy::LinkState::Down && HasObserver())
+            GetObserver().LinkDown();
+    }
+}

--- a/services/util/SmiPhyLinkMonitor.hpp
+++ b/services/util/SmiPhyLinkMonitor.hpp
@@ -14,7 +14,7 @@ namespace services
         : public hal::EthernetSmi
     {
     public:
-        SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t portPhyAddress, infra::Duration pollInterval = std::chrono::milliseconds{ 200 });
+        SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t phyAddress, infra::Duration pollInterval = std::chrono::milliseconds{ 200 });
 
         uint16_t PhyAddress() const override;
 

--- a/services/util/SmiPhyLinkMonitor.hpp
+++ b/services/util/SmiPhyLinkMonitor.hpp
@@ -25,6 +25,7 @@ namespace services
         uint8_t phyAddress;
         SmiPhy phy;
         infra::TimerRepeating pollingTimer;
+        SmiPhy::LinkState lastReportedState = SmiPhy::LinkState::Down;
     };
 }
 

--- a/services/util/SmiPhyLinkMonitor.hpp
+++ b/services/util/SmiPhyLinkMonitor.hpp
@@ -1,0 +1,34 @@
+#ifndef SERVICES_SMI_PHY_LINK_MONITOR_HPP
+#define SERVICES_SMI_PHY_LINK_MONITOR_HPP
+
+#include "hal/interfaces/Ethernet.hpp"
+#include "hal/interfaces/SmiBus.hpp"
+#include "infra/timer/Timer.hpp"
+#include "services/util/SmiPhy.hpp"
+#include <chrono>
+#include <cstdint>
+
+namespace services
+{
+    // Polls a single SMI-accessible port PHY at a fixed interval and exposes the
+    // link state via the hal::EthernetSmi observer interface.
+    // PhyAddress() returns the virtual PHY address (VPHY) used by the MAC-side
+    // RMII connection, not the polled port PHY address.
+    class SmiPhyLinkMonitor
+        : public hal::EthernetSmi
+    {
+    public:
+        SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t vphyAddress, uint8_t portPhyAddress, infra::Duration pollInterval = std::chrono::milliseconds{ 200 });
+
+        uint16_t PhyAddress() const override;
+
+    private:
+        void PollPort();
+
+        uint8_t vphyAddress_;
+        SmiPhy phy_;
+        infra::TimerRepeating pollingTimer_;
+    };
+}
+
+#endif

--- a/services/util/SmiPhyLinkMonitor.hpp
+++ b/services/util/SmiPhyLinkMonitor.hpp
@@ -10,22 +10,18 @@
 
 namespace services
 {
-    // Polls a single SMI-accessible port PHY at a fixed interval and exposes the
-    // link state via the hal::EthernetSmi observer interface.
-    // PhyAddress() returns the virtual PHY address (VPHY) used by the MAC-side
-    // RMII connection, not the polled port PHY address.
     class SmiPhyLinkMonitor
         : public hal::EthernetSmi
     {
     public:
-        SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t vphyAddress, uint8_t portPhyAddress, infra::Duration pollInterval = std::chrono::milliseconds{ 200 });
+        SmiPhyLinkMonitor(hal::SmiBus& smi, uint8_t portPhyAddress, infra::Duration pollInterval = std::chrono::milliseconds{ 200 });
 
         uint16_t PhyAddress() const override;
 
     private:
         void PollPort();
 
-        uint8_t vphyAddress_;
+        uint8_t phyAddress_;
         SmiPhy phy_;
         infra::TimerRepeating pollingTimer_;
     };

--- a/services/util/SmiPhyLinkMonitor.hpp
+++ b/services/util/SmiPhyLinkMonitor.hpp
@@ -21,9 +21,10 @@ namespace services
     private:
         void PollPort();
 
-        uint8_t phyAddress_;
-        SmiPhy phy_;
-        infra::TimerRepeating pollingTimer_;
+    private:
+        uint8_t phyAddress;
+        SmiPhy phy;
+        infra::TimerRepeating pollingTimer;
     };
 }
 

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -50,6 +50,8 @@ target_sources(services.util_test PRIVATE
     TestSleepOnInactivityFlashDecorator.cpp
     TestSpiMasterWithChipSelect.cpp
     TestSpiMultipleAccess.cpp
+    TestSmiPhy.cpp
+    TestSmiPhyLinkMonitor.cpp
     TestTerminal.cpp
     TestTimeWithLocalization.cpp
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestWritableConfiguration.cpp>

--- a/services/util/test/TestSmiPhy.cpp
+++ b/services/util/test/TestSmiPhy.cpp
@@ -1,0 +1,294 @@
+#include "hal/interfaces/test_doubles/SmiBusMock.hpp"
+#include "services/util/SmiPhy.hpp"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace testing;
+using namespace services;
+using namespace hal;
+
+namespace
+{
+    static constexpr uint8_t phyAddress = 5;
+
+    // Bit helpers (matches register layout in SmiPhy.hpp)
+    static constexpr uint16_t bcrAutoNegEnable = static_cast<uint16_t>(1u << SmiPhy::BasicControlRegister::AutoNegEnableBit);
+    static constexpr uint16_t bcrSpeedSelectLsb = static_cast<uint16_t>(1u << SmiPhy::BasicControlRegister::SpeedSelectLsbBit);
+    static constexpr uint16_t bcrDuplexMode = static_cast<uint16_t>(1u << SmiPhy::BasicControlRegister::DuplexModeBit);
+    static constexpr uint16_t bcrReset = static_cast<uint16_t>(1u << SmiPhy::BasicControlRegister::ResetBit);
+
+    static constexpr uint16_t bsrLinked = SmiPhy::BasicStatusRegister::LinkStatusMask;
+    static constexpr uint16_t bsrAutoNegCapable = SmiPhy::BasicStatusRegister::AutoNegAbilityMask;
+    static constexpr uint16_t bsrAutoNegComplete = SmiPhy::BasicStatusRegister::AutoNegCompleteMask;
+    static constexpr uint16_t bsrNotPresent = SmiPhy::BasicStatusRegister::NotPresentValue;
+
+    static constexpr uint16_t anegFullDuplex100 = static_cast<uint16_t>(1u << SmiPhy::AutoNegRegister::FullDuplex100MHzBit);
+    static constexpr uint16_t anegHalfDuplex100 = static_cast<uint16_t>(1u << SmiPhy::AutoNegRegister::HalfDuplex100MHzBit);
+    static constexpr uint16_t anegFullDuplex10 = static_cast<uint16_t>(1u << SmiPhy::AutoNegRegister::FullDuplex10MHzBit);
+    static constexpr uint16_t anegHalfDuplex10 = static_cast<uint16_t>(1u << SmiPhy::AutoNegRegister::HalfDuplex10MHzBit);
+}
+
+class SmiPhyTest
+    : public ::testing::Test
+{
+protected:
+    StrictMock<SmiBusMock> smi;
+    SmiPhy phy{ smi, phyAddress };
+};
+
+// ---- BasicControlRegister static helpers -----------------------------------
+
+TEST(SmiPhyBasicControlRegisterTest, IsResettingReturnsTrueWhenResetBitSet)
+{
+    EXPECT_TRUE(SmiPhy::BasicControlRegister::IsResetting(bcrReset));
+}
+
+TEST(SmiPhyBasicControlRegisterTest, IsResettingReturnsFalseWhenResetBitClear)
+{
+    EXPECT_FALSE(SmiPhy::BasicControlRegister::IsResetting(0));
+}
+
+// ---- BasicStatusRegister static helpers ------------------------------------
+
+TEST(SmiPhyBasicStatusRegisterTest, IsLinkedReturnsTrueWhenLinkBitSet)
+{
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsLinked(bsrLinked));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsLinkedReturnsFalseWhenLinkBitClear)
+{
+    EXPECT_FALSE(SmiPhy::BasicStatusRegister::IsLinked(0));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsRespondingReturnsFalseFor0xFFFF)
+{
+    EXPECT_FALSE(SmiPhy::BasicStatusRegister::IsResponding(bsrNotPresent));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsRespondingReturnsTrueForOtherValues)
+{
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsResponding(0));
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsResponding(bsrLinked));
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsResponding(0xFFFEu));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsAutoNegCapableReturnsTrueWhenBitSet)
+{
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsAutoNegCapable(bsrAutoNegCapable));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsAutoNegCapableReturnsFalseWhenBitClear)
+{
+    EXPECT_FALSE(SmiPhy::BasicStatusRegister::IsAutoNegCapable(0));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsAutoNegCompleteReturnsTrueWhenBitSet)
+{
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::IsAutoNegComplete(bsrAutoNegComplete));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, IsAutoNegCompleteReturnsFalseWhenBitClear)
+{
+    EXPECT_FALSE(SmiPhy::BasicStatusRegister::IsAutoNegComplete(0));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, HasRemoteFaultReturnsTrueWhenBitSet)
+{
+    EXPECT_TRUE(SmiPhy::BasicStatusRegister::HasRemoteFault(SmiPhy::BasicStatusRegister::RemoteFaultMask));
+}
+
+TEST(SmiPhyBasicStatusRegisterTest, HasRemoteFaultReturnsFalseWhenBitClear)
+{
+    EXPECT_FALSE(SmiPhy::BasicStatusRegister::HasRemoteFault(0));
+}
+
+// ---- ReadBcr / WriteBcr / ReadBsr ------------------------------------------
+
+TEST_F(SmiPhyTest, ReadBcrReadsRegister0)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0x1234u));
+    EXPECT_THAT(phy.ReadBcr(), Eq(0x1234u));
+}
+
+TEST_F(SmiPhyTest, WriteBcrWritesRegister0)
+{
+    EXPECT_CALL(smi, Write(phyAddress, SmiPhy::BasicControlRegister::Address, 0xABCDu));
+    phy.WriteBcr(0xABCDu);
+}
+
+TEST_F(SmiPhyTest, ReadBsrReadsRegister1)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0x5678u));
+    EXPECT_THAT(phy.ReadBsr(), Eq(0x5678u));
+}
+
+// ---- ReadLinkState ---------------------------------------------------------
+
+TEST_F(SmiPhyTest, ReadLinkStatePhyNotRespondingReturnsDown)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrNotPresent));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Down));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateNoLinkNoAutoNegReturnsDown)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Down));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateLinkUpNoAutoNegReturnsUp)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Up));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateLinkUpAutoNegEnabledButNotCompleteReturnsDown)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Down));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateLinkUpAutoNegEnabledAndCompleteReturnsUp)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked | bsrAutoNegComplete));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Up));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptWhenStateUnchanged)
+{
+    // First call: down → down, already starts down so no change
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptOnRepeatUp)
+{
+    // Transition to up
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ASSERT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Up));
+
+    // Still up → no change
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
+}
+
+TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptOnRepeatDown)
+{
+    // Transition up then down
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    phy.ReadLinkState();
+
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ASSERT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Down));
+
+    // Still down → no change
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
+}
+
+// ---- EnableAutoNegIfCapable ------------------------------------------------
+
+TEST_F(SmiPhyTest, EnableAutoNegIfCapableWritesBcrWhenCapable)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrAutoNegCapable));
+    EXPECT_CALL(smi, Write(phyAddress, SmiPhy::BasicControlRegister::Address, bcrAutoNegEnable));
+    phy.EnableAutoNegIfCapable();
+}
+
+TEST_F(SmiPhyTest, EnableAutoNegIfCapableDoesNotWriteWhenNotCapable)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    phy.EnableAutoNegIfCapable();
+}
+
+// ---- LinkSpeed (manual, autoneg disabled) ----------------------------------
+
+TEST_F(SmiPhyTest, LinkSpeedManualFullDuplex100MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address))
+        .WillOnce(Return(bcrSpeedSelectLsb | bcrDuplexMode));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::fullDuplex100MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedManualHalfDuplex100MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address))
+        .WillOnce(Return(bcrSpeedSelectLsb));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::halfDuplex100MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedManualFullDuplex10MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address))
+        .WillOnce(Return(bcrDuplexMode));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::fullDuplex10MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedManualHalfDuplex10MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address))
+        .WillOnce(Return(0));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::halfDuplex10MHz));
+}
+
+// ---- LinkSpeed (autoneg enabled — negotiated from ANLPA/ANLPAR) ------------
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedFullDuplex100MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(anegFullDuplex100));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(anegFullDuplex100));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::fullDuplex100MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedHalfDuplex100MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(anegHalfDuplex100));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(anegHalfDuplex100));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::halfDuplex100MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedFullDuplex10MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(anegFullDuplex10));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(anegFullDuplex10));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::fullDuplex10MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedHalfDuplex10MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(anegHalfDuplex10));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(anegHalfDuplex10));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::halfDuplex10MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedPrefersHigherSpeed)
+{
+    // Both sides advertise all speeds — highest common wins (full 100)
+    const uint16_t allSpeeds = anegFullDuplex100 | anegHalfDuplex100 | anegFullDuplex10 | anegHalfDuplex10;
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(allSpeeds));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(allSpeeds));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::fullDuplex100MHz));
+}
+
+TEST_F(SmiPhyTest, LinkSpeedNegotiatedNoCommonCapabilityFallsBackToHalfDuplex10MHz)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrAutoNegEnable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::AdvertisementAddress)).WillOnce(Return(anegFullDuplex100));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::AutoNegRegister::LinkPartnerAddress)).WillOnce(Return(anegHalfDuplex10));
+    EXPECT_THAT(phy.LinkSpeed(), Eq(LinkSpeed::halfDuplex10MHz));
+}

--- a/services/util/test/TestSmiPhy.cpp
+++ b/services/util/test/TestSmiPhy.cpp
@@ -201,6 +201,7 @@ TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptOnRepeatDown)
 TEST_F(SmiPhyTest, EnableAutoNegIfCapableWritesBcrWhenCapable)
 {
     EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrAutoNegCapable));
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
     EXPECT_CALL(smi, Write(phyAddress, SmiPhy::BasicControlRegister::Address, bcrAutoNegEnable));
     phy.EnableAutoNegIfCapable();
 }

--- a/services/util/test/TestSmiPhy.cpp
+++ b/services/util/test/TestSmiPhy.cpp
@@ -174,6 +174,12 @@ TEST_F(SmiPhyTest, EnableAutoNegIfCapableDoesNotWriteWhenNotCapable)
     phy.EnableAutoNegIfCapable();
 }
 
+TEST_F(SmiPhyTest, EnableAutoNegIfCapableDoesNothingWhenPhyNotResponding)
+{
+    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrNotPresent));
+    phy.EnableAutoNegIfCapable();
+}
+
 // ---- LinkSpeed (manual, autoneg disabled) ----------------------------------
 
 TEST_F(SmiPhyTest, LinkSpeedManualFullDuplex100MHz)

--- a/services/util/test/TestSmiPhy.cpp
+++ b/services/util/test/TestSmiPhy.cpp
@@ -158,44 +158,6 @@ TEST_F(SmiPhyTest, ReadLinkStateLinkUpAutoNegEnabledAndCompleteReturnsUp)
     EXPECT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Up));
 }
 
-TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptWhenStateUnchanged)
-{
-    // First call: down → down, already starts down so no change
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
-}
-
-TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptOnRepeatUp)
-{
-    // Transition to up
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    ASSERT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Up));
-
-    // Still up → no change
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
-}
-
-TEST_F(SmiPhyTest, ReadLinkStateReturnsNulloptOnRepeatDown)
-{
-    // Transition up then down
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinked));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    phy.ReadLinkState();
-
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    ASSERT_THAT(phy.ReadLinkState(), Eq(SmiPhy::LinkState::Down));
-
-    // Still down → no change
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
-    EXPECT_CALL(smi, Read(phyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
-    EXPECT_THAT(phy.ReadLinkState(), Eq(std::nullopt));
-}
-
 // ---- EnableAutoNegIfCapable ------------------------------------------------
 
 TEST_F(SmiPhyTest, EnableAutoNegIfCapableWritesBcrWhenCapable)

--- a/services/util/test/TestSmiPhyLinkMonitor.cpp
+++ b/services/util/test/TestSmiPhyLinkMonitor.cpp
@@ -14,21 +14,21 @@ class SmiPhyLinkMonitorTest
     , public infra::ClockFixture
 {
 protected:
-    static constexpr uint8_t vphyAddress = 2;
     static constexpr uint8_t portPhyAddress = 9;
     static constexpr uint16_t bsrLinkUp = 0x0004u;          // bit 2: link status
     static constexpr uint16_t bsrAutoNegComplete = 0x0020u; // bit 5: autoneg complete
     static constexpr uint16_t bsrNotPresent = 0xFFFFu;
+    static constexpr uint16_t bcrFullDuplex100MHz = 0x2100u; // bit 8 (duplex) + bit 13 (speed)
 
     StrictMock<SmiBusMock> smi;
-    SmiPhyLinkMonitor monitor{ smi, vphyAddress, portPhyAddress };
+    SmiPhyLinkMonitor monitor{ smi, portPhyAddress };
 };
 
 // ---- PhyAddress ------------------------------------------------------------
 
-TEST_F(SmiPhyLinkMonitorTest, PhyAddressReturnsVphyAddress)
+TEST_F(SmiPhyLinkMonitorTest, PhyAddressReturnsPortPhyAddress)
 {
-    ASSERT_THAT(monitor.PhyAddress(), Eq(vphyAddress));
+    ASSERT_THAT(monitor.PhyAddress(), Eq(portPhyAddress));
 }
 
 // ---- Polling timing --------------------------------------------------------
@@ -64,11 +64,12 @@ TEST_F(SmiPhyLinkMonitorTest, PollsRepeatinglyAtInterval)
 
 TEST_F(SmiPhyLinkMonitorTest, CustomPollIntervalIsRespected)
 {
-    SmiPhyLinkMonitor fastMonitor{ smi, vphyAddress, portPhyAddress, std::chrono::milliseconds{ 50 } };
+    SmiPhyLinkMonitor fastMonitor{ smi, portPhyAddress, std::chrono::milliseconds{ 50 } };
     StrictMock<EthernetSmiObserverMock> observer{ fastMonitor };
 
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).Times(4).WillRepeatedly(Return(0));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(4).WillRepeatedly(Return(0));
+    // fastMonitor polls 4 times (50, 100, 150, 200ms) and the fixture monitor polls once (200ms)
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).Times(5).WillRepeatedly(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(5).WillRepeatedly(Return(0));
 
     ForwardTime(std::chrono::milliseconds{ 200 });
 }
@@ -92,7 +93,7 @@ TEST_F(SmiPhyLinkMonitorTest, PhyUpCallsLinkUp)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
 
     ForwardTime(std::chrono::milliseconds{ 200 });
@@ -103,12 +104,12 @@ TEST_F(SmiPhyLinkMonitorTest, NoDuplicateLinkUpCallback)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(bcrFullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 }
 
@@ -119,7 +120,7 @@ TEST_F(SmiPhyLinkMonitorTest, LinkUpThenDownCallsLinkDown)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 
@@ -134,7 +135,7 @@ TEST_F(SmiPhyLinkMonitorTest, NoDuplicateLinkDownCallback)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 
@@ -153,7 +154,7 @@ TEST_F(SmiPhyLinkMonitorTest, LinkUpDownUpReportsAllTransitions)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 
@@ -163,7 +164,7 @@ TEST_F(SmiPhyLinkMonitorTest, LinkUpDownUpReportsAllTransitions)
     ForwardTime(std::chrono::milliseconds{ 200 });
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 }
@@ -184,7 +185,7 @@ TEST_F(SmiPhyLinkMonitorTest, PhyDisappearsAfterLinkUpCallsLinkDown)
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
-    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(2).WillRepeatedly(Return(bcrFullDuplex100MHz));
     EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
     ForwardTime(std::chrono::milliseconds{ 200 });
 
@@ -221,7 +222,7 @@ TEST_F(SmiPhyLinkMonitorTest, PortPhyAddressIsUsedForPolling)
 {
     static constexpr uint8_t otherAddress = 3;
     StrictMock<EthernetSmiObserverMock> observer{ monitor };
-    SmiPhyLinkMonitor otherMonitor{ smi, vphyAddress, otherAddress };
+    SmiPhyLinkMonitor otherMonitor{ smi, otherAddress };
 
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
     EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));

--- a/services/util/test/TestSmiPhyLinkMonitor.cpp
+++ b/services/util/test/TestSmiPhyLinkMonitor.cpp
@@ -1,0 +1,232 @@
+#include "hal/interfaces/test_doubles/EthernetSmiObserverMock.hpp"
+#include "hal/interfaces/test_doubles/SmiBusMock.hpp"
+#include "infra/timer/test_helper/ClockFixture.hpp"
+#include "services/util/SmiPhyLinkMonitor.hpp"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace testing;
+using namespace services;
+using namespace hal;
+
+class SmiPhyLinkMonitorTest
+    : public ::testing::Test
+    , public infra::ClockFixture
+{
+protected:
+    static constexpr uint8_t vphyAddress = 2;
+    static constexpr uint8_t portPhyAddress = 9;
+    static constexpr uint16_t bsrLinkUp = 0x0004u;          // bit 2: link status
+    static constexpr uint16_t bsrAutoNegComplete = 0x0020u; // bit 5: autoneg complete
+    static constexpr uint16_t bsrNotPresent = 0xFFFFu;
+
+    StrictMock<SmiBusMock> smi;
+    SmiPhyLinkMonitor monitor{ smi, vphyAddress, portPhyAddress };
+};
+
+// ---- PhyAddress ------------------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, PhyAddressReturnsVphyAddress)
+{
+    ASSERT_THAT(monitor.PhyAddress(), Eq(vphyAddress));
+}
+
+// ---- Polling timing --------------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, NoPollBeforeFirstInterval)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    ForwardTime(std::chrono::milliseconds{ 199 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, PollOccursAtFirstInterval)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, PollsRepeatinglyAtInterval)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).Times(3).WillRepeatedly(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(3).WillRepeatedly(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 600 });
+}
+
+// ---- Custom poll interval --------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, CustomPollIntervalIsRespected)
+{
+    SmiPhyLinkMonitor fastMonitor{ smi, vphyAddress, portPhyAddress, std::chrono::milliseconds{ 50 } };
+    StrictMock<EthernetSmiObserverMock> observer{ fastMonitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).Times(4).WillRepeatedly(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).Times(4).WillRepeatedly(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- Link down (initial state) ---------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, PhyDownInitialStateNoCallback)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- Link up ---------------------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, PhyUpCallsLinkUp)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, NoDuplicateLinkUpCallback)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- Link down after up ----------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, LinkUpThenDownCallsLinkDown)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkDown());
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, NoDuplicateLinkDownCallback)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkDown());
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, LinkUpDownUpReportsAllTransitions)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkDown());
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- PHY not present -------------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, PhyNotRespondingNoCallback)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrNotPresent));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, PhyDisappearsAfterLinkUpCallsLinkDown)
+{
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(observer, LinkUp(LinkSpeed::fullDuplex100MHz));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    // PHY not responding: 0xFFFF → early return, no BCR read
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrNotPresent));
+    EXPECT_CALL(observer, LinkDown());
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- No observer -----------------------------------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, LinkUpWithNoObserverDoesNotCrash)
+{
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+TEST_F(SmiPhyLinkMonitorTest, LinkDownWithNoObserverDoesNotCrash)
+{
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(bsrLinkUp));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}
+
+// ---- Port PHY address is used for polling ----------------------------------
+
+TEST_F(SmiPhyLinkMonitorTest, PortPhyAddressIsUsedForPolling)
+{
+    static constexpr uint8_t otherAddress = 3;
+    StrictMock<EthernetSmiObserverMock> observer{ monitor };
+    SmiPhyLinkMonitor otherMonitor{ smi, vphyAddress, otherAddress };
+
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(portPhyAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(otherAddress, SmiPhy::BasicStatusRegister::Address)).WillOnce(Return(0));
+    EXPECT_CALL(smi, Read(otherAddress, SmiPhy::BasicControlRegister::Address)).WillOnce(Return(0));
+
+    ForwardTime(std::chrono::milliseconds{ 200 });
+}


### PR DESCRIPTION
Introduces SMI (Serial Management Interface) support for Ethernet PHY management.

## Changes

### New: `hal::SmiBus` interface (`hal/interfaces/SmiBus.hpp`)
Adds an abstract interface for synchronous read/write access to PHY registers over SMI (MDIO/MDC). Includes a `SmiBusMock` test double.

### New: `services::SmiPhy` (`services/util/SmiPhy.hpp/cpp`)
Wraps a single IEEE 802.3 PHY accessible over a `SmiBus`. Encapsulates all register address and bit-field knowledge for standard PHY registers (BCR, BSR, ANLPA, ANLPAR) and tracks link state transitions. Supports auto-negotiation detection and link speed resolution.

### New: `services::SmiPhyLinkMonitor` (`services/util/SmiPhyLinkMonitor.hpp/cpp`)
Implements `hal::EthernetSmi` and uses a repeating timer to periodically poll the PHY via `SmiPhy`, reporting link state changes. Removes the dependency on a virtual PHY object in the link monitor — only a `SmiBus` and a PHY address are required.