### PR TITLE
feat: sequential requests on flash over echo

### DIFF
--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -182,16 +182,16 @@ namespace services
         MethodDone();
     }
 
-    void FlashEchoProxyBase::OnReadIncomplete(uint32_t, uint32_t)
+    void FlashEchoProxyBase::OnReadIncomplete([[maybe_unused]] uint32_t address, [[maybe_unused]] uint32_t bufferPosition)
     {}
 
-    void FlashEchoProxyBase::OnWriteIncomplete(uint32_t, uint32_t)
+    void FlashEchoProxyBase::OnWriteIncomplete([[maybe_unused]] uint32_t address, [[maybe_unused]] uint32_t bufferPosition)
     {}
 
-    void FlashEchoProxyBase::OnReadChunkSent(uint32_t, uint32_t)
+    void FlashEchoProxyBase::OnReadChunkSent([[maybe_unused]] uint32_t address, [[maybe_unused]] uint32_t nextStart)
     {}
 
-    void FlashEchoProxyBase::OnWriteChunkSent(uint32_t, uint32_t)
+    void FlashEchoProxyBase::OnWriteChunkSent([[maybe_unused]] uint32_t address, [[maybe_unused]] uint32_t nextStart)
     {}
 
     void FlashEchoProxyBase::ReadPartialBuffer(uint32_t address, uint32_t start)
@@ -232,14 +232,14 @@ namespace services
         WritePartialBuffer(address, nextStart);
     }
 
-    void FlashEchoSequentialProxy::OnReadIncomplete(uint32_t address, uint32_t bufferPosition)
+    void FlashEchoSequentialProxy::OnReadIncomplete(uint32_t address, uint32_t nextStart)
     {
-        ReadPartialBuffer(address, bufferPosition);
+        ReadPartialBuffer(address, nextStart);
     }
 
-    void FlashEchoSequentialProxy::OnWriteIncomplete(uint32_t address, uint32_t bufferPosition)
+    void FlashEchoSequentialProxy::OnWriteIncomplete(uint32_t address, uint32_t nextStart)
     {
-        WritePartialBuffer(address, bufferPosition);
+        WritePartialBuffer(address, nextStart);
     }
 
     FlashEchoHomogeneousProxy::FlashEchoHomogeneousProxy(services::Echo& echo, uint32_t numberOfSectors, uint32_t sizeOfEachSector)

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -88,6 +88,14 @@ namespace services
         , proxy(echo)
     {}
 
+    FlashEchoProxy::FlashEchoProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes)
+        : FlashEchoProxyBase(echo, sectorSizes)
+    {}
+
+    FlashEchoSequentialProxy::FlashEchoSequentialProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes)
+        : FlashEchoProxyBase(echo, sectorSizes)
+    {}
+
     uint32_t FlashEchoProxyBase::NumberOfSectors() const
     {
         return sectorSizes.size();

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -159,7 +159,7 @@ namespace services
         if (bufferPosition == readingBuffer.size())
             onDone();
         else
-            OnReadIncomplete();
+            OnReadIncomplete(address, bufferPosition);
 
         MethodDone();
     }
@@ -171,7 +171,7 @@ namespace services
         if (bufferPosition == writingBuffer.size())
             onDone();
         else
-            OnWriteIncomplete();
+            OnWriteIncomplete(address, bufferPosition);
 
         MethodDone();
     }
@@ -181,6 +181,18 @@ namespace services
         onDone();
         MethodDone();
     }
+
+    void FlashEchoProxyBase::OnReadIncomplete(uint32_t, uint32_t)
+    {}
+
+    void FlashEchoProxyBase::OnWriteIncomplete(uint32_t, uint32_t)
+    {}
+
+    void FlashEchoProxyBase::OnReadChunkSent(uint32_t, uint32_t)
+    {}
+
+    void FlashEchoProxyBase::OnWriteChunkSent(uint32_t, uint32_t)
+    {}
 
     void FlashEchoProxyBase::ReadPartialBuffer(uint32_t address, uint32_t start)
     {
@@ -210,12 +222,6 @@ namespace services
         }
     }
 
-    void FlashEchoProxy::OnReadIncomplete()
-    {}
-
-    void FlashEchoProxy::OnWriteIncomplete()
-    {}
-
     void FlashEchoProxy::OnReadChunkSent(uint32_t address, uint32_t nextStart)
     {
         ReadPartialBuffer(address, nextStart);
@@ -226,12 +232,12 @@ namespace services
         WritePartialBuffer(address, nextStart);
     }
 
-    void FlashEchoSequentialProxy::OnReadIncomplete()
+    void FlashEchoSequentialProxy::OnReadIncomplete(uint32_t address, uint32_t bufferPosition)
     {
         ReadPartialBuffer(address, bufferPosition);
     }
 
-    void FlashEchoSequentialProxy::OnWriteIncomplete()
+    void FlashEchoSequentialProxy::OnWriteIncomplete(uint32_t address, uint32_t bufferPosition)
     {
         WritePartialBuffer(address, bufferPosition);
     }

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -82,23 +82,23 @@ namespace services
             });
     }
 
-    FlashEchoProxy::FlashEchoProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes)
+    FlashEchoProxyBase::FlashEchoProxyBase(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes)
         : flash::FlashResult(echo)
         , sectorSizes(sectorSizes)
         , proxy(echo)
     {}
 
-    uint32_t FlashEchoProxy::NumberOfSectors() const
+    uint32_t FlashEchoProxyBase::NumberOfSectors() const
     {
         return sectorSizes.size();
     }
 
-    uint32_t FlashEchoProxy::SizeOfSector(uint32_t sectorIndex) const
+    uint32_t FlashEchoProxyBase::SizeOfSector(uint32_t sectorIndex) const
     {
         return sectorSizes[sectorIndex];
     }
 
-    uint32_t FlashEchoProxy::SectorOfAddress(uint32_t address) const
+    uint32_t FlashEchoProxyBase::SectorOfAddress(uint32_t address) const
     {
         uint32_t totalSize = 0;
         for (uint32_t sector = 0; sector != sectorSizes.size(); ++sector)
@@ -112,7 +112,7 @@ namespace services
         return sectorSizes.size();
     }
 
-    uint32_t FlashEchoProxy::AddressOfSector(uint32_t sectorIndex) const
+    uint32_t FlashEchoProxyBase::AddressOfSector(uint32_t sectorIndex) const
     {
         uint32_t address = 0;
         for (uint32_t sector = 0; sector != sectorIndex; ++sector)
@@ -120,7 +120,7 @@ namespace services
         return address;
     }
 
-    void FlashEchoProxy::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    void FlashEchoProxyBase::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         bufferPosition = 0;
         writingBuffer = buffer;
@@ -129,7 +129,7 @@ namespace services
         WritePartialBuffer(address, 0);
     }
 
-    void FlashEchoProxy::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    void FlashEchoProxyBase::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         bufferPosition = 0;
         readingBuffer = buffer;
@@ -138,7 +138,7 @@ namespace services
         ReadPartialBuffer(address, 0);
     }
 
-    void FlashEchoProxy::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
+    void FlashEchoProxyBase::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
     {
         this->onDone = onDone;
         this->endIndex = endIndex;
@@ -149,32 +149,104 @@ namespace services
             });
     }
 
-    void FlashEchoProxy::ReadDone(infra::ConstByteRange contents)
+    void FlashEchoProxyBase::ReadDone(infra::ConstByteRange contents)
     {
         infra::Copy(contents, infra::Head(infra::DiscardHead(readingBuffer, bufferPosition), contents.size()));
         bufferPosition += contents.size();
 
         if (bufferPosition == readingBuffer.size())
             onDone();
+        else
+            OnReadIncomplete();
 
         MethodDone();
     }
 
-    void FlashEchoProxy::WriteDone()
+    void FlashEchoProxyBase::WriteDone()
     {
         bufferPosition += std::min<std::size_t>(writingBuffer.size() - bufferPosition, flash::WriteRequest::contentsSize);
 
         if (bufferPosition == writingBuffer.size())
             onDone();
+        else
+            OnWriteIncomplete();
 
         MethodDone();
     }
 
-    void FlashEchoProxy::EraseSectorsDone()
+    void FlashEchoProxyBase::EraseSectorsDone()
     {
         onDone();
         MethodDone();
     }
+
+    void FlashEchoProxyBase::ReadPartialBuffer(uint32_t address, uint32_t start)
+    {
+        if (readingBuffer.size() > start)
+        {
+            this->start = start;
+            proxy.RequestSend([this, address]()
+                {
+                    auto size = std::min<uint32_t>(readingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
+                    proxy.Read(address + this->start, size);
+                    ReadPartialBuffer(address, this->start + size);
+                });
+        }
+    }
+
+    void FlashEchoProxyBase::WritePartialBuffer(uint32_t address, uint32_t start)
+    {
+        if (writingBuffer.size() > start)
+        {
+            this->start = start;
+            proxy.RequestSend([this, address]()
+                {
+                    auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
+                    proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
+                    WritePartialBuffer(address, this->start + size);
+                });
+        }
+    }
+
+    void FlashEchoProxyBase::OnReadIncomplete()
+    {}
+
+    void FlashEchoProxyBase::OnWriteIncomplete()
+    {}
+
+    void FlashEchoProxyBase::ReadPartialBuffer(uint32_t address, uint32_t start)
+    {
+        if (readingBuffer.size() > start)
+        {
+            this->start = start;
+            proxy.RequestSend([this, address]()
+                {
+                    auto size = std::min<uint32_t>(readingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
+                    proxy.Read(address + this->start, size);
+                    ReadPartialBuffer(address, this->start + size);
+                });
+        }
+    }
+
+    void FlashEchoProxyBase::WritePartialBuffer(uint32_t address, uint32_t start)
+    {
+        if (writingBuffer.size() > start)
+        {
+            this->start = start;
+            proxy.RequestSend([this, address]()
+                {
+                    auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
+                    proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
+                    WritePartialBuffer(address, this->start + size);
+                });
+        }
+    }
+
+    void FlashEchoProxyBase::OnReadIncomplete()
+    {}
+
+    void FlashEchoProxyBase::OnWriteIncomplete()
+    {}
 
     void FlashEchoProxy::ReadPartialBuffer(uint32_t address, uint32_t start)
     {
@@ -204,8 +276,18 @@ namespace services
         }
     }
 
+    void FlashEchoSequentialProxy::OnReadIncomplete()
+    {
+        ReadPartialBuffer(address, bufferPosition);
+    }
+
+    void FlashEchoSequentialProxy::OnWriteIncomplete()
+    {
+        WritePartialBuffer(address, bufferPosition);
+    }
+
     FlashEchoHomogeneousProxy::FlashEchoHomogeneousProxy(services::Echo& echo, uint32_t numberOfSectors, uint32_t sizeOfEachSector)
-        : FlashEchoProxy(echo, {})
+        : FlashEchoProxy(echo, infra::MemoryRange<const uint32_t>{})
         , numberOfSectors(numberOfSectors)
         , sizeOfEachSector(sizeOfEachSector)
     {}

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -215,7 +215,7 @@ namespace services
             this->start = start;
             proxy.RequestSend([this, address]()
                 {
-                    auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
+                    auto size = std::min<uint32_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
                     proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
                     OnWriteChunkSent(address, this->start + size);
                 });

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -125,6 +125,7 @@ namespace services
         bufferPosition = 0;
         writingBuffer = buffer;
         this->onDone = onDone;
+        this->address = address;
 
         WritePartialBuffer(address, 0);
     }
@@ -132,6 +133,7 @@ namespace services
     void FlashEchoProxyBase::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         bufferPosition = 0;
+        this->address = address;
         readingBuffer = buffer;
         this->onDone = onDone;
 
@@ -189,7 +191,7 @@ namespace services
                 {
                     auto size = std::min<uint32_t>(readingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
                     proxy.Read(address + this->start, size);
-                    ReadPartialBuffer(address, this->start + size);
+                    OnReadChunkSent(address, this->start + size);
                 });
         }
     }
@@ -203,77 +205,25 @@ namespace services
                 {
                     auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
                     proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
-                    WritePartialBuffer(address, this->start + size);
+                    OnWriteChunkSent(address, this->start + size);
                 });
         }
     }
 
-    void FlashEchoProxyBase::OnReadIncomplete()
+    void FlashEchoProxy::OnReadIncomplete()
     {}
 
-    void FlashEchoProxyBase::OnWriteIncomplete()
+    void FlashEchoProxy::OnWriteIncomplete()
     {}
 
-    void FlashEchoProxyBase::ReadPartialBuffer(uint32_t address, uint32_t start)
+    void FlashEchoProxy::OnReadChunkSent(uint32_t address, uint32_t nextStart)
     {
-        if (readingBuffer.size() > start)
-        {
-            this->start = start;
-            proxy.RequestSend([this, address]()
-                {
-                    auto size = std::min<uint32_t>(readingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
-                    proxy.Read(address + this->start, size);
-                    ReadPartialBuffer(address, this->start + size);
-                });
-        }
+        ReadPartialBuffer(address, nextStart);
     }
 
-    void FlashEchoProxyBase::WritePartialBuffer(uint32_t address, uint32_t start)
+    void FlashEchoProxy::OnWriteChunkSent(uint32_t address, uint32_t nextStart)
     {
-        if (writingBuffer.size() > start)
-        {
-            this->start = start;
-            proxy.RequestSend([this, address]()
-                {
-                    auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
-                    proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
-                    WritePartialBuffer(address, this->start + size);
-                });
-        }
-    }
-
-    void FlashEchoProxyBase::OnReadIncomplete()
-    {}
-
-    void FlashEchoProxyBase::OnWriteIncomplete()
-    {}
-
-    void FlashEchoProxy::ReadPartialBuffer(uint32_t address, uint32_t start)
-    {
-        if (readingBuffer.size() > start)
-        {
-            this->start = start;
-            proxy.RequestSend([this, address]()
-                {
-                    auto size = std::min<uint32_t>(readingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
-                    proxy.Read(address + this->start, size);
-                    ReadPartialBuffer(address, this->start + size);
-                });
-        }
-    }
-
-    void FlashEchoProxy::WritePartialBuffer(uint32_t address, uint32_t start)
-    {
-        if (writingBuffer.size() > start)
-        {
-            this->start = start;
-            proxy.RequestSend([this, address]()
-                {
-                    auto size = std::min<std::size_t>(writingBuffer.size() - this->start, flash::WriteRequest::contentsSize);
-                    proxy.Write(address + this->start, infra::Head(infra::DiscardHead(writingBuffer, this->start), size));
-                    WritePartialBuffer(address, this->start + size);
-                });
-        }
+        WritePartialBuffer(address, nextStart);
     }
 
     void FlashEchoSequentialProxy::OnReadIncomplete()

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -56,12 +56,12 @@ namespace services
         void WriteDone() override;
         void EraseSectorsDone() override;
 
-        virtual void OnReadIncomplete() = 0;
-        virtual void OnWriteIncomplete() = 0;
-        virtual void OnReadChunkSent(uint32_t address, uint32_t nextStart) = 0;
-        virtual void OnWriteChunkSent(uint32_t address, uint32_t nextStart) = 0;
+        virtual void OnReadIncomplete(uint32_t address, uint32_t bufferPosition);
+        virtual void OnWriteIncomplete(uint32_t address, uint32_t bufferPosition);
+        virtual void OnReadChunkSent(uint32_t address, uint32_t nextStart);
+        virtual void OnWriteChunkSent(uint32_t address, uint32_t nextStart);
 
-    protected:
+    private:
         infra::MemoryRange<const uint32_t> sectorSizes;
         flash::FlashProxy proxy;
         infra::AutoResetFunction<void()> onDone;
@@ -80,8 +80,6 @@ namespace services
         using FlashEchoProxyBase::FlashEchoProxyBase;
 
     private:
-        void OnReadIncomplete() override;
-        void OnWriteIncomplete() override;
         void OnReadChunkSent(uint32_t address, uint32_t nextStart) override;
         void OnWriteChunkSent(uint32_t address, uint32_t nextStart) override;
     };
@@ -93,10 +91,8 @@ namespace services
         using FlashEchoProxyBase::FlashEchoProxyBase;
 
     private:
-        void OnReadIncomplete() override;
-        void OnWriteIncomplete() override;
-        void OnReadChunkSent(uint32_t address, uint32_t nextStart) override {}
-        void OnWriteChunkSent(uint32_t address, uint32_t nextStart) override {}
+        void OnReadIncomplete(uint32_t address, uint32_t bufferPosition) override;
+        void OnWriteIncomplete(uint32_t address, uint32_t bufferPosition) override;
     };
 
     class FlashEchoHomogeneousProxy

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -34,9 +34,10 @@ namespace services
         : public hal::Flash
         , private flash::FlashResult
     {
-    public:
+    protected:
         FlashEchoProxyBase(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes);
 
+    public:
         // Implementation of hal::Flash
         uint32_t NumberOfSectors() const override;
         uint32_t SizeOfSector(uint32_t sectorIndex) const override;
@@ -77,7 +78,7 @@ namespace services
         : public FlashEchoProxyBase
     {
     public:
-        using FlashEchoProxyBase::FlashEchoProxyBase;
+        FlashEchoProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes);
 
     private:
         void OnReadChunkSent(uint32_t address, uint32_t nextStart) override;
@@ -88,7 +89,7 @@ namespace services
         : public FlashEchoProxyBase
     {
     public:
-        using FlashEchoProxyBase::FlashEchoProxyBase;
+        FlashEchoSequentialProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes);
 
     private:
         void OnReadIncomplete(uint32_t address, uint32_t bufferPosition) override;

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -47,8 +47,8 @@ namespace services
         void EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone) override;
 
     protected:
-        virtual void ReadPartialBuffer(uint32_t address, uint32_t start);
-        virtual void WritePartialBuffer(uint32_t address, uint32_t start);
+        void ReadPartialBuffer(uint32_t address, uint32_t start);
+        void WritePartialBuffer(uint32_t address, uint32_t start);
 
     private:
         // Implementation of flash::FlashResult
@@ -56,8 +56,10 @@ namespace services
         void WriteDone() override;
         void EraseSectorsDone() override;
 
-        virtual void OnReadIncomplete();
-        virtual void OnWriteIncomplete();
+        virtual void OnReadIncomplete() = 0;
+        virtual void OnWriteIncomplete() = 0;
+        virtual void OnReadChunkSent(uint32_t address, uint32_t nextStart) = 0;
+        virtual void OnWriteChunkSent(uint32_t address, uint32_t nextStart) = 0;
 
     protected:
         infra::MemoryRange<const uint32_t> sectorSizes;
@@ -77,9 +79,11 @@ namespace services
     public:
         using FlashEchoProxyBase::FlashEchoProxyBase;
 
-    protected:
-        void ReadPartialBuffer(uint32_t address, uint32_t start) override;
-        void WritePartialBuffer(uint32_t address, uint32_t start) override;
+    private:
+        void OnReadIncomplete() override;
+        void OnWriteIncomplete() override;
+        void OnReadChunkSent(uint32_t address, uint32_t nextStart) override;
+        void OnWriteChunkSent(uint32_t address, uint32_t nextStart) override;
     };
 
     class FlashEchoSequentialProxy
@@ -91,6 +95,8 @@ namespace services
     private:
         void OnReadIncomplete() override;
         void OnWriteIncomplete() override;
+        void OnReadChunkSent(uint32_t address, uint32_t nextStart) override {}
+        void OnWriteChunkSent(uint32_t address, uint32_t nextStart) override {}
     };
 
     class FlashEchoHomogeneousProxy

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -30,12 +30,12 @@ namespace services
         infra::AutoResetFunction<void()> onStopped;
     };
 
-    class FlashEchoProxy
+    class FlashEchoProxyBase
         : public hal::Flash
         , private flash::FlashResult
     {
     public:
-        FlashEchoProxy(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes);
+        FlashEchoProxyBase(services::Echo& echo, infra::MemoryRange<const uint32_t> sectorSizes);
 
         // Implementation of hal::Flash
         uint32_t NumberOfSectors() const override;
@@ -46,24 +46,51 @@ namespace services
         void ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
         void EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone) override;
 
+    protected:
+        virtual void ReadPartialBuffer(uint32_t address, uint32_t start);
+        virtual void WritePartialBuffer(uint32_t address, uint32_t start);
+
     private:
         // Implementation of flash::FlashResult
         void ReadDone(infra::ConstByteRange contents) override;
         void WriteDone() override;
         void EraseSectorsDone() override;
 
-        void ReadPartialBuffer(uint32_t address, uint32_t start);
-        void WritePartialBuffer(uint32_t address, uint32_t start);
+        virtual void OnReadIncomplete();
+        virtual void OnWriteIncomplete();
 
-    private:
+    protected:
         infra::MemoryRange<const uint32_t> sectorSizes;
         flash::FlashProxy proxy;
         infra::AutoResetFunction<void()> onDone;
         infra::ConstByteRange writingBuffer;
         infra::ByteRange readingBuffer;
         uint32_t bufferPosition = 0;
-        uint32_t start;
-        uint32_t endIndex;
+        uint32_t start = 0;
+        uint32_t address = 0;
+        uint32_t endIndex = 0;
+    };
+
+    class FlashEchoProxy
+        : public FlashEchoProxyBase
+    {
+    public:
+        using FlashEchoProxyBase::FlashEchoProxyBase;
+
+    protected:
+        void ReadPartialBuffer(uint32_t address, uint32_t start) override;
+        void WritePartialBuffer(uint32_t address, uint32_t start) override;
+    };
+
+    class FlashEchoSequentialProxy
+        : public FlashEchoProxyBase
+    {
+    public:
+        using FlashEchoProxyBase::FlashEchoProxyBase;
+
+    private:
+        void OnReadIncomplete() override;
+        void OnWriteIncomplete() override;
     };
 
     class FlashEchoHomogeneousProxy

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -56,8 +56,8 @@ namespace services
         void WriteDone() override;
         void EraseSectorsDone() override;
 
-        virtual void OnReadIncomplete(uint32_t address, uint32_t bufferPosition);
-        virtual void OnWriteIncomplete(uint32_t address, uint32_t bufferPosition);
+        virtual void OnReadIncomplete(uint32_t address, uint32_t nextStart);
+        virtual void OnWriteIncomplete(uint32_t address, uint32_t nextStart);
         virtual void OnReadChunkSent(uint32_t address, uint32_t nextStart);
         virtual void OnWriteChunkSent(uint32_t address, uint32_t nextStart);
 

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -197,3 +197,263 @@ TEST_F(FlashProxyTest, EraseSectors)
     infra::VerifyingFunction<void()> onDone;
     flashProxy.EraseSectors(12, 34, onDone);
 }
+
+TEST_F(FlashProxyTest, ReadBuffer_TwoChunks_BothRequestedBeforeDone)
+{
+    constexpr auto twoChunkSize = flash::WriteRequest::contentsSize + 4;
+    std::array<uint8_t, twoChunkSize> buffer{};
+
+    infra::Function<void()> sendReadDone1;
+    infra::Function<void()> sendReadDone2;
+
+    EXPECT_CALL(flash, Read(1234, flash::WriteRequest::contentsSize))
+        .WillOnce([&](uint32_t address, uint32_t size)
+            {
+                flash.MethodDone();
+                sendReadDone1 = [this, size]()
+                {
+                    flashResult.RequestSend([this, size]()
+                        {
+                            std::array<uint8_t, flash::WriteRequest::contentsSize> chunk{};
+                            flashResult.ReadDone(infra::Head(infra::MakeRange(chunk), size));
+                        });
+                };
+            });
+    EXPECT_CALL(flash, Read(1234 + flash::WriteRequest::contentsSize, 4))
+        .WillOnce([&](uint32_t address, uint32_t size)
+            {
+                flash.MethodDone();
+                sendReadDone2 = [this, size]()
+                {
+                    flashResult.RequestSend([this, size]()
+                        {
+                            std::array<uint8_t, 4> chunk{};
+                            flashResult.ReadDone(infra::Head(infra::MakeRange(chunk), size));
+                        });
+                };
+            });
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, onDone);
+
+    // Both reads were requested before any ReadDone (pipelined)
+    ASSERT_TRUE(sendReadDone1);
+    ASSERT_TRUE(sendReadDone2);
+
+    sendReadDone1();
+    sendReadDone2();
+}
+
+TEST_F(FlashProxyTest, WriteBuffer_TwoChunks_BothRequestedBeforeDone)
+{
+    constexpr auto twoChunkSize = flash::WriteRequest::contentsSize + 4;
+    std::array<uint8_t, twoChunkSize> writeData{};
+
+    infra::Function<void()> sendWriteDone1;
+    infra::Function<void()> sendWriteDone2;
+
+    EXPECT_CALL(flash, Write(1234, testing::_))
+        .WillOnce([&](uint32_t address, infra::ConstByteRange contents)
+            {
+                flash.MethodDone();
+                sendWriteDone1 = [this]()
+                {
+                    flashResult.RequestSend([this]()
+                        {
+                            flashResult.WriteDone();
+                        });
+                };
+            });
+    EXPECT_CALL(flash, Write(1234 + flash::WriteRequest::contentsSize, testing::_))
+        .WillOnce([&](uint32_t address, infra::ConstByteRange contents)
+            {
+                flash.MethodDone();
+                sendWriteDone2 = [this]()
+                {
+                    flashResult.RequestSend([this]()
+                        {
+                            flashResult.WriteDone();
+                        });
+                };
+            });
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.WriteBuffer(infra::MakeRange(writeData), 1234, onDone);
+
+    // Both writes were requested before any WriteDone (pipelined)
+    ASSERT_TRUE(sendWriteDone1);
+    ASSERT_TRUE(sendWriteDone2);
+
+    sendWriteDone1();
+    sendWriteDone2();
+}
+
+class FlashSequentialProxyTest
+    : public testing::Test
+{
+public:
+    services::MethodSerializerFactory::OnHeap serializerFactory;
+    application::EchoSingleLoopback echo{ serializerFactory };
+    const std::array<uint32_t, 4> sectorSizesArray{ 4096, 4096, 4096, 4096 };
+    services::FlashEchoSequentialProxy flashProxy{ echo, infra::MakeRange(sectorSizesArray) };
+    testing::StrictMock<FlashMock> flash{ echo };
+    flash::FlashResultProxy flashResult{ echo };
+
+    const std::array<uint8_t, 4> data{ 5, 8, 2, 3 };
+};
+
+TEST_F(FlashSequentialProxyTest, Accessors)
+{
+    EXPECT_EQ(4, flashProxy.NumberOfSectors());
+    EXPECT_EQ(4096, flashProxy.SizeOfSector(0));
+    EXPECT_EQ(1, flashProxy.SectorOfAddress(5000));
+    EXPECT_EQ(4096, flashProxy.AddressOfSector(1));
+}
+
+TEST_F(FlashSequentialProxyTest, ReadBuffer)
+{
+    EXPECT_CALL(flash, Read(1234, 4)).WillOnce(testing::Invoke([this](uint32_t address, uint32_t size)
+        {
+            flashResult.RequestSend([this]()
+                {
+                    flashResult.ReadDone(infra::MakeRange(data));
+                    flash.MethodDone();
+                });
+        }));
+
+    std::array<uint8_t, 4> buffer{ 5, 8, 2, 3 };
+    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, [&]()
+        {
+            EXPECT_TRUE(infra::ContentsEqual(infra::MakeRange(buffer), infra::MakeRange(data)));
+        });
+}
+
+TEST_F(FlashSequentialProxyTest, WriteBuffer)
+{
+    EXPECT_CALL(flash, Write(1234, infra::CheckByteRangeContents(infra::MakeRange(data)))).WillOnce(testing::Invoke([this](uint32_t address, infra::ConstByteRange contents)
+        {
+            flashResult.RequestSend([this]()
+                {
+                    flashResult.WriteDone();
+                    flash.MethodDone();
+                });
+        }));
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.WriteBuffer(infra::MakeRange(data), 1234, onDone);
+}
+
+TEST_F(FlashSequentialProxyTest, EraseSectors)
+{
+    EXPECT_CALL(flash, EraseSectors(12, 22)).WillOnce(testing::Invoke([this](uint32_t sector, uint32_t numberOfSectors)
+        {
+            flashResult.RequestSend([this]()
+                {
+                    flashResult.EraseSectorsDone();
+                    flash.MethodDone();
+                });
+        }));
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.EraseSectors(12, 34, onDone);
+}
+
+TEST_F(FlashSequentialProxyTest, ReadBuffer_TwoChunks_SecondOnlyAfterFirstDone)
+{
+    constexpr auto twoChunkSize = flash::WriteRequest::contentsSize + 4;
+    std::array<uint8_t, twoChunkSize> buffer{};
+
+    infra::Function<void()> sendReadDone1;
+    infra::Function<void()> sendReadDone2;
+
+    EXPECT_CALL(flash, Read(1234, flash::WriteRequest::contentsSize))
+        .WillOnce([&](uint32_t address, uint32_t size)
+            {
+                flash.MethodDone();
+                sendReadDone1 = [this, size]()
+                {
+                    flashResult.RequestSend([this, size]()
+                        {
+                            std::array<uint8_t, flash::WriteRequest::contentsSize> chunk{};
+                            flashResult.ReadDone(infra::Head(infra::MakeRange(chunk), size));
+                        });
+                };
+            });
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, onDone);
+
+    // Only the first read was requested; the second is waiting for the first ReadDone
+    ASSERT_TRUE(sendReadDone1);
+    ASSERT_FALSE(sendReadDone2);
+
+    EXPECT_CALL(flash, Read(1234 + flash::WriteRequest::contentsSize, 4))
+        .WillOnce([&](uint32_t address, uint32_t size)
+            {
+                flash.MethodDone();
+                sendReadDone2 = [this, size]()
+                {
+                    flashResult.RequestSend([this, size]()
+                        {
+                            std::array<uint8_t, 4> chunk{};
+                            flashResult.ReadDone(infra::Head(infra::MakeRange(chunk), size));
+                        });
+                };
+            });
+
+    sendReadDone1();
+
+    // Now the second read was requested after the first completed
+    ASSERT_TRUE(sendReadDone2);
+
+    sendReadDone2();
+}
+
+TEST_F(FlashSequentialProxyTest, WriteBuffer_TwoChunks_SecondOnlyAfterFirstDone)
+{
+    constexpr auto twoChunkSize = flash::WriteRequest::contentsSize + 4;
+    std::array<uint8_t, twoChunkSize> writeData{};
+
+    infra::Function<void()> sendWriteDone1;
+    infra::Function<void()> sendWriteDone2;
+
+    EXPECT_CALL(flash, Write(1234, testing::_))
+        .WillOnce([&](uint32_t address, infra::ConstByteRange contents)
+            {
+                flash.MethodDone();
+                sendWriteDone1 = [this]()
+                {
+                    flashResult.RequestSend([this]()
+                        {
+                            flashResult.WriteDone();
+                        });
+                };
+            });
+
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.WriteBuffer(infra::MakeRange(writeData), 1234, onDone);
+
+    // Only the first write was requested; the second is waiting for the first WriteDone
+    ASSERT_TRUE(sendWriteDone1);
+    ASSERT_FALSE(sendWriteDone2);
+
+    EXPECT_CALL(flash, Write(1234 + flash::WriteRequest::contentsSize, testing::_))
+        .WillOnce([&](uint32_t address, infra::ConstByteRange contents)
+            {
+                flash.MethodDone();
+                sendWriteDone2 = [this]()
+                {
+                    flashResult.RequestSend([this]()
+                        {
+                            flashResult.WriteDone();
+                        });
+                };
+            });
+
+    sendWriteDone1();
+
+    // Now the second write was requested after the first completed
+    ASSERT_TRUE(sendWriteDone2);
+
+    sendWriteDone2();
+}

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -321,11 +321,11 @@ TEST_F(FlashSequentialProxyTest, ReadBuffer)
                 });
         }));
 
-    std::array<uint8_t, 4> buffer{ 5, 8, 2, 3 };
-    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, [&]()
-        {
-            EXPECT_TRUE(infra::ContentsEqual(infra::MakeRange(buffer), infra::MakeRange(data)));
-        });
+    std::array<uint8_t, 4> buffer{};
+    infra::VerifyingFunction<void()> onDone;
+    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, onDone);
+
+    EXPECT_TRUE(infra::ContentsEqual(infra::MakeRange(buffer), infra::MakeRange(data)));
 }
 
 TEST_F(FlashSequentialProxyTest, WriteBuffer)

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -237,8 +237,8 @@ TEST_F(FlashProxyTest, ReadBuffer_TwoChunks_BothRequestedBeforeDone)
     flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, onDone);
 
     // Both reads were requested before any ReadDone (pipelined)
-    ASSERT_TRUE(sendReadDone1);
-    ASSERT_TRUE(sendReadDone2);
+    EXPECT_TRUE(sendReadDone1);
+    EXPECT_TRUE(sendReadDone2);
 
     sendReadDone1();
     sendReadDone2();
@@ -281,8 +281,8 @@ TEST_F(FlashProxyTest, WriteBuffer_TwoChunks_BothRequestedBeforeDone)
     flashProxy.WriteBuffer(infra::MakeRange(writeData), 1234, onDone);
 
     // Both writes were requested before any WriteDone (pipelined)
-    ASSERT_TRUE(sendWriteDone1);
-    ASSERT_TRUE(sendWriteDone2);
+    EXPECT_TRUE(sendWriteDone1);
+    EXPECT_TRUE(sendWriteDone2);
 
     sendWriteDone1();
     sendWriteDone2();
@@ -384,8 +384,8 @@ TEST_F(FlashSequentialProxyTest, ReadBuffer_TwoChunks_SecondOnlyAfterFirstDone)
     flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, onDone);
 
     // Only the first read was requested; the second is waiting for the first ReadDone
-    ASSERT_TRUE(sendReadDone1);
-    ASSERT_FALSE(sendReadDone2);
+    EXPECT_TRUE(sendReadDone1);
+    EXPECT_FALSE(sendReadDone2);
 
     EXPECT_CALL(flash, Read(1234 + flash::WriteRequest::contentsSize, 4))
         .WillOnce([&](uint32_t address, uint32_t size)
@@ -434,8 +434,8 @@ TEST_F(FlashSequentialProxyTest, WriteBuffer_TwoChunks_SecondOnlyAfterFirstDone)
     flashProxy.WriteBuffer(infra::MakeRange(writeData), 1234, onDone);
 
     // Only the first write was requested; the second is waiting for the first WriteDone
-    ASSERT_TRUE(sendWriteDone1);
-    ASSERT_FALSE(sendWriteDone2);
+    EXPECT_TRUE(sendWriteDone1);
+    EXPECT_FALSE(sendWriteDone2);
 
     EXPECT_CALL(flash, Write(1234 + flash::WriteRequest::contentsSize, testing::_))
         .WillOnce([&](uint32_t address, infra::ConstByteRange contents)
@@ -453,7 +453,7 @@ TEST_F(FlashSequentialProxyTest, WriteBuffer_TwoChunks_SecondOnlyAfterFirstDone)
     sendWriteDone1();
 
     // Now the second write was requested after the first completed
-    ASSERT_TRUE(sendWriteDone2);
+    EXPECT_TRUE(sendWriteDone2);
 
     sendWriteDone2();
 }


### PR DESCRIPTION
This PR adds support for choosing between *pipelined* vs *sequential* chunked flash read/write behavior when using the Echo-based flash proxy, and expands the unit tests to validate both behaviors.

**Changes:**
- Refactors the existing `FlashEchoProxy` into a shared `FlashEchoProxyBase`, and introduces `FlashEchoSequentialProxy` for sequential chunk dispatch.
- Adds new unit tests to verify that `FlashEchoProxy` pipelines chunk requests while `FlashEchoSequentialProxy` waits for each `*Done` before issuing the next chunk.
- Updates homogeneous proxy construction to work with the refactor.