### PR TITLE
feat: add TracerWithPrefix

### DIFF
--- a/services/tracer/CMakeLists.txt
+++ b/services/tracer/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(services.tracer PRIVATE
     TracerOnIoOutputInfrastructure.hpp
     TracerWithDateTime.cpp
     TracerWithDateTime.hpp
+    TracerWithPrefix.cpp
+    TracerWithPrefix.hpp
     TracerWithTime.cpp
     TracerWithTime.hpp
     TracerAdapterPrintf.cpp

--- a/services/tracer/TracerWithPrefix.cpp
+++ b/services/tracer/TracerWithPrefix.cpp
@@ -9,8 +9,8 @@ namespace services
 
     void TracerWithPrefix::InsertHeader()
     {
-        Continue() << prefix;
-
         TracerToDelegate::InsertHeader();
+
+        Continue() << prefix;
     }
 }

--- a/services/tracer/TracerWithPrefix.cpp
+++ b/services/tracer/TracerWithPrefix.cpp
@@ -1,0 +1,16 @@
+#include "services/tracer/TracerWithPrefix.hpp"
+
+namespace services
+{
+    TracerWithPrefix::TracerWithPrefix(infra::BoundedConstString prefix, Tracer& delegate)
+        : TracerToDelegate(delegate)
+        , prefix(prefix)
+    {}
+
+    void TracerWithPrefix::InsertHeader()
+    {
+        Continue() << prefix;
+
+        TracerToDelegate::InsertHeader();
+    }
+}

--- a/services/tracer/TracerWithPrefix.hpp
+++ b/services/tracer/TracerWithPrefix.hpp
@@ -1,0 +1,22 @@
+#ifndef SERVICES_TRACER_WITH_PREFIX_HPP
+#define SERVICES_TRACER_WITH_PREFIX_HPP
+
+#include "services/tracer/Tracer.hpp"
+
+namespace services
+{
+    class TracerWithPrefix
+        : public TracerToDelegate
+    {
+    public:
+        TracerWithPrefix(infra::BoundedConstString prefix, Tracer& delegate);
+
+    protected:
+        void InsertHeader() override;
+
+    private:
+        infra::BoundedConstString prefix;
+    };
+}
+
+#endif

--- a/services/tracer/test/CMakeLists.txt
+++ b/services/tracer/test/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(services.tracer_test PRIVATE
     TestTracer.cpp
     TestTracerAdapterPrintf.cpp
     TestTracerWithDateTime.cpp
+    TestTracerWithPrefix.cpp
     TestTracerWithTime.cpp
     TestTracingReset.cpp
 )

--- a/services/tracer/test/TestTracerWithPrefix.cpp
+++ b/services/tracer/test/TestTracerWithPrefix.cpp
@@ -1,0 +1,41 @@
+#include "infra/stream/StringOutputStream.hpp"
+#include "services/tracer/TracerWithPrefix.hpp"
+#include "gmock/gmock.h"
+
+class TracerWithPrefixTest
+    : public testing::Test
+{};
+
+TEST(TracerWithPrefixTest, prefix_is_inserted_before_message)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerWithPrefix tracer("prefix: ", baseTracer);
+
+    tracer.Trace() << "message";
+
+    EXPECT_EQ("\r\nprefix: message", stream.Storage());
+}
+
+TEST(TracerWithPrefixTest, empty_prefix_leaves_output_unchanged)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerWithPrefix tracer("", baseTracer);
+
+    tracer.Trace() << "message";
+
+    EXPECT_EQ("\r\nmessage", stream.Storage());
+}
+
+TEST(TracerWithPrefixTest, prefix_is_repeated_on_each_trace)
+{
+    infra::StringOutputStream::WithStorage<64> stream;
+    services::TracerToStream baseTracer(stream);
+    services::TracerWithPrefix tracer("[mod] ", baseTracer);
+
+    tracer.Trace() << "first";
+    tracer.Trace() << "second";
+
+    EXPECT_EQ("\r\n[mod] first\r\n[mod] second", stream.Storage());
+}

--- a/services/tracer/test/TestTracerWithPrefix.cpp
+++ b/services/tracer/test/TestTracerWithPrefix.cpp
@@ -2,10 +2,6 @@
 #include "services/tracer/TracerWithPrefix.hpp"
 #include "gmock/gmock.h"
 
-class TracerWithPrefixTest
-    : public testing::Test
-{};
-
 TEST(TracerWithPrefixTest, prefix_is_inserted_before_message)
 {
     infra::StringOutputStream::WithStorage<64> stream;


### PR DESCRIPTION
This enables the application to provide a tracer with a prefix and distinguish between different sources.

For example, on some applications there might be more than one echo connections, and the user can use TracerWithPrefix to distinguish between multiple connections