### PR TITLE
feat: prefixed tracer

### DIFF
--- a/services/tracer/Tracer.hpp
+++ b/services/tracer/Tracer.hpp
@@ -128,6 +128,26 @@ namespace services
     private:
         uint8_t colour;
     };
+
+    class TracerPrefixed
+        : public TracerToDelegate
+    {
+    public:
+        TracerPrefixed(infra::BoundedConstString prefix, services::Tracer& delegate)
+            : TracerToDelegate(delegate)
+            , prefix(prefix)
+        {}
+
+    protected:
+        void InsertHeader() override
+        {
+            TracerToDelegate::InsertHeader();
+            Continue() << prefix;
+        }
+
+    private:
+        infra::BoundedConstString prefix;
+    };
 }
 
 #endif

--- a/services/tracer/test/TestTracer.cpp
+++ b/services/tracer/test/TestTracer.cpp
@@ -43,3 +43,37 @@ TEST(GlobalTracerTest, global_tracer_streams_text)
 
     EXPECT_EQ("\r\nText", stream.Storage());
 }
+
+TEST(TracerPrefixedTest, prefix_is_inserted_before_message)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerPrefixed tracer("prefix: ", baseTracer);
+
+    tracer.Trace() << "message";
+
+    EXPECT_EQ("\r\nprefix: message", stream.Storage());
+}
+
+TEST(TracerPrefixedTest, empty_prefix_leaves_output_unchanged)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerPrefixed tracer("", baseTracer);
+
+    tracer.Trace() << "message";
+
+    EXPECT_EQ("\r\nmessage", stream.Storage());
+}
+
+TEST(TracerPrefixedTest, prefix_is_repeated_on_each_trace)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerPrefixed tracer("[mod] ", baseTracer);
+
+    tracer.Trace() << "first";
+    tracer.Trace() << "second";
+
+    EXPECT_EQ("\r\n[mod] first\r\n[mod] second", stream.Storage());
+}


### PR DESCRIPTION
This enables the application to provide a tracer with a prefix and distinguish between different sources.

For example, on some applications there might be more than one echo connections, and the user can use TracerPrefixed to distinguish between multiple connections