### PR TITLE
chore: add copilot instructions for review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,8 +33,8 @@ if (TARGET_MCU_VENDOR STREQUAL ti)
 cmake --list-presets
 
 # Configure and build for target
-cmake --preset <configure_preset>
-cmake --build --preset <build_preset>
+cmake --preset=<configure_preset>
+cmake --build --preset=<build_preset>
 
 # Run all tests (host preset only)
 ctest --preset host

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ ctest --preset host -R <test_name>
 
 ## Testing Strategy
 
-**Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`. For more information on micro tests, see `./.github/instructions/microtest.instructions.md`.
+**Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`, and guard the executable with `emil_build_for(<target> BOOL EMIL_BUILD_TESTS)`. For more information on micro tests, see `./.github/instructions/microtest.instructions.md`.
 
 **Test Doubles**: Mock implementations in `test_doubles/` directories.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,6 +85,5 @@ ctest --preset host --test-dir build/host -R <test_name>
 - No exceptions shall be used in the codebase, except in Host applications and tests.
 - Avoid protected members in classes except test classes; prefer private members with public/protected accessors if needed.
 - Use SFINAE to restrict template parameters if the template is only valid for specific types.
-- Always use `override` keyword for overridden virtual functions and do not use `final` keyword.
 - Use `assert` for non-critical preconditions and `really_assert` for critical preconditions that must never be violated.
 - Use `LOG_AND_ABORT(...)` when the code reached an unexpected location/state.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,14 +33,14 @@ if (TARGET_MCU_VENDOR STREQUAL ti)
 cmake --list-presets
 
 # Configure and build for target
-cmake --preset=<preset>
-cmake --build --preset=<preset>
+cmake --preset <configure_preset>
+cmake --build --preset <build_preset>
 
 # Run all tests (host preset only)
-ctest --preset host --test-dir build/host
+ctest --preset host
 
 # Run a single test by name
-ctest --preset host --test-dir build/host -R <test_name>
+ctest --preset host -R <test_name>
 ```
 
 **Pull Requests and Commits**:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ This repository is a set of C++ libraries and headers that provide heap-less, ST
 
 **EmIL Patterns**: All CMake uses EmIL conventions:
 ```cmake
-emil_build_for(target PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_build_for(target BOOL EMIL_BUILD_TESTS)
 emil_generate_artifacts(TARGET target HEX MAP)
 emil_exclude_from_clang_format(directory)
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,13 +55,13 @@ ctest --preset Host-Debug --test-dir build/Host -R <test_name>
 
 **Echo/Sesame**: RPC mechanisms from EmIL. Echo for TCP/IP and/or Echo on top of Sesame for serial communication. Refer to `./documents/modules/ROOT/pages/Sesame.adoc` for details on Sesame and `./documents/modules/ROOT/pages/Echo.adoc` for details on Echo.
 
-TODO: Expand?
+**EventDispatcher**: Centralized event handling system. Always read `./documents/modules/ROOT/pages/EventDispatcher.adoc` if usage of EventDispatcher is involved.
+
+**ClaimableResource**: Resource management pattern for shared software resources. Refer to `./documents/modules/ROOT/pages/ClaimableResource.adoc` for details.
 
 ## Testing Strategy
 
 **Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`.
-
-**Integration Tests**: Cucumber-based tests in `cucumber_test/` for end-to-end scenarios. Tests are executed through self hosted runners on GitHub Actions.
 
 **Test Doubles**: Mock implementations in `test_doubles/` directories.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,8 +78,8 @@ ctest --preset host --test-dir build/host -R <test_name>
 
 ## General Coding Rules
 
-- Code shall not contain comments unless they are absolutely necessary and the user specifically asks for them.
-- STL containers from amp-embedded-infra-lib shall be used instead of standard library containers except Host applications and tests.
+- Avoid adding code comments unless they are necessary to clarify non-obvious intent.
+- Prefer `infra` containers (e.g., `infra::Bounded*`, `infra::Intrusive*`) over standard library containers, except in host applications and tests.
 - When declaring a class with base classes, place the colon and inheritance list on a separate line with proper indentation.
 - Constructors with one parameter must be an explicit constructor.
 - No exceptions shall be used in the codebase, except in Host applications and tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,12 @@
 # Copilot Instructions for amp-embedded-infra-lib
 
-This repository is a set of C++ libraries and headers that provide heap-less, STL like, infrastructure for embedded software development.
+This repository is a set of C++ libraries and headers that provide heap-less, STL-like, infrastructure for embedded software development.
 
 ## Build System Conventions
 
 **CMake Presets**: Use CMake presets extensively. Key presets:
-- `Host` - Host tooling/tests (use for development)
-- `Coverage` - Test coverage analysis
+- `host` - Host tooling/tests (use for development)
+- `coverage` - Test coverage analysis
 
 **EmIL Patterns**: All CMake uses EmIL conventions:
 ```cmake
@@ -25,7 +25,7 @@ if (TARGET_MCU_VENDOR STREQUAL ti)
 
 **Container Development**: Strongly recommended to use devcontainer - contains all cross-compilation toolchains and tools. Commands assume container environment.
 
-**Code Style and Formatting**: MUST follow the `./amp-embedded-infra-lib/documents/modules/ROOT/pages/CodingStandard.adoc`. Use `clang-format` for formatting; configured via `.clang-format`.
+**Code Style and Formatting**: MUST follow the `./documents/modules/ROOT/pages/CodingStandard.adoc`. Use `clang-format` for formatting; configured via `.clang-format`.
 
 **Build Commands**:
 ```bash
@@ -36,11 +36,11 @@ cmake --list-presets
 cmake --preset=<preset>
 cmake --build --preset=<preset>
 
-# Run all tests (Host preset only)
-ctest --preset Host-Debug --test-dir build/Host
+# Run all tests (host preset only)
+ctest --preset host --test-dir build/host
 
 # Run a single test by name
-ctest --preset Host-Debug --test-dir build/Host -R <test_name>
+ctest --preset host --test-dir build/host -R <test_name>
 ```
 
 **Pull Requests and Commits**:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,90 @@
+# Copilot Instructions for amp-embedded-infra-lib
+
+This repository is a set of C++ libraries and headers that provide heap-less, STL like, infrastructure for embedded software development.
+
+## Build System Conventions
+
+**CMake Presets**: Use CMake presets extensively. Key presets:
+- `Host` - Host tooling/tests (use for development)
+- `Coverage` - Test coverage analysis
+
+**EmIL Patterns**: All CMake uses EmIL conventions:
+```cmake
+emil_build_for(target PREREQUISITE_BOOL EMIL_BUILD_TESTS)
+emil_generate_artifacts(TARGET target HEX MAP)
+emil_exclude_from_clang_format(directory)
+```
+
+**Target Conditionals**: Build logic heavily uses target conditionals:
+```cmake
+if ("${TARGET_MCU}" STREQUAL stm32wb55)
+if (TARGET_MCU_VENDOR STREQUAL ti)
+```
+
+## Development Workflow
+
+**Container Development**: Strongly recommended to use devcontainer - contains all cross-compilation toolchains and tools. Commands assume container environment.
+
+**Code Style and Formatting**: MUST follow the `./amp-embedded-infra-lib/documents/modules/ROOT/pages/CodingStandard.adoc`. Use `clang-format` for formatting; configured via `.clang-format`.
+
+**Build Commands**:
+```bash
+# List available presets
+cmake --list-presets
+
+# Configure and build for target
+cmake --preset=<preset>
+cmake --build --preset=<preset>
+
+# Run all tests (Host preset only)
+ctest --preset Host-Debug --test-dir build/Host
+
+# Run a single test by name
+ctest --preset Host-Debug --test-dir build/Host -R <test_name>
+```
+
+**Pull Requests and Commits**:
+- Follow Conventional Commit style from `CONTRIBUTING.md` when proposing pull request titles and when creating commit messages.
+
+**VS Code Integration**:
+- CMake extension manages presets via status bar
+- TestMate C++ for micro tests
+- Gcov Viewer for coverage analysis
+
+## Service Architecture
+
+**Echo/Sesame**: RPC mechanisms from EmIL. Echo for TCP/IP and/or Echo on top of Sesame for serial communication. Refer to `./documents/modules/ROOT/pages/Sesame.adoc` for details on Sesame and `./documents/modules/ROOT/pages/Echo.adoc` for details on Echo.
+
+TODO: Expand?
+
+## Testing Strategy
+
+**Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`.
+
+**Integration Tests**: Cucumber-based tests in `cucumber_test/` for end-to-end scenarios. Tests are executed through self hosted runners on GitHub Actions.
+
+**Test Doubles**: Mock implementations in `test_doubles/` directories.
+
+## File Naming Conventions
+
+- Source files: `CamelCase.cpp/.hpp`
+- CMake targets: `package.component` (e.g., `infra.timer`, `services.tracer`)
+- Executables: Often match directory structure (`examples.serial_net`)
+
+## Common Issues
+
+- Cross-compilation toolchain paths are container-specific
+- EmIL build flags (`EMIL_*`) control feature inclusion
+
+## General Coding Rules
+
+- Code shall not contain comments unless they are absolutely necessary and the user specifically asks for them.
+- STL containers from amp-embedded-infra-lib shall be used instead of standard library containers except Host applications and tests.
+- When declaring a class with base classes, place the colon and inheritance list on a separate line with proper indentation.
+- Constructors with one parameter must be an explicit constructor.
+- No exceptions shall be used in the codebase, except in Host applications and tests.
+- Avoid protected members in classes except test classes; prefer private members with public/protected accessors if needed.
+- Use SFINAE to restrict template parameters if the template is only valid for specific types.
+- Always use `override` keyword for overridden virtual functions and do not use `final` keyword.
+- Use `assert` for non-critical preconditions and `really_assert` for critical preconditions that must never be violated.
+- Use `LOG_AND_ABORT(...)` when the code reached an unexpected location/state.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ ctest --preset host --test-dir build/host -R <test_name>
 
 ## Testing Strategy
 
-**Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`.
+**Micro Tests**: Unit tests alongside source code in `test/` subdirectories. Use `emil_add_test()`. For more information on micro tests, see `./.github/instructions/microtest.instructions.md`.
 
 **Test Doubles**: Mock implementations in `test_doubles/` directories.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ ctest --preset host --test-dir build/host -R <test_name>
 ```
 
 **Pull Requests and Commits**:
-- Follow Conventional Commit style from `CONTRIBUTING.md` when proposing pull request titles and when creating commit messages.
+- Follow Conventional Commit style from `.github/CONTRIBUTING.md` when proposing pull request titles and when creating commit messages.
 
 **VS Code Integration**:
 - CMake extension manages presets via status bar

--- a/.github/instructions/microtest.instructions.md
+++ b/.github/instructions/microtest.instructions.md
@@ -1,5 +1,7 @@
 ---
-applyTo: "**/test/**, **/test_doubles/**"
+applyTo:
+  - "**/test/**"
+  - "**/test_doubles/**"
 ---
 
 ## Google Test Suite Coding Rules
@@ -12,7 +14,7 @@ applyTo: "**/test/**, **/test_doubles/**"
 - Avoid death tests unless absolutely necessary, as they can slow down the test suite significantly.
 - Avoid iterating over elements in tests; use matchers that can handle collections instead.
 - Whenever a parameter is needed for multiple tests, use test fixtures or parameterized functions to avoid code duplication.
-- Whenever a behaviour is needed for multiple tests, use parameterized functions to avoid code duplication.
+- Whenever a behavior is needed for multiple tests, use parameterized functions to avoid code duplication.
 - Default parameters are allowed when writing test helper functions to increase readability.
 - Prefer using test helper functions as public members of the test fixture class instead of free functions in the test file.
 - Always use `MOCK_METHOD`; never use outdated `MOCK_METHOD*` macros (e.g. `MOCK_METHOD0`, `MOCK_METHOD1`) to keep tests readable and maintainable.

--- a/.github/instructions/microtest.instructions.md
+++ b/.github/instructions/microtest.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**/test/**, **/test_doubles/**"
+---
+
+## Google Test Suite Coding Rules
+
+- `using namespace testing;` is not allowed; use fully qualified names instead.
+- Code comments are not allowed inside tests; use descriptive test and subtest names instead.
+- Always prefer `EXPECT_THAT` macros over `EXPECT_EQ` macros for better failure messages.
+- When testing outputs, prefer using matchers from the Google Test Matchers library, to match the full output instead of parts of it.
+- Always prefer `EXPECT_THAT` over `ASSERT_THAT`, unless the test cannot continue or for documenting pre-conditions.
+- Avoid death tests unless absolutely necessary, as they can slow down the test suite significantly.
+- Avoid iterating over elements in tests; use matchers that can handle collections instead.
+- Whenever a parameter is needed for multiple tests, use test fixtures or parameterized functions to avoid code duplication.
+- Whenever a behaviour is needed for multiple tests, use parameterized functions to avoid code duplication.
+- Default parameters are allowed when writing test helper functions to increase readability.
+- Prefer using test helper functions as public members of the test fixture class instead of free functions in the test file.
+- Always use `MOCK_METHOD`; never use outdated `MOCK_METHOD*` macros (e.g. `MOCK_METHOD0`, `MOCK_METHOD1`) to keep tests readable and maintainable.
+- Do not split a single scenario across multiple tests; if steps in a flow belong to the same scenario, combine them into one test that covers the complete sequence.
+- Guard death tests with `#ifndef EMIL_MUTATION_TESTING` to avoid running them during mutation testing. They are very slow and can crash the runner.

--- a/documents/modules/ROOT/pages/CodingStandard.adoc
+++ b/documents/modules/ROOT/pages/CodingStandard.adoc
@@ -465,7 +465,7 @@ int32_t Max(int32_t a, int32_t b)
 
 *Rule 51.* `NULL` and `0` shall not be used as null pointers. Use `nullptr` instead.
 
-*Rule 52.* When overriding `virtual` functions in a derived class always use the keyword `override`, never use `final`. The `virtual` keyword shall not be repeated.
+*Rule 52.* When overriding `virtual` functions in a derived class, always use the keyword `override`, never use `final`. The `virtual` keyword shall not be repeated.
 
 *Rule 53.* The `++` and `--` operators shall be written in front of the variable, unless post increment/post decrement is really the intended operation.
 

--- a/documents/modules/ROOT/pages/CodingStandard.adoc
+++ b/documents/modules/ROOT/pages/CodingStandard.adoc
@@ -465,7 +465,7 @@ int32_t Max(int32_t a, int32_t b)
 
 *Rule 51.* `NULL` and `0` shall not be used as null pointers. Use `nullptr` instead.
 
-*Rule 52.* When overriding `virtual` functions in a derived class, always use the keyword `override`, never use `final`. The `virtual` keyword shall not be repeated.
+*Rule 52.* When overriding `virtual` functions in a derived class, the keyword `override` shall be used and the keyword `final` shall not be used. The `virtual` keyword shall not be repeated.
 
 *Rule 53.* The `++` and `--` operators shall be written in front of the variable, unless post increment/post decrement is really the intended operation.
 

--- a/documents/modules/ROOT/pages/CodingStandard.adoc
+++ b/documents/modules/ROOT/pages/CodingStandard.adoc
@@ -465,7 +465,7 @@ int32_t Max(int32_t a, int32_t b)
 
 *Rule 51.* `NULL` and `0` shall not be used as null pointers. Use `nullptr` instead.
 
-*Rule 52.* When overriding `virtual` functions in a derived class, the keywords `override` or `final` shall be used to explicitly declare the function to `override` a base function. The `virtual` keyword shall not be repeated.
+*Rule 52.* When overriding `virtual` functions in a derived class always use the keyword `override`, never use `final`. The `virtual` keyword shall not be repeated.
 
 *Rule 53.* The `++` and `--` operators shall be written in front of the variable, unless post increment/post decrement is really the intended operation.
 

--- a/documents/modules/ROOT/pages/CodingStandard.adoc
+++ b/documents/modules/ROOT/pages/CodingStandard.adoc
@@ -465,7 +465,7 @@ int32_t Max(int32_t a, int32_t b)
 
 *Rule 51.* `NULL` and `0` shall not be used as null pointers. Use `nullptr` instead.
 
-*Rule 52.* When overriding `virtual` functions in a derived class, the keyword `override` shall be used and the keyword `final` shall not be used. The `virtual` keyword shall not be repeated.
+*Rule 52.* When overriding `virtual` functions in a derived class, the keyword `override` shall be used, and the keyword `final` shall not be used. The `virtual` keyword shall not be repeated.
 
 *Rule 53.* The `++` and `--` operators shall be written in front of the variable, unless post increment/post decrement is really the intended operation.
 


### PR DESCRIPTION
Adds instructions for Co-Pilot to improve the reviews in this repository. The main goal is to include notes about using the EventDispatcher, as added in #1222. Also updates the coding standard to nto use `final`.