### PR TITLE
feat: add tracer classes that only trace the name of the service and method

### DIFF
--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
@@ -1633,7 +1633,7 @@ switch (methodId)
         return "Name";
     }
 
-    void NameTracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    void NameTracingServiceGenerator::TraceParameters([[maybe_unused]] const EchoMethod& method, [[maybe_unused]] google::protobuf::io::Printer& printer) const
     {}
 
     EchoGenerator::EchoGenerator(google::protobuf::compiler::GeneratorContext* generatorContext, const std::string& name, const google::protobuf::FileDescriptor* file)

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
@@ -1487,24 +1487,41 @@ SetSerializer(serializer);
         serviceFormatter->Add(dataMembers);
     }
 
-    NameTracingServiceGenerator::NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter, const std::string& namePrefix)
+    TracingServiceGenerator::TracingServiceGenerator(const std::shared_ptr<const EchoService>& service)
         : service(service)
+    {}
+
+    void TracingServiceGenerator::Generate(Entities& formatter)
     {
-        auto serviceClass = std::make_shared<Class>(service->name + namePrefix + "Tracer");
+        auto serviceClass = std::make_shared<Class>(service->name + NamePrefix() + "Tracer");
         serviceClass->Parent("public services::ServiceTracer");
         serviceFormatter = serviceClass.get();
         formatter.Add(serviceClass);
 
-        GenerateServiceConstructors(namePrefix);
+        GenerateServiceConstructors(NamePrefix());
         GenerateServiceFunctions();
         GenerateFieldConstants();
         GenerateDataMembers();
     }
 
-    void NameTracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
-    {}
+    std::string TracingServiceGenerator::NamePrefix() const
+    {
+        return "";
+    }
 
-    void NameTracingServiceGenerator::GenerateServiceConstructors(const std::string& namePrefix)
+    void TracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    {
+        if (method.parameter)
+            for (auto& field : method.parameter->fields)
+            {
+                if (&field != &method.parameter->fields.front())
+                    printer.Print(R"(            tracer.Continue() << ", ";
+)");
+                printer.Print("            services::PrintField(argument.$field$, tracer);\n", "field", field->name);
+            }
+    }
+
+    void TracingServiceGenerator::GenerateServiceConstructors(const std::string& namePrefix)
     {
         auto constructors = std::make_shared<Access>("public");
         auto constructor = std::make_shared<Constructor>(service->name + namePrefix + "Tracer", "tracingEcho.AddServiceTracer(*this);\n", 0);
@@ -1518,7 +1535,7 @@ SetSerializer(serializer);
         serviceFormatter->Add(constructors);
     }
 
-    void NameTracingServiceGenerator::GenerateServiceFunctions()
+    void TracingServiceGenerator::GenerateServiceFunctions()
     {
         auto functions = std::make_shared<Access>("public");
 
@@ -1531,7 +1548,7 @@ SetSerializer(serializer);
         serviceFormatter->Add(functions);
     }
 
-    void NameTracingServiceGenerator::GenerateFieldConstants()
+    void TracingServiceGenerator::GenerateFieldConstants()
     {
         auto fields = std::make_shared<Access>("public");
 
@@ -1543,7 +1560,7 @@ SetSerializer(serializer);
         serviceFormatter->Add(fields);
     }
 
-    void NameTracingServiceGenerator::GenerateDataMembers()
+    void TracingServiceGenerator::GenerateDataMembers()
     {
         auto dataMembers = std::make_shared<Access>("public");
 
@@ -1552,7 +1569,7 @@ SetSerializer(serializer);
         serviceFormatter->Add(dataMembers);
     }
 
-    std::string NameTracingServiceGenerator::TraceMethodBody() const
+    std::string TracingServiceGenerator::TraceMethodBody() const
     {
         std::ostringstream result;
         {
@@ -1607,21 +1624,17 @@ switch (methodId)
         return result.str();
     }
 
-    TracingServiceGenerator::TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
-        : NameTracingServiceGenerator(service, formatter, "")
+    NameTracingServiceGenerator::NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service)
+        : TracingServiceGenerator(service)
     {}
 
-    void TracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    std::string NameTracingServiceGenerator::NamePrefix() const
     {
-        if (method.parameter)
-            for (auto& field : method.parameter->fields)
-            {
-                if (&field != &method.parameter->fields.front())
-                    printer.Print(R"(            tracer.Continue() << ", ";
-)");
-                printer.Print("            services::PrintField(argument.$field$, tracer);\n", "field", field->name);
-            }
+        return "Name";
     }
+
+    void NameTracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    {}
 
     EchoGenerator::EchoGenerator(google::protobuf::compiler::GeneratorContext* generatorContext, const std::string& name, const google::protobuf::FileDescriptor* file)
         : stream(generatorContext->Open(name))
@@ -1741,9 +1754,11 @@ switch (methodId)
 
         for (auto& service : root.GetFile(*file)->services)
         {
-            tracingServiceGenerators.emplace_back(std::make_shared<TracingServiceGenerator>(service, *currentEntity));
+            tracingServiceGenerators.emplace_back(std::make_shared<TracingServiceGenerator>(service));
+            tracingServiceGenerators.back()->Generate(*currentEntity);
             nullTracingServiceGenerators.emplace_back(std::make_shared<NullTracingServiceGenerator>(service, *currentEntity));
-            nameTracingServiceGenerators.emplace_back(std::make_shared<NameTracingServiceGenerator>(service, *currentEntity));
+            nameTracingServiceGenerators.emplace_back(std::make_shared<NameTracingServiceGenerator>(service));
+            nameTracingServiceGenerators.back()->Generate(*currentEntity);
         }
     }
 

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
@@ -1428,130 +1428,6 @@ SetSerializer(serializer);
         return result.str();
     }
 
-    TracingServiceGenerator::TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
-        : service(service)
-    {
-        auto serviceClass = std::make_shared<Class>(service->name + "Tracer");
-        serviceClass->Parent("public services::ServiceTracer");
-        serviceFormatter = serviceClass.get();
-        formatter.Add(serviceClass);
-
-        GenerateServiceConstructors();
-        GenerateServiceFunctions();
-        GenerateFieldConstants();
-        GenerateDataMembers();
-    }
-
-    void TracingServiceGenerator::GenerateServiceConstructors()
-    {
-        auto constructors = std::make_shared<Access>("public");
-        auto constructor = std::make_shared<Constructor>(service->name + "Tracer", "tracingEcho.AddServiceTracer(*this);\n", 0);
-        constructor->Parameter("services::TracingEchoOnStreams& tracingEcho");
-        constructor->Initializer("services::ServiceTracer(serviceId)");
-        constructor->Initializer("tracingEcho(tracingEcho)");
-        constructors->Add(constructor);
-
-        constructors->Add(std::make_shared<Constructor>("~" + service->name + "Tracer", "tracingEcho.RemoveServiceTracer(*this);\n", 0));
-
-        serviceFormatter->Add(constructors);
-    }
-
-    void TracingServiceGenerator::GenerateServiceFunctions()
-    {
-        auto functions = std::make_shared<Access>("public");
-
-        auto handle = std::make_shared<Function>("TraceMethod", TraceMethodBody(), "void", Function::fOverride | Function::fConst);
-        handle->Parameter("uint32_t methodId");
-        handle->Parameter("infra::ProtoLengthDelimited& contents");
-        handle->Parameter("services::Tracer& tracer");
-        functions->Add(handle);
-
-        serviceFormatter->Add(functions);
-    }
-
-    void TracingServiceGenerator::GenerateFieldConstants()
-    {
-        auto fields = std::make_shared<Access>("public");
-
-        fields->Add(std::make_shared<DataMember>("serviceId", "static const uint32_t", absl::StrCat(service->serviceId)));
-
-        for (auto& method : service->methods)
-            fields->Add(std::make_shared<DataMember>("id" + method.name, "static const uint32_t", absl::StrCat(method.methodId)));
-
-        serviceFormatter->Add(fields);
-    }
-
-    void TracingServiceGenerator::GenerateDataMembers()
-    {
-        auto dataMembers = std::make_shared<Access>("public");
-
-        dataMembers->Add(std::make_shared<DataMember>("tracingEcho", "services::TracingEchoOnStreams&"));
-
-        serviceFormatter->Add(dataMembers);
-    }
-
-    std::string TracingServiceGenerator::TraceMethodBody() const
-    {
-        std::ostringstream result;
-        {
-            google::protobuf::io::OstreamOutputStream stream(&result);
-            google::protobuf::io::Printer printer(&stream, '$', nullptr);
-
-            if (!service->methods.empty())
-            {
-                printer.Print(R"(infra::ProtoParser parser(contents.Parser());
-
-switch (methodId)
-{
-)");
-
-                for (auto& method : service->methods)
-                {
-                    printer.Print(R"(    case id$name$:
-    {
-)",
-                        "name", method.name);
-                    if (method.parameter)
-                        printer.Print("        $argument$ argument(parser);\n", "argument", method.parameter->qualifiedName);
-                    printer.Print(R"(        if (!parser.FormatFailed())
-        {
-            tracer.Continue() << "$servicename$.$name$(";
-)",
-                        "servicename", service->name, "name", method.name);
-
-                    if (method.parameter)
-                        for (auto& field : method.parameter->fields)
-                        {
-                            if (&field != &method.parameter->fields.front())
-                                printer.Print(R"(            tracer.Continue() << ", ";
-)");
-                            printer.Print("            services::PrintField(argument.$field$, tracer);\n", "field", field->name);
-                        }
-
-                    printer.Print(R"_(            tracer.Continue() << ")";
-        }
-        else
-            tracer.Continue() << "$servicename$.$name$(parse error)";
-        break;
-    }
-)_",
-                        "servicename", service->name, "name", method.name);
-                }
-
-                printer.Print(R"(    default:
-        tracer.Continue() << "$servicename$ method " << methodId << " not found";
-)",
-                    "servicename", service->name);
-
-                printer.Print("}\n");
-            }
-            else
-                printer.Print(R"(tracer.Continue() << "$servicename$ method " << methodId << " not found";\ncontents.SkipEverything();\n)", "servicename", service->name);
-        }
-
-        return result.str();
-    }
-
     NullTracingServiceGenerator::NullTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
         : service(service)
     {
@@ -1584,7 +1460,7 @@ switch (methodId)
     {
         auto functions = std::make_shared<Access>("public");
 
-        auto handle = std::make_shared<Function>("TraceMethod", "contents.SkipEverything();", "void", Function::fOverride | Function::fConst);
+        auto handle = std::make_shared<Function>("TraceMethod", "contents.SkipEverything();\n", "void", Function::fOverride | Function::fConst);
         handle->Parameter("uint32_t methodId");
         handle->Parameter("infra::ProtoLengthDelimited& contents");
         handle->Parameter("services::Tracer& tracer");
@@ -1609,6 +1485,142 @@ switch (methodId)
         dataMembers->Add(std::make_shared<DataMember>("tracingEcho", "services::TracingEchoOnStreams&"));
 
         serviceFormatter->Add(dataMembers);
+    }
+
+    NameTracingServiceGenerator::NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter, const std::string& namePrefix)
+        : service(service)
+    {
+        auto serviceClass = std::make_shared<Class>(service->name + namePrefix + "Tracer");
+        serviceClass->Parent("public services::ServiceTracer");
+        serviceFormatter = serviceClass.get();
+        formatter.Add(serviceClass);
+
+        GenerateServiceConstructors(namePrefix);
+        GenerateServiceFunctions();
+        GenerateFieldConstants();
+        GenerateDataMembers();
+    }
+
+    void NameTracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    {}
+
+    void NameTracingServiceGenerator::GenerateServiceConstructors(const std::string& namePrefix)
+    {
+        auto constructors = std::make_shared<Access>("public");
+        auto constructor = std::make_shared<Constructor>(service->name + namePrefix + "Tracer", "tracingEcho.AddServiceTracer(*this);\n", 0);
+        constructor->Parameter("services::TracingEchoOnStreams& tracingEcho");
+        constructor->Initializer("services::ServiceTracer(serviceId)");
+        constructor->Initializer("tracingEcho(tracingEcho)");
+        constructors->Add(constructor);
+
+        constructors->Add(std::make_shared<Constructor>("~" + service->name + namePrefix + "Tracer", "tracingEcho.RemoveServiceTracer(*this);\n", 0));
+
+        serviceFormatter->Add(constructors);
+    }
+
+    void NameTracingServiceGenerator::GenerateServiceFunctions()
+    {
+        auto functions = std::make_shared<Access>("public");
+
+        auto handle = std::make_shared<Function>("TraceMethod", TraceMethodBody(), "void", Function::fOverride | Function::fConst);
+        handle->Parameter("uint32_t methodId");
+        handle->Parameter("infra::ProtoLengthDelimited& contents");
+        handle->Parameter("services::Tracer& tracer");
+        functions->Add(handle);
+
+        serviceFormatter->Add(functions);
+    }
+
+    void NameTracingServiceGenerator::GenerateFieldConstants()
+    {
+        auto fields = std::make_shared<Access>("public");
+
+        fields->Add(std::make_shared<DataMember>("serviceId", "static const uint32_t", absl::StrCat(service->serviceId)));
+
+        for (auto& method : service->methods)
+            fields->Add(std::make_shared<DataMember>("id" + method.name, "static const uint32_t", absl::StrCat(method.methodId)));
+
+        serviceFormatter->Add(fields);
+    }
+
+    void NameTracingServiceGenerator::GenerateDataMembers()
+    {
+        auto dataMembers = std::make_shared<Access>("public");
+
+        dataMembers->Add(std::make_shared<DataMember>("tracingEcho", "services::TracingEchoOnStreams&"));
+
+        serviceFormatter->Add(dataMembers);
+    }
+
+    std::string NameTracingServiceGenerator::TraceMethodBody() const
+    {
+        std::ostringstream result;
+        {
+            google::protobuf::io::OstreamOutputStream stream(&result);
+            google::protobuf::io::Printer printer(&stream, '$', nullptr);
+
+            if (!service->methods.empty())
+            {
+                printer.Print(R"(infra::ProtoParser parser(contents.Parser());
+
+switch (methodId)
+{
+)");
+
+                for (auto& method : service->methods)
+                {
+                    printer.Print(R"(    case id$name$:
+    {
+)",
+                        "name", method.name);
+                    if (method.parameter)
+                        printer.Print("        $argument$ argument(parser);\n", "argument", method.parameter->qualifiedName);
+                    printer.Print(R"(        if (!parser.FormatFailed())
+        {
+            tracer.Continue() << "$servicename$.$name$(";
+)",
+                        "servicename", service->name, "name", method.name);
+
+                    TraceParameters(method, printer);
+
+                    printer.Print(R"_(            tracer.Continue() << ")";
+        }
+        else
+            tracer.Continue() << "$servicename$.$name$(parse error)";
+        break;
+    }
+)_",
+                        "servicename", service->name, "name", method.name);
+                }
+
+                printer.Print(R"(    default:
+        tracer.Continue() << "$servicename$ method " << methodId << " not found";
+)",
+                    "servicename", service->name);
+
+                printer.Print("}\n");
+            }
+            else
+                printer.Print(R"(tracer.Continue() << "$servicename$ method " << methodId << " not found";\ncontents.SkipEverything();\n)", "servicename", service->name);
+        }
+
+        return result.str();
+    }
+
+    TracingServiceGenerator::TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
+        : NameTracingServiceGenerator(service, formatter, "")
+    {}
+
+    void TracingServiceGenerator::TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const
+    {
+        if (method.parameter)
+            for (auto& field : method.parameter->fields)
+            {
+                if (&field != &method.parameter->fields.front())
+                    printer.Print(R"(            tracer.Continue() << ", ";
+)");
+                printer.Print("            services::PrintField(argument.$field$, tracer);\n", "field", field->name);
+            }
     }
 
     EchoGenerator::EchoGenerator(google::protobuf::compiler::GeneratorContext* generatorContext, const std::string& name, const google::protobuf::FileDescriptor* file)
@@ -1731,6 +1743,7 @@ switch (methodId)
         {
             tracingServiceGenerators.emplace_back(std::make_shared<TracingServiceGenerator>(service, *currentEntity));
             nullTracingServiceGenerators.emplace_back(std::make_shared<NullTracingServiceGenerator>(service, *currentEntity));
+            nameTracingServiceGenerators.emplace_back(std::make_shared<NameTracingServiceGenerator>(service, *currentEntity));
         }
     }
 

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.cpp
@@ -1428,65 +1428,6 @@ SetSerializer(serializer);
         return result.str();
     }
 
-    NullTracingServiceGenerator::NullTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
-        : service(service)
-    {
-        auto serviceClass = std::make_shared<Class>(service->name + "NullTracer");
-        serviceClass->Parent("public services::ServiceNullTracer");
-        serviceFormatter = serviceClass.get();
-        formatter.Add(serviceClass);
-
-        GenerateServiceConstructors();
-        GenerateServiceFunctions();
-        GenerateFieldConstants();
-        GenerateDataMembers();
-    }
-
-    void NullTracingServiceGenerator::GenerateServiceConstructors()
-    {
-        auto constructors = std::make_shared<Access>("public");
-        auto constructor = std::make_shared<Constructor>(service->name + "NullTracer", "tracingEcho.AddServiceTracer(*this);\n", 0);
-        constructor->Parameter("services::TracingEchoOnStreams& tracingEcho");
-        constructor->Initializer("services::ServiceNullTracer(serviceId)");
-        constructor->Initializer("tracingEcho(tracingEcho)");
-        constructors->Add(constructor);
-
-        constructors->Add(std::make_shared<Constructor>("~" + service->name + "NullTracer", "tracingEcho.RemoveServiceTracer(*this);\n", 0));
-
-        serviceFormatter->Add(constructors);
-    }
-
-    void NullTracingServiceGenerator::GenerateServiceFunctions()
-    {
-        auto functions = std::make_shared<Access>("public");
-
-        auto handle = std::make_shared<Function>("TraceMethod", "contents.SkipEverything();\n", "void", Function::fOverride | Function::fConst);
-        handle->Parameter("uint32_t methodId");
-        handle->Parameter("infra::ProtoLengthDelimited& contents");
-        handle->Parameter("services::Tracer& tracer");
-        functions->Add(handle);
-
-        serviceFormatter->Add(functions);
-    }
-
-    void NullTracingServiceGenerator::GenerateFieldConstants()
-    {
-        auto fields = std::make_shared<Access>("public");
-
-        fields->Add(std::make_shared<DataMember>("serviceId", "static const uint32_t", absl::StrCat(service->serviceId)));
-
-        serviceFormatter->Add(fields);
-    }
-
-    void NullTracingServiceGenerator::GenerateDataMembers()
-    {
-        auto dataMembers = std::make_shared<Access>("public");
-
-        dataMembers->Add(std::make_shared<DataMember>("tracingEcho", "services::TracingEchoOnStreams&"));
-
-        serviceFormatter->Add(dataMembers);
-    }
-
     TracingServiceGenerator::TracingServiceGenerator(const std::shared_ptr<const EchoService>& service)
         : service(service)
     {}
@@ -1622,6 +1563,65 @@ switch (methodId)
         }
 
         return result.str();
+    }
+
+    NullTracingServiceGenerator::NullTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter)
+        : service(service)
+    {
+        auto serviceClass = std::make_shared<Class>(service->name + "NullTracer");
+        serviceClass->Parent("public services::ServiceNullTracer");
+        serviceFormatter = serviceClass.get();
+        formatter.Add(serviceClass);
+
+        GenerateServiceConstructors();
+        GenerateServiceFunctions();
+        GenerateFieldConstants();
+        GenerateDataMembers();
+    }
+
+    void NullTracingServiceGenerator::GenerateServiceConstructors()
+    {
+        auto constructors = std::make_shared<Access>("public");
+        auto constructor = std::make_shared<Constructor>(service->name + "NullTracer", "tracingEcho.AddServiceTracer(*this);\n", 0);
+        constructor->Parameter("services::TracingEchoOnStreams& tracingEcho");
+        constructor->Initializer("services::ServiceNullTracer(serviceId)");
+        constructor->Initializer("tracingEcho(tracingEcho)");
+        constructors->Add(constructor);
+
+        constructors->Add(std::make_shared<Constructor>("~" + service->name + "NullTracer", "tracingEcho.RemoveServiceTracer(*this);\n", 0));
+
+        serviceFormatter->Add(constructors);
+    }
+
+    void NullTracingServiceGenerator::GenerateServiceFunctions()
+    {
+        auto functions = std::make_shared<Access>("public");
+
+        auto handle = std::make_shared<Function>("TraceMethod", "contents.SkipEverything();\n", "void", Function::fOverride | Function::fConst);
+        handle->Parameter("uint32_t methodId");
+        handle->Parameter("infra::ProtoLengthDelimited& contents");
+        handle->Parameter("services::Tracer& tracer");
+        functions->Add(handle);
+
+        serviceFormatter->Add(functions);
+    }
+
+    void NullTracingServiceGenerator::GenerateFieldConstants()
+    {
+        auto fields = std::make_shared<Access>("public");
+
+        fields->Add(std::make_shared<DataMember>("serviceId", "static const uint32_t", absl::StrCat(service->serviceId)));
+
+        serviceFormatter->Add(fields);
+    }
+
+    void NullTracingServiceGenerator::GenerateDataMembers()
+    {
+        auto dataMembers = std::make_shared<Access>("public");
+
+        dataMembers->Add(std::make_shared<DataMember>("tracingEcho", "services::TracingEchoOnStreams&"));
+
+        serviceFormatter->Add(dataMembers);
     }
 
     NameTracingServiceGenerator::NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service)

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
@@ -177,25 +177,6 @@ namespace application
         Class* serviceProxyFormatter;
     };
 
-    class NullTracingServiceGenerator
-    {
-    public:
-        NullTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter);
-        NullTracingServiceGenerator(const NullTracingServiceGenerator& other) = delete;
-        NullTracingServiceGenerator& operator=(const NullTracingServiceGenerator& other) = delete;
-        ~NullTracingServiceGenerator() = default;
-
-    private:
-        void GenerateServiceConstructors();
-        void GenerateServiceFunctions();
-        void GenerateFieldConstants();
-        void GenerateDataMembers();
-
-    private:
-        std::shared_ptr<const EchoService> service;
-        Class* serviceFormatter;
-    };
-
     class TracingServiceGenerator
     {
     public:
@@ -217,6 +198,25 @@ namespace application
         void GenerateDataMembers();
 
         std::string TraceMethodBody() const;
+
+    private:
+        std::shared_ptr<const EchoService> service;
+        Class* serviceFormatter;
+    };
+
+    class NullTracingServiceGenerator
+    {
+    public:
+        NullTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter);
+        NullTracingServiceGenerator(const NullTracingServiceGenerator& other) = delete;
+        NullTracingServiceGenerator& operator=(const NullTracingServiceGenerator& other) = delete;
+        ~NullTracingServiceGenerator() = default;
+
+    private:
+        void GenerateServiceConstructors();
+        void GenerateServiceFunctions();
+        void GenerateFieldConstants();
+        void GenerateDataMembers();
 
     private:
         std::shared_ptr<const EchoService> service;

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
@@ -177,27 +177,6 @@ namespace application
         Class* serviceProxyFormatter;
     };
 
-    class TracingServiceGenerator
-    {
-    public:
-        TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter);
-        TracingServiceGenerator(const TracingServiceGenerator& other) = delete;
-        TracingServiceGenerator& operator=(const TracingServiceGenerator& other) = delete;
-        ~TracingServiceGenerator() = default;
-
-    private:
-        void GenerateServiceConstructors();
-        void GenerateServiceFunctions();
-        void GenerateFieldConstants();
-        void GenerateDataMembers();
-
-        std::string TraceMethodBody() const;
-
-    private:
-        std::shared_ptr<const EchoService> service;
-        Class* serviceFormatter;
-    };
-
     class NullTracingServiceGenerator
     {
     public:
@@ -215,6 +194,40 @@ namespace application
     private:
         std::shared_ptr<const EchoService> service;
         Class* serviceFormatter;
+    };
+
+    class NameTracingServiceGenerator
+    {
+    public:
+        NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter, const std::string& namePrefix = "Name");
+        NameTracingServiceGenerator(const NameTracingServiceGenerator& other) = delete;
+        NameTracingServiceGenerator& operator=(const NameTracingServiceGenerator& other) = delete;
+        ~NameTracingServiceGenerator() = default;
+
+    protected:
+        virtual void TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const;
+
+    private:
+        void GenerateServiceConstructors(const std::string& namePrefix);
+        void GenerateServiceFunctions();
+        void GenerateFieldConstants();
+        void GenerateDataMembers();
+
+        std::string TraceMethodBody() const;
+
+    private:
+        std::shared_ptr<const EchoService> service;
+        Class* serviceFormatter;
+    };
+
+    class TracingServiceGenerator
+        : private NameTracingServiceGenerator
+    {
+    public:
+        TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter);
+
+    private:
+        void TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const override;
     };
 
     class EchoGenerator
@@ -269,6 +282,7 @@ namespace application
 
         std::vector<std::shared_ptr<TracingServiceGenerator>> tracingServiceGenerators;
         std::vector<std::shared_ptr<NullTracingServiceGenerator>> nullTracingServiceGenerators;
+        std::vector<std::shared_ptr<NameTracingServiceGenerator>> nameTracingServiceGenerators;
     };
 }
 

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
@@ -196,15 +196,18 @@ namespace application
         Class* serviceFormatter;
     };
 
-    class NameTracingServiceGenerator
+    class TracingServiceGenerator
     {
     public:
-        NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter, const std::string& namePrefix = "Name");
-        NameTracingServiceGenerator(const NameTracingServiceGenerator& other) = delete;
-        NameTracingServiceGenerator& operator=(const NameTracingServiceGenerator& other) = delete;
-        ~NameTracingServiceGenerator() = default;
+        TracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
+        TracingServiceGenerator(const TracingServiceGenerator& other) = delete;
+        TracingServiceGenerator& operator=(const TracingServiceGenerator& other) = delete;
+        ~TracingServiceGenerator() = default;
+
+        void Generate(Entities& formatter);
 
     protected:
+        virtual std::string NamePrefix() const;
         virtual void TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const;
 
     private:
@@ -220,13 +223,14 @@ namespace application
         Class* serviceFormatter;
     };
 
-    class TracingServiceGenerator
-        : private NameTracingServiceGenerator
+    class NameTracingServiceGenerator
+        : public TracingServiceGenerator
     {
     public:
-        TracingServiceGenerator(const std::shared_ptr<const EchoService>& service, Entities& formatter);
+        NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
 
     private:
+        std::string NamePrefix() const override;
         void TraceParameters(const EchoMethod& method, google::protobuf::io::Printer& printer) const override;
     };
 

--- a/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
+++ b/protobuf/protoc_echo_plugin/ProtoCEchoPlugin.hpp
@@ -180,7 +180,7 @@ namespace application
     class TracingServiceGenerator
     {
     public:
-        TracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
+        explicit TracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
         TracingServiceGenerator(const TracingServiceGenerator& other) = delete;
         TracingServiceGenerator& operator=(const TracingServiceGenerator& other) = delete;
         ~TracingServiceGenerator() = default;
@@ -227,7 +227,7 @@ namespace application
         : public TracingServiceGenerator
     {
     public:
-        NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
+        explicit NameTracingServiceGenerator(const std::shared_ptr<const EchoService>& service);
 
     private:
         std::string NamePrefix() const override;


### PR DESCRIPTION
## Pull request overview

This PR extends the `protoc_echo_plugin` code generator with additional tracer-class variants, specifically introducing a “name-only” service tracer while refactoring the existing tracer generator to share common trace-method generation logic.