### PR TITLE
docs: add information about event dispatcher

### DIFF
--- a/documents/modules/ROOT/nav.adoc
+++ b/documents/modules/ROOT/nav.adoc
@@ -1,4 +1,6 @@
 * xref:ExecutionModel.adoc[Execution Model]
+* xref:EventDispatcher.adoc[Event Dispatcher]
+* xref:ClaimableResource.adoc[ClaimableResource]
 * xref:MemoryRange.adoc[MemoryRange]
 * xref:Containers.adoc[Containers]
 * xref:Echo.adoc[Echo]

--- a/documents/modules/ROOT/pages/ClaimableResource.adoc
+++ b/documents/modules/ROOT/pages/ClaimableResource.adoc
@@ -15,7 +15,7 @@ depending on current ownership and queue state.
 2. Do not assume there are no scheduled claim-related callbacks after releasing interest.
 3. Do not destroy objects while it is still possible that claim handling is queued.
 
-== Recommended workarounds
+== Recommended solutions
 
 1. Design claim callbacks so they are safe regardless of whether execution is effectively immediate or delayed.
 2. Explicitly release claimers during shutdown.

--- a/documents/modules/ROOT/pages/ClaimableResource.adoc
+++ b/documents/modules/ROOT/pages/ClaimableResource.adoc
@@ -1,0 +1,23 @@
+= ClaimableResource
+:source-highlighter: highlight.js
+
+== Introduction
+
+`infra::ClaimableResource` queues claimers until the resource can be granted.
+This is useful for serialized access, but it introduces ordering and lifetime subtleties.
+
+For broader dispatcher usage and lifetime patterns, see xref:EventDispatcher.adoc[Event Dispatcher].
+
+== Common pitfalls
+
+1. Do not assume a fixed timing model for `Claim()`. A claim can be granted very soon (next dispatcher turn) or later,
+depending on current ownership and queue state.
+2. Do not assume there are no scheduled claim-related callbacks after releasing interest.
+3. Do not destroy objects while it is still possible that claim handling is queued.
+
+== Recommended workarounds
+
+1. Design claim callbacks so they are safe regardless of whether execution is effectively immediate or delayed.
+2. Explicitly release claimers during shutdown.
+3. If it is not certain that no claim-related work is scheduled anymore, implement an asynchronous stop phase with
+`services::Stoppable` and wait for stop completion before destruction.

--- a/documents/modules/ROOT/pages/EventDispatcher.adoc
+++ b/documents/modules/ROOT/pages/EventDispatcher.adoc
@@ -14,9 +14,7 @@ Use `Schedule()` to queue small units of work on the dispatcher. Scheduled actio
 which avoids most synchronization concerns that are common in multi-threaded code.
 
 `Schedule()` takes an `infra::Function<void()>`, and is therefore often used with lambda functions.
-Applications typically create an event dispatcher during startup and enter its `Run()` loop from `main()`.
-
-For generic tasks there is also a globally available dispatcher via `infra::EventDispatcher::Instance()`.
+Applications typically create an event dispatcher during startup. This event dispatcher is globally available via `infra::EventDispatcher::Instance()`. By invoking `Run()` on that event dispatcher from `main()`, that event dispatcher indefinitely executes all scheduled actions.
 
 Actions on the dispatcher should be short and non-blocking. Long-running work should start asynchronously,
 and completion should schedule follow-up work back on the dispatcher.

--- a/documents/modules/ROOT/pages/EventDispatcher.adoc
+++ b/documents/modules/ROOT/pages/EventDispatcher.adoc
@@ -25,7 +25,7 @@ Be careful when capturing state in lambdas passed to `Schedule()`. Scheduled wor
 so both lifetime and value stability must be considered.
 
 1. Capturing by reference (or by capturing `this`) means the lambda observes the value at the time it executes, not at the time it is scheduled.
-2. This is often undesirable for critical updates, such as reporting a specific status, where the original value must be preserved. In that case, capture that value explicitly by value.
+2. This is often undesirable for critical updates, such as reporting a specific status, where the original value must be preserved. In that case, capture that status explicitly by value.
 3. Capture size is typically limited, so large state is sometimes stored on `this` instead of inside the lambda. When doing that, remember that the state read by the lambda may have changed before execution.
 
 When scheduling work on an object that may be destroyed before execution, use one of the lifetime management patterns below.

--- a/documents/modules/ROOT/pages/EventDispatcher.adoc
+++ b/documents/modules/ROOT/pages/EventDispatcher.adoc
@@ -1,0 +1,75 @@
+= Event Dispatcher
+:source-highlighter: highlight.js
+
+== Introduction
+
+This page provides practical guidance for using the event dispatcher in Embedded Infrastructure Library,
+with a focus on lifetime management and common pitfalls.
+
+For the high-level execution model, see xref:ExecutionModel.adoc[Execution Model].
+
+== Scheduling work
+
+Use `Schedule()` to queue small units of work on the dispatcher. Scheduled actions are executed one by one,
+which avoids most synchronization concerns that are common in multi-threaded code.
+
+`Schedule()` takes an `infra::Function<void()>`, and is therefore often used with lambda functions.
+Applications typically create an event dispatcher during startup and enter its `Run()` loop from `main()`.
+
+For generic tasks there is also a globally available dispatcher via `infra::EventDispatcher::Instance()`.
+
+Actions on the dispatcher should be short and non-blocking. Long-running work should start asynchronously,
+and completion should schedule follow-up work back on the dispatcher.
+
+=== Capturing state in scheduled lambdas
+
+Be careful when capturing state in lambdas passed to `Schedule()`. Scheduled work runs later,
+so both lifetime and value stability must be considered.
+
+1. Capturing by reference (or by capturing `this`) means the lambda observes the value at the time it executes, not at the time it is scheduled.
+2. This is often undesirable for critical updates, such as reporting a specific status, where the original value must be preserved. In that case, capture that value explicitly by value.
+3. Capture size is typically limited, so large state is sometimes stored on `this` instead of inside the lambda. When doing that, remember that the state read by the lambda may have changed before execution.
+
+When scheduling work on an object that may be destroyed before execution, use one of the lifetime management patterns below.
+
+== Lifetime management patterns
+
+The most common source of bugs is scheduled work outliving the object that scheduled it.
+The patterns below are typical ways to manage that.
+
+=== Keep object alive for the full runtime
+
+The simplest strategy is to keep an object alive until application shutdown.
+This avoids lifetime races at the cost of less flexible ownership.
+
+=== Use `infra::EventDispatcherWithWeakPtr`
+
+`infra::EventDispatcherWithWeakPtr` supports scheduling actions with an `infra::WeakPtr<T>`.
+When the action is about to run, the weak pointer is promoted to `infra::SharedPtr<T>`:
+
+1. If promotion succeeds, the object is still alive and the action runs.
+2. If promotion fails, the object already expired and the action is skipped.
+
+This pattern avoids executing callbacks on destroyed objects. Memory overhead is generally negligible,
+but the ownership model is more complex than direct scheduling.
+
+When objects contain other objects managed by shared pointers, `infra::MakeContainedSharedObject()`
+can simplify ownership by tying lifetimes together.
+
+=== Make objects stoppable
+
+Use `services::Stoppable` when teardown must be explicit and asynchronous.
+`Stop(onDone)` allows pending asynchronous work to complete or cancel before destruction.
+
+Important constraints:
+
+1. `Stop()` is asynchronous and therefore should not be called from a destructor.
+2. Destruction should happen only after `onDone` is called.
+
+Trade-offs:
+
+1. Memory cost is low.
+2. The model is usually straightforward to understand.
+3. Destruction flow is more complex because shutdown must wait for asynchronous completion.
+
+

--- a/documents/modules/ROOT/pages/EventDispatcher.adoc
+++ b/documents/modules/ROOT/pages/EventDispatcher.adoc
@@ -64,7 +64,7 @@ Important constraints:
 1. `Stop()` is asynchronous and therefore should not be called from a destructor.
 2. Destruction should happen only after `onDone` is called.
 
-Trade-offs:
+Tradeoffs:
 
 1. Memory cost is low.
 2. The model is usually straightforward to understand.

--- a/documents/modules/ROOT/pages/ExecutionModel.adoc
+++ b/documents/modules/ROOT/pages/ExecutionModel.adoc
@@ -7,12 +7,9 @@ Embedded Infrastructure Library supports various execution models, but the most 
 scheduling blocks of work on an event dispatcher. This is a lightweight way of being able to perform multiple tasks
 in parallel, without needing multiple stacks or synchronization.
 
-The event dispatcher is used by scheduling an action by using its `Schedule()` method. `Schedule()` takes a single argument of
-type `infra::Function<void()>`, and is therefore often used in combination with lambda functions. `Schedule()` does not
-execute its action immediately, but pushes it on a queue for later execution. The event dispatcher is typically constantly
-running on the application's main thread, and executes queued actions one after another. This way, a scheduled action is
-completely finished before the next action is started, so in contrast with running actions in different threads no synchronization
-is needed.
+The event dispatcher queues actions for later execution, typically on the application's main thread, and executes them one
+after another. This way, a scheduled action is completely finished before the next action is started, so in contrast with
+running actions in different threads no synchronization is needed.
 
 An action executed by an event dispatcher should never waste any time; no action should ever sleep, waiting for an external task, such as
 a write towards flash, to finish. Instead, after having started a write towards flash, a new action is scheduled when the write has
@@ -23,20 +20,12 @@ event dispatchers, by either interrupt handlers or by using threads), but multip
 time, with each component making steady progress.
 
 While it is possible to have multiple event dispatchers (when using multiple threads, a specific thread may have its own event
-dispatcher for dedicated tasks), there is one event dispatcher globally available via `infra::EventDispatcher::Instance()`.
-This event dispatcher is used for generic tasks; for example, the `ConfigurationStore` uses the `Flash` interface to read and write
-towards flash; the completion of a read or write action is dispatched on this globally available event dispatcher. A typical
-`main` function will therefore start with declaring an event dispatcher, and end with invoking that event dispatcher's `Run()` method.
+dispatcher for dedicated tasks), applications often also have a general-purpose event dispatcher for generic tasks. For example,
+the `ConfigurationStore` uses the `Flash` interface to read and write towards flash; the completion of a read or write action is
+dispatched on such a general-purpose event dispatcher.
 
-=== Support for `infra::WeakPtr`
-
-Objects that are managed by shared pointers may schedule actions to be executed, but it may happen that that object is destroyed before
-that action is executed. In that case, that action should be discarded instead of being executed. `infra::EventDispatcherWithWeakPtr`
-exists to facilitate this usecase. Next to the typical `Schedule()` function that takes an action as parameter, it supports an
-overload that takes a second parameter: an `infra::WeakPtr<T>` towards the object that schedules the action. That parameter is
-converted to a shared pointer just before executing the action: if this conversion succeeds, the object is still alive, and the action
-is executed with that shared pointer as parameter. If the conversion fails, then the object was already expired, and execution of
-that action is skipped.
+For practical usage guidance, lifetime patterns, and pitfalls around asynchronous scheduling,
+see xref:EventDispatcher.adoc[Event Dispatcher].
 
 == Multi-threaded execution
 


### PR DESCRIPTION
This adds more information about the EventDispatcher, including common pitfalls and work arounds. This is for developers to read, and also importantly, for AI reviewers to read when touching code with EventDispatchers.