### PR TITLE
fix: when EchoPolicyDiffieHellman is initialized, it should not cancel a previous request

### DIFF
--- a/protobuf/echo/EchoOnStreams.cpp
+++ b/protobuf/echo/EchoOnStreams.cpp
@@ -79,7 +79,7 @@ namespace services
             sendRequesters.erase(serviceProxy);
         else
         {
-            assert(&serviceProxy == sendingProxy);
+            really_assert(&serviceProxy == sendingProxy);
             sendingProxy = nullptr;
             skipNextStream = true;
         }

--- a/services/util/EchoPolicyDiffieHellman.cpp
+++ b/services/util/EchoPolicyDiffieHellman.cpp
@@ -38,16 +38,12 @@ namespace services
 
     void EchoPolicyDiffieHellman::Initialized()
     {
-        if (busy)
-            DiffieHellmanKeyEstablishmentProxy::CancelRequestSend();
-
         initializingKeys = true;
         nextKeyPair.reset();
         verifier.reset();
 
         keyExchange.emplace(keyExchangeCreator, randomDataGenerator);
 
-        busy = true;
         DiffieHellmanKeyEstablishmentProxy::RequestSend([this]()
             {
                 DiffieHellmanKeyEstablishmentProxy::PresentCertificate(dsaCertificate);
@@ -58,7 +54,6 @@ namespace services
                         auto [r, s] = signer.Sign(encodedDhPublicKey);
 
                         DiffieHellmanKeyEstablishmentProxy::Exchange(encodedDhPublicKey, r, s);
-                        busy = false;
                     });
             });
     }

--- a/services/util/EchoPolicyDiffieHellman.hpp
+++ b/services/util/EchoPolicyDiffieHellman.hpp
@@ -78,7 +78,6 @@ namespace services
         infra::Function<void(ServiceProxy& proxy)> onRequest;
 
         bool initializingKeys = true;
-        bool busy = false;
         std::optional<std::pair<SesameSecured::KeyType, SesameSecured::IvType>> nextKeyPair;
         infra::IntrusiveList<ServiceProxy> waitingProxies;
 

--- a/services/util/test/TestEchoPolicyDiffieHellman.cpp
+++ b/services/util/test/TestEchoPolicyDiffieHellman.cpp
@@ -171,6 +171,14 @@ TEST_F(EchoPolicyDiffieHellmanTest, send_and_receive)
 
 TEST_F(EchoPolicyDiffieHellmanTest, intialize_while_initializing_starts_over)
 {
+    lowerLeftRequest = false;
+    lowerRightRequest = false;
+    EXPECT_CALL(lowerLeft, ResetReading());
+    EXPECT_CALL(lowerLeft, Reset());
+    echoOnSesameLeft.Reset();
+    EXPECT_CALL(lowerRight, ResetReading());
+    EXPECT_CALL(lowerRight, Reset());
+    echoOnSesameRight.Reset();
     Initialized(); // second initialization
 
     EXPECT_CALL(echoPolicyLeft, KeyExchangeSuccessful());


### PR DESCRIPTION
## Pull request overview

This PR adjusts the Diffie-Hellman based Echo policy initialization flow to avoid canceling a previously scheduled/in-flight send request when `EchoPolicyDiffieHellman::Initialized()` is called again, and tightens an invariant check in the stream-based Echo transport.