### PR TITLE
fix: first initialize EchoOnStreams, then observers

### DIFF
--- a/services/util/EchoOnSesame.cpp
+++ b/services/util/EchoOnSesame.cpp
@@ -17,14 +17,14 @@ namespace services
 
     void EchoOnSesame::Initialized()
     {
+        EchoOnStreams::Initialized();
+
         infra::Subject<EchoInitializationObserver>::NotifyObservers([](auto& observer)
             {
                 observer.Initialized();
             });
 
         initialized = true;
-
-        EchoOnStreams::Initialized();
 
         if (requestedSize != std::nullopt)
             RequestSendStream(*std::exchange(requestedSize, std::nullopt));


### PR DESCRIPTION
## Pull request overview

This PR adjusts the initialization order in `EchoOnSesame::Initialized()` so that the `EchoOnStreams` base class state is fully initialized before `EchoInitializationObserver` listeners are notified.

**Changes:**
- Call `EchoOnStreams::Initialized()` at the start of `EchoOnSesame::Initialized()` (before notifying observers).
- Preserve existing behavior for setting `initialized` and replaying any deferred `RequestSendStream()`.