### PR TITLE
fix: in EchoPolicyDiffieHellman, distinguish between Initialized and Reset + Initialized

### DIFF
--- a/protobuf/echo/Echo.hpp
+++ b/protobuf/echo/Echo.hpp
@@ -85,6 +85,7 @@ namespace services
     public:
         using infra::Observer<EchoInitializationObserver, EchoInitialization>::Observer;
 
+        virtual void Reset() = 0;
         virtual void Initialized() = 0;
     };
 

--- a/services/util/EchoOnSesame.cpp
+++ b/services/util/EchoOnSesame.cpp
@@ -12,6 +12,12 @@ namespace services
         EchoOnStreams::Reset();
         initialized = false;
         requestedSize.reset();
+
+        infra::Subject<EchoInitializationObserver>::NotifyObservers([](auto& observer)
+            {
+                observer.Reset();
+            });
+
         SesameObserver::Subject().Reset();
     }
 

--- a/services/util/EchoPolicyDiffieHellman.cpp
+++ b/services/util/EchoPolicyDiffieHellman.cpp
@@ -39,6 +39,7 @@ namespace services
     void EchoPolicyDiffieHellman::Reset()
     {
         busy = false;
+        initializingKeys = true;
     }
 
     void EchoPolicyDiffieHellman::Initialized()

--- a/services/util/EchoPolicyDiffieHellman.cpp
+++ b/services/util/EchoPolicyDiffieHellman.cpp
@@ -36,14 +36,23 @@ namespace services
         echo.SetPolicy(*this);
     }
 
+    void EchoPolicyDiffieHellman::Reset()
+    {
+        busy = false;
+    }
+
     void EchoPolicyDiffieHellman::Initialized()
     {
+        if (busy)
+            DiffieHellmanKeyEstablishmentProxy::CancelRequestSend();
+
         initializingKeys = true;
         nextKeyPair.reset();
         verifier.reset();
 
         keyExchange.emplace(keyExchangeCreator, randomDataGenerator);
 
+        busy = true;
         DiffieHellmanKeyEstablishmentProxy::RequestSend([this]()
             {
                 DiffieHellmanKeyEstablishmentProxy::PresentCertificate(dsaCertificate);
@@ -54,6 +63,7 @@ namespace services
                         auto [r, s] = signer.Sign(encodedDhPublicKey);
 
                         DiffieHellmanKeyEstablishmentProxy::Exchange(encodedDhPublicKey, r, s);
+                        busy = false;
                     });
             });
     }

--- a/services/util/EchoPolicyDiffieHellman.hpp
+++ b/services/util/EchoPolicyDiffieHellman.hpp
@@ -53,6 +53,7 @@ namespace services
 
     private:
         // Implementation of SesameObserver
+        void Reset() override;
         void Initialized() override;
 
         // Implementation of EchoPolicy
@@ -78,6 +79,7 @@ namespace services
         infra::Function<void(ServiceProxy& proxy)> onRequest;
 
         bool initializingKeys = true;
+        bool busy = false;
         std::optional<std::pair<SesameSecured::KeyType, SesameSecured::IvType>> nextKeyPair;
         infra::IntrusiveList<ServiceProxy> waitingProxies;
 

--- a/services/util/EchoPolicyDiffieHellman.hpp
+++ b/services/util/EchoPolicyDiffieHellman.hpp
@@ -52,7 +52,7 @@ namespace services
         EchoPolicyDiffieHellman(const Crypto& crypto, Echo& echo, EchoInitialization& echoInitialization, SesameSecured& secured, infra::ConstByteRange dsaCertificate, infra::ConstByteRange rootCaCertificate, hal::SynchronousRandomDataGenerator& randomDataGenerator);
 
     private:
-        // Implementation of SesameObserver
+        // Implementation of EchoInitializationObserver
         void Reset() override;
         void Initialized() override;
 

--- a/services/util/EchoPolicySymmetricKey.cpp
+++ b/services/util/EchoPolicySymmetricKey.cpp
@@ -24,6 +24,11 @@ namespace services
         echo.SetPolicy(*this);
     }
 
+    void EchoPolicySymmetricKey::Reset()
+    {
+        initializingSending = true;
+    }
+
     void EchoPolicySymmetricKey::Initialized()
     {
         initializingSending = true;

--- a/services/util/EchoPolicySymmetricKey.hpp
+++ b/services/util/EchoPolicySymmetricKey.hpp
@@ -19,6 +19,7 @@ namespace services
 
     private:
         // Implementation of EchoInitializationObserver
+        void Reset() override;
         void Initialized() override;
 
         // Implementation of EchoPolicy

--- a/services/util/test/TestEchoPolicyDiffieHellman.cpp
+++ b/services/util/test/TestEchoPolicyDiffieHellman.cpp
@@ -169,7 +169,17 @@ TEST_F(EchoPolicyDiffieHellmanTest, send_and_receive)
     ExchangeData();
 }
 
-TEST_F(EchoPolicyDiffieHellmanTest, intialize_while_initializing_starts_over)
+TEST_F(EchoPolicyDiffieHellmanTest, initialize_while_initializing_starts_over)
+{
+    Initialized(); // second initialization
+
+    EXPECT_CALL(echoPolicyLeft, KeyExchangeSuccessful());
+    EXPECT_CALL(echoPolicyRight, KeyExchangeSuccessful());
+
+    ExchangeData();
+}
+
+TEST_F(EchoPolicyDiffieHellmanTest, reset_and_initialize_while_initializing_starts_over)
 {
     lowerLeftRequest = false;
     lowerRightRequest = false;
@@ -179,6 +189,7 @@ TEST_F(EchoPolicyDiffieHellmanTest, intialize_while_initializing_starts_over)
     EXPECT_CALL(lowerRight, ResetReading());
     EXPECT_CALL(lowerRight, Reset());
     echoOnSesameRight.Reset();
+
     Initialized(); // second initialization
 
     EXPECT_CALL(echoPolicyLeft, KeyExchangeSuccessful());


### PR DESCRIPTION
## Pull request overview

This PR extends the Echo initialization lifecycle with an explicit `Reset()` notification so policies can distinguish a clean re-initialization from a reset + re-initialization scenario, and updates Diffie-Hellman behavior/tests accordingly.

**Changes:**
- Add `Reset()` to `EchoInitializationObserver` and propagate it from `EchoOnSesame::Reset()`.
- Implement `Reset()` in `EchoPolicyDiffieHellman` (with a new `busy` flag) and `EchoPolicySymmetricKey`.
- Update/extend Diffie-Hellman policy tests to cover “initialize while initializing” vs “reset + initialize while initializing”.