### PR TITLE
chore: harden FlashEcho for unexpected function calls

### DIFF
--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -174,7 +174,7 @@ namespace services
 
     void FlashEchoProxyBase::ReadDone(infra::ConstByteRange contents)
     {
-        really_assert(onDone);
+        really_assert(onDone != nullptr);
         really_assert(readingBuffer.size() > bufferPosition);
         really_assert(contents.size() <= readingBuffer.size() - bufferPosition);
         really_assert(writingBuffer.empty());

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -192,7 +192,7 @@ namespace services
 
     void FlashEchoProxyBase::WriteDone()
     {
-        really_assert(onDone);
+        really_assert(onDone != nullptr);
         really_assert(bufferPosition < writingBuffer.size());
         really_assert(readingBuffer.empty());
 

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -1,5 +1,6 @@
 #include "services/util/FlashEcho.hpp"
 #include "infra/util/ReallyAssert.hpp"
+#include <algorithm>
 
 namespace services
 {

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -134,6 +134,7 @@ namespace services
     void FlashEchoProxyBase::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         really_assert(!this->onDone);
+
         bufferPosition = 0;
         readingBuffer = {};
         writingBuffer = buffer;
@@ -146,6 +147,7 @@ namespace services
     void FlashEchoProxyBase::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         really_assert(!this->onDone);
+
         bufferPosition = 0;
         this->address = address;
         writingBuffer = {};
@@ -158,6 +160,7 @@ namespace services
     void FlashEchoProxyBase::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
     {
         really_assert(!this->onDone);
+
         readingBuffer = {};
         writingBuffer = {};
         this->onDone = onDone;
@@ -175,6 +178,7 @@ namespace services
         really_assert(readingBuffer.size() > bufferPosition);
         really_assert(contents.size() <= readingBuffer.size() - bufferPosition);
         really_assert(writingBuffer.empty());
+
         infra::Copy(contents, infra::Head(infra::DiscardHead(readingBuffer, bufferPosition), contents.size()));
         bufferPosition += contents.size();
 
@@ -191,6 +195,7 @@ namespace services
         really_assert(onDone);
         really_assert(bufferPosition < writingBuffer.size());
         really_assert(readingBuffer.empty());
+
         bufferPosition += std::min<std::size_t>(writingBuffer.size() - bufferPosition, flash::WriteRequest::contentsSize);
 
         if (bufferPosition == writingBuffer.size())
@@ -203,9 +208,9 @@ namespace services
 
     void FlashEchoProxyBase::EraseSectorsDone()
     {
-        really_assert(onDone);
         really_assert(readingBuffer.empty());
         really_assert(writingBuffer.empty());
+
         onDone();
         MethodDone();
     }

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -1,5 +1,5 @@
 #include "services/util/FlashEcho.hpp"
-#include <utility>
+#include "infra/util/ReallyAssert.hpp"
 
 namespace services
 {
@@ -19,6 +19,7 @@ namespace services
 
     void FlashEcho::Read(uint32_t address, uint32_t size)
     {
+        really_assert(!busy);
         busy = true;
 
         flash.ReadBuffer(infra::Head(infra::MakeRange(buffer), size), address, [this, size]()
@@ -41,6 +42,7 @@ namespace services
 
     void FlashEcho::Write(uint32_t address, infra::ConstByteRange contents)
     {
+        really_assert(!busy);
         busy = true;
 
         flash.WriteBuffer(contents, address, [this]()
@@ -63,6 +65,7 @@ namespace services
 
     void FlashEcho::EraseSectors(uint32_t sector, uint32_t numberOfSectors)
     {
+        really_assert(!busy);
         busy = true;
 
         flash.EraseSectors(sector, sector + numberOfSectors, [this]()
@@ -130,7 +133,9 @@ namespace services
 
     void FlashEchoProxyBase::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
+        really_assert(!this->onDone);
         bufferPosition = 0;
+        readingBuffer = {};
         writingBuffer = buffer;
         this->onDone = onDone;
         this->address = address;
@@ -140,8 +145,10 @@ namespace services
 
     void FlashEchoProxyBase::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
+        really_assert(!this->onDone);
         bufferPosition = 0;
         this->address = address;
+        writingBuffer = {};
         readingBuffer = buffer;
         this->onDone = onDone;
 
@@ -150,6 +157,9 @@ namespace services
 
     void FlashEchoProxyBase::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
     {
+        really_assert(!this->onDone);
+        readingBuffer = {};
+        writingBuffer = {};
         this->onDone = onDone;
         this->endIndex = endIndex;
 
@@ -161,6 +171,10 @@ namespace services
 
     void FlashEchoProxyBase::ReadDone(infra::ConstByteRange contents)
     {
+        really_assert(onDone);
+        really_assert(readingBuffer.size() > bufferPosition);
+        really_assert(contents.size() <= readingBuffer.size() - bufferPosition);
+        really_assert(writingBuffer.empty());
         infra::Copy(contents, infra::Head(infra::DiscardHead(readingBuffer, bufferPosition), contents.size()));
         bufferPosition += contents.size();
 
@@ -174,6 +188,9 @@ namespace services
 
     void FlashEchoProxyBase::WriteDone()
     {
+        really_assert(onDone);
+        really_assert(bufferPosition < writingBuffer.size());
+        really_assert(readingBuffer.empty());
         bufferPosition += std::min<std::size_t>(writingBuffer.size() - bufferPosition, flash::WriteRequest::contentsSize);
 
         if (bufferPosition == writingBuffer.size())
@@ -186,6 +203,9 @@ namespace services
 
     void FlashEchoProxyBase::EraseSectorsDone()
     {
+        really_assert(onDone);
+        really_assert(readingBuffer.empty());
+        really_assert(writingBuffer.empty());
         onDone();
         MethodDone();
     }

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -208,6 +208,7 @@ namespace services
 
     void FlashEchoProxyBase::EraseSectorsDone()
     {
+        really_assert(onDone != nullptr);
         really_assert(readingBuffer.empty());
         really_assert(writingBuffer.empty());
 

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -519,3 +519,12 @@ TEST_F(FlashProxyDeathTest, write_done_while_idle_aborts)
                      }),
         "");
 }
+
+TEST_F(FlashProxyDeathTest, erase_sectors_done_while_idle_aborts)
+{
+    EXPECT_DEATH(flashResult.RequestSend([this]()
+                     {
+                         flashResult.EraseSectorsDone();
+                     }),
+        "");
+}

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -457,3 +457,65 @@ TEST_F(FlashSequentialProxyTest, WriteBuffer_TwoChunks_SecondOnlyAfterFirstDone)
 
     sendWriteDone2();
 }
+
+class FlashEchoDeathTest
+    : public testing::Test
+{
+public:
+    services::MethodSerializerFactory::OnHeap serializerFactory;
+    application::EchoSingleLoopback echo{ serializerFactory };
+    testing::NiceMock<hal::CleanFlashMock> delegate;
+    services::FlashEcho flash{ echo, delegate };
+
+    const std::array<uint8_t, 4> data{ 5, 8, 2, 3 };
+    infra::Function<void()> onDone;
+};
+
+TEST_F(FlashEchoDeathTest, write_while_read_in_progress_aborts)
+{
+    EXPECT_CALL(delegate, ReadBuffer(testing::_, 1234, testing::_)).WillOnce(testing::SaveArg<2>(&onDone));
+    flash.Read(1234, data.size());
+
+    EXPECT_DEATH(flash.Write(1234, data), "");
+}
+
+class FlashProxyDeathTest
+    : public testing::Test
+{
+public:
+    services::MethodSerializerFactory::OnHeap serializerFactory;
+    application::EchoSingleLoopback echo{ serializerFactory };
+    services::FlashEchoHomogeneousProxy flashProxy{ echo, 4, 4096 };
+    testing::NiceMock<FlashMock> flash{ echo };
+    flash::FlashResultProxy flashResult{ echo };
+
+    const std::array<uint8_t, 4> data{ 5, 8, 2, 3 };
+};
+
+TEST_F(FlashProxyDeathTest, write_buffer_while_read_buffer_in_progress_aborts)
+{
+    EXPECT_CALL(flash, Read(1234, 4));
+
+    std::array<uint8_t, 4> buffer{};
+    flashProxy.ReadBuffer(infra::MakeRange(buffer), 1234, []() {});
+
+    EXPECT_DEATH(flashProxy.WriteBuffer(infra::MakeRange(data), 1234, []() {}), "");
+}
+
+TEST_F(FlashProxyDeathTest, read_done_while_idle_aborts)
+{
+    EXPECT_DEATH(flashResult.RequestSend([this]()
+                     {
+                         flashResult.ReadDone(infra::MakeRange(data));
+                     }),
+        "");
+}
+
+TEST_F(FlashProxyDeathTest, write_done_while_idle_aborts)
+{
+    EXPECT_DEATH(flashResult.RequestSend([this]()
+                     {
+                         flashResult.WriteDone();
+                     }),
+        "");
+}


### PR DESCRIPTION
This PR hardens `FlashEcho` so that unexpected commands written or received immediately crash, instead of resulting in undefined behavior which would cause an ambiguous crash later.

I'm not sure about checking the `busy` flag, because it's set back to `false` _before_ the method is actually done.