### PR TITLE
feat: IPv6 support for BSD and Win connections

### DIFF
--- a/services/network_instantiations/ConnectionBsd.cpp
+++ b/services/network_instantiations/ConnectionBsd.cpp
@@ -98,8 +98,7 @@ namespace
         if (!IN6_IS_ADDR_V4MAPPED(&address))
             return std::nullopt;
 
-        const std::array<uint8_t, 4> ipv4Bytes{ address.s6_addr[12], address.s6_addr[13], address.s6_addr[14], address.s6_addr[15] };
-        return services::IPv4Address{ ipv4Bytes[0], ipv4Bytes[1], ipv4Bytes[2], ipv4Bytes[3] };
+        return services::IPv4Address{ address.s6_addr[12], address.s6_addr[13], address.s6_addr[14], address.s6_addr[15] };
     }
 }
 

--- a/services/network_instantiations/ConnectionBsd.cpp
+++ b/services/network_instantiations/ConnectionBsd.cpp
@@ -1,12 +1,48 @@
 #include "services/network_instantiations/ConnectionBsd.hpp"
+#include "infra/event/EventDispatcherWithWeakPtr.hpp"
 #include "services/network_instantiations/EventDispatcherWithNetworkBsd.hpp"
+#include <arpa/inet.h>
+#include <cstring>
 #include <errno.h>
 #include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <optional>
 #include <sys/socket.h>
 #include <unistd.h>
 
 namespace
 {
+    template<class SockAddr>
+    const sockaddr* AsSockAddr(const SockAddr& address)
+    {
+        return static_cast<const sockaddr*>(static_cast<const void*>(&address));
+    }
+
+    template<class SockAddr>
+    sockaddr* AsSockAddr(SockAddr& address)
+    {
+        return static_cast<sockaddr*>(static_cast<void*>(&address));
+    }
+
+    template<class SockAddr>
+    int BindSocket(int fileDescriptor, const SockAddr& address)
+    {
+        return bind(fileDescriptor, AsSockAddr(address), sizeof(address));
+    }
+
+    template<class SockAddr>
+    int ConnectSocket(int fileDescriptor, const SockAddr& address)
+    {
+        return connect(fileDescriptor, AsSockAddr(address), sizeof(address));
+    }
+
+    void GetPeerName(int fileDescriptor, sockaddr_storage& address, socklen_t& addressLength)
+    {
+        if (getpeername(fileDescriptor, AsSockAddr(address), &addressLength) == -1)
+            std::abort();
+    }
+
     void SetNonBlocking(int fileDescriptor)
     {
         auto status_flags = fcntl(fileDescriptor, F_GETFL, 0);
@@ -14,6 +50,56 @@ namespace
             std::abort();
         if (fcntl(fileDescriptor, F_SETFL, status_flags | O_NONBLOCK) == -1)
             std::abort();
+    }
+
+    void EnableKeepAlive(int fileDescriptor)
+    {
+        int enabled = 1;
+        setsockopt(fileDescriptor, SOL_SOCKET, SO_KEEPALIVE, &enabled, sizeof(enabled));
+
+#ifdef __linux__
+        int idleSeconds = 10;
+        int intervalSeconds = 3;
+        int probeCount = 3;
+
+        setsockopt(fileDescriptor, IPPROTO_TCP, TCP_KEEPIDLE, &idleSeconds, sizeof(idleSeconds));
+        setsockopt(fileDescriptor, IPPROTO_TCP, TCP_KEEPINTVL, &intervalSeconds, sizeof(intervalSeconds));
+        setsockopt(fileDescriptor, IPPROTO_TCP, TCP_KEEPCNT, &probeCount, sizeof(probeCount));
+#endif
+    }
+
+    services::IPv6Address ToIpv6Address(const in6_addr& address)
+    {
+        services::IPv6Address ipv6Address{};
+        for (std::size_t i = 0; i != ipv6Address.size(); ++i)
+        {
+            uint16_t value;
+            std::memcpy(&value, &address.s6_addr[i * 2], sizeof(value));
+            ipv6Address[i] = ntohs(value);
+        }
+
+        return ipv6Address;
+    }
+
+    in6_addr ToIn6Addr(const services::IPv6Address& address)
+    {
+        in6_addr in6Address{};
+        for (std::size_t i = 0; i != address.size(); ++i)
+        {
+            const auto value = htons(address[i]);
+            std::memcpy(&in6Address.s6_addr[i * 2], &value, sizeof(value));
+        }
+
+        return in6Address;
+    }
+
+    std::optional<services::IPv4Address> ToIpv4AddressWhenV4Mapped(const in6_addr& address)
+    {
+        if (!IN6_IS_ADDR_V4MAPPED(&address))
+            return std::nullopt;
+
+        const std::array<uint8_t, 4> ipv4Bytes{ address.s6_addr[12], address.s6_addr[13], address.s6_addr[14], address.s6_addr[15] };
+        return services::IPv4Address{ ipv4Bytes[0], ipv4Bytes[1], ipv4Bytes[2], ipv4Bytes[3] };
     }
 }
 
@@ -28,6 +114,7 @@ namespace services
               })
     {
         SetNonBlocking(socket);
+        EnableKeepAlive(socket);
     }
 
     ConnectionBsd::~ConnectionBsd()
@@ -78,13 +165,25 @@ namespace services
         ResetOwnership();
     }
 
-    IPv4Address ConnectionBsd::Ipv4Address() const
+    IPAddress ConnectionBsd::Address() const
     {
-        sockaddr_in address{};
+        sockaddr_storage address{};
         socklen_t addressLength = sizeof(address);
-        getpeername(socket, reinterpret_cast<sockaddr*>(&address), &addressLength);
+        GetPeerName(socket, address, addressLength);
 
-        return services::ConvertFromUint32(htonl(address.sin_addr.s_addr));
+        if (address.ss_family == AF_INET)
+        {
+            sockaddr_in ipv4Address{};
+            std::memcpy(&ipv4Address, &address, sizeof(ipv4Address));
+            return services::ConvertFromUint32(htonl(ipv4Address.sin_addr.s_addr));
+        }
+
+        sockaddr_in6 ipv6Address{};
+        std::memcpy(&ipv6Address, &address, sizeof(ipv6Address));
+        if (auto ipv4Address = ToIpv4AddressWhenV4Mapped(ipv6Address.sin6_addr); ipv4Address)
+            return *ipv4Address;
+
+        return ToIpv6Address(ipv6Address.sin6_addr);
     }
 
     void ConnectionBsd::SetObserver(infra::SharedPtr<services::ConnectionObserver> connectionObserver)
@@ -218,19 +317,42 @@ namespace services
         Rewind(0);
     }
 
-    ListenerBsd::ListenerBsd(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory)
+    ListenerBsd::ListenerBsd(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions)
         : network(network)
         , factory(factory)
     {
-        listenSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        const auto family = versions == IPVersions::ipv4 ? AF_INET : AF_INET6;
+
+        listenSocket = socket(family, SOCK_STREAM, IPPROTO_TCP);
         assert(listenSocket != -1);
 
-        sockaddr_in address = {};
-        address.sin_family = AF_INET;
-        address.sin_addr.s_addr = htonl(INADDR_ANY);
-        address.sin_port = htons(port);
-        if (bind(listenSocket, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
-            std::abort();
+        int reuseAddress = 1;
+        setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &reuseAddress, sizeof(reuseAddress));
+
+        if (family == AF_INET6)
+        {
+            int v6Only = versions == IPVersions::ipv6 ? 1 : 0;
+            setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, &v6Only, sizeof(v6Only));
+        }
+
+        if (family == AF_INET)
+        {
+            sockaddr_in address = {};
+            address.sin_family = AF_INET;
+            address.sin_addr.s_addr = htonl(INADDR_ANY);
+            address.sin_port = htons(port);
+            if (BindSocket(listenSocket, address) == -1)
+                std::abort();
+        }
+        else
+        {
+            sockaddr_in6 address = {};
+            address.sin6_family = AF_INET6;
+            address.sin6_addr = in6addr_any;
+            address.sin6_port = htons(port);
+            if (BindSocket(listenSocket, address) == -1)
+                std::abort();
+        }
 
         if (listen(listenSocket, 1) == -1)
             std::abort();
@@ -255,28 +377,45 @@ namespace services
                 if (connectionObserver)
                     connection->SetObserver(connectionObserver);
             },
-            connection->Ipv4Address());
+            connection->Address());
     }
 
     ConnectorBsd::ConnectorBsd(EventDispatcherWithNetwork& network, services::ClientConnectionObserverFactory& factory)
         : network(network)
         , factory(factory)
     {
-        auto address = std::get<services::IPv4Address>(factory.Address());
+        const auto address = factory.Address();
 
-        connectSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        if (std::holds_alternative<services::IPv4Address>(address))
+        {
+            auto ipv4Address = std::get<services::IPv4Address>(address);
+
+            connectSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+            assert(connectSocket != -1);
+            SetNonBlocking(connectSocket);
+
+            sockaddr_in saddress = {};
+            saddress.sin_family = AF_INET;
+            saddress.sin_addr.s_addr = htonl(services::ConvertToUint32(ipv4Address));
+            saddress.sin_port = htons(factory.Port());
+            if (ConnectSocket(connectSocket, saddress) == -1 && errno != EWOULDBLOCK && errno != EINPROGRESS)
+                std::abort();
+
+            return;
+        }
+
+        const auto& ipv6Address = std::get<services::IPv6Address>(address);
+
+        connectSocket = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
         assert(connectSocket != -1);
         SetNonBlocking(connectSocket);
 
-        sockaddr_in saddress = {};
-        saddress.sin_family = AF_INET;
-        saddress.sin_addr.s_addr = htonl(services::ConvertToUint32(address));
-        saddress.sin_port = htons(factory.Port());
-        if (connect(connectSocket, reinterpret_cast<sockaddr*>(&saddress), sizeof(saddress)) == -1)
-        {
-            if (errno != EWOULDBLOCK && errno != EINPROGRESS)
-                std::abort();
-        }
+        sockaddr_in6 saddress = {};
+        saddress.sin6_family = AF_INET6;
+        saddress.sin6_addr = ToIn6Addr(ipv6Address);
+        saddress.sin6_port = htons(factory.Port());
+        if (ConnectSocket(connectSocket, saddress) == -1 && errno != EWOULDBLOCK && errno != EINPROGRESS)
+            std::abort();
     }
 
     ConnectorBsd::~ConnectorBsd()

--- a/services/network_instantiations/ConnectionBsd.cpp
+++ b/services/network_instantiations/ConnectionBsd.cpp
@@ -325,13 +325,14 @@ namespace services
         listenSocket = socket(family, SOCK_STREAM, IPPROTO_TCP);
         assert(listenSocket != -1);
 
-        int reuseAddress = 1;
-        setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &reuseAddress, sizeof(reuseAddress));
+        if (int reuseAddress = 1; setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &reuseAddress, sizeof(reuseAddress)) == -1)
+            std::abort();
 
         if (family == AF_INET6)
         {
             int v6Only = versions == IPVersions::ipv6 ? 1 : 0;
-            setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, &v6Only, sizeof(v6Only));
+            if (setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, &v6Only, sizeof(v6Only)) == -1)
+                std::abort();
         }
 
         if (family == AF_INET)

--- a/services/network_instantiations/ConnectionBsd.hpp
+++ b/services/network_instantiations/ConnectionBsd.hpp
@@ -1,14 +1,12 @@
 #ifndef SERVICES_CONNECTION_BSD_HPP
 #define SERVICES_CONNECTION_BSD_HPP
 
-#include "infra/event/EventDispatcherWithWeakPtr.hpp"
 #include "infra/stream/BoundedDequeInputStream.hpp"
 #include "infra/stream/ByteOutputStream.hpp"
 #include "infra/util/IntrusiveList.hpp"
 #include "infra/util/SharedObjectAllocator.hpp"
 #include "infra/util/SharedOptional.hpp"
 #include "services/network/Connection.hpp"
-#include <list>
 
 namespace services
 {
@@ -29,7 +27,7 @@ namespace services
         void CloseAndDestroy() override;
         void AbortAndDestroy() override;
 
-        IPv4Address Ipv4Address() const;
+        IPAddress Address() const;
         void SetObserver(infra::SharedPtr<services::ConnectionObserver> connectionObserver);
         bool Connected() const;
         bool SendBufferEmpty() const;
@@ -92,7 +90,7 @@ namespace services
         : public infra::IntrusiveList<ListenerBsd>::NodeType
     {
     public:
-        ListenerBsd(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory);
+        ListenerBsd(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions);
         ListenerBsd(const ListenerBsd& other) = delete;
         ListenerBsd& operator=(const ListenerBsd& other) = delete;
         ~ListenerBsd();

--- a/services/network_instantiations/ConnectionWin.cpp
+++ b/services/network_instantiations/ConnectionWin.cpp
@@ -1,5 +1,50 @@
 #include "services/network_instantiations/ConnectionWin.hpp"
 #include "services/network_instantiations/EventDispatcherWithNetworkWin.hpp"
+#include <cstring>
+#include <optional>
+#include <ws2tcpip.h>
+
+namespace
+{
+    void EnableKeepAlive(SOCKET socket)
+    {
+        int enabled = 1;
+        setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<const char*>(&enabled), sizeof(enabled));
+    }
+
+    services::IPv6Address ToIpv6Address(const IN6_ADDR& address)
+    {
+        services::IPv6Address ipv6Address{};
+        for (std::size_t i = 0; i != ipv6Address.size(); ++i)
+        {
+            uint16_t value;
+            std::memcpy(&value, &address.u.Byte[i * 2], sizeof(value));
+            ipv6Address[i] = ntohs(value);
+        }
+
+        return ipv6Address;
+    }
+
+    IN6_ADDR ToIn6Addr(const services::IPv6Address& address)
+    {
+        IN6_ADDR in6Address{};
+        for (std::size_t i = 0; i != address.size(); ++i)
+        {
+            const auto value = htons(address[i]);
+            std::memcpy(&in6Address.u.Byte[i * 2], &value, sizeof(value));
+        }
+
+        return in6Address;
+    }
+
+    std::optional<services::IPv4Address> ToIpv4AddressWhenV4Mapped(const IN6_ADDR& address)
+    {
+        if (!IN6_IS_ADDR_V4MAPPED(&address))
+            return std::nullopt;
+
+        return services::IPv4Address{ address.u.Byte[12], address.u.Byte[13], address.u.Byte[14], address.u.Byte[15] };
+    }
+}
 
 namespace services
 {
@@ -11,6 +56,7 @@ namespace services
                   keepAliveForReader = nullptr;
               })
     {
+        EnableKeepAlive(socket);
         UpdateEventFlags();
     }
 
@@ -66,13 +112,25 @@ namespace services
         ResetOwnership();
     }
 
-    IPv4Address ConnectionWin::Ipv4Address() const
+    IPAddress ConnectionWin::Address() const
     {
-        sockaddr_in address{};
+        sockaddr_storage address{};
         int addressLength = sizeof(address);
-        getpeername(socket, reinterpret_cast<SOCKADDR*>(&address), &addressLength);
+        if (getpeername(socket, reinterpret_cast<SOCKADDR*>(&address), &addressLength) == SOCKET_ERROR)
+            std::abort();
 
-        return services::ConvertFromUint32(htonl(address.sin_addr.s_addr));
+        if (address.ss_family == AF_INET)
+        {
+            const auto& ipv4Address = reinterpret_cast<const sockaddr_in&>(address);
+            return services::ConvertFromUint32(htonl(ipv4Address.sin_addr.s_addr));
+        }
+
+        const auto& ipv6Address = reinterpret_cast<const sockaddr_in6&>(address);
+        auto ipv4Address = ToIpv4AddressWhenV4Mapped(ipv6Address.sin6_addr);
+        if (ipv4Address)
+            return *ipv4Address;
+
+        return ToIpv6Address(ipv6Address.sin6_addr);
     }
 
     void ConnectionWin::SetObserver(infra::SharedPtr<services::ConnectionObserver> connectionObserver)
@@ -214,21 +272,44 @@ namespace services
         Rewind(0);
     }
 
-    ListenerWin::ListenerWin(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory)
+    ListenerWin::ListenerWin(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions)
         : network(network)
         , factory(factory)
     {
-        listenSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        const auto family = versions == IPVersions::ipv4 ? AF_INET : AF_INET6;
+
+        listenSocket = socket(family, SOCK_STREAM, IPPROTO_TCP);
         assert(listenSocket != INVALID_SOCKET);
         int result = WSAEventSelect(listenSocket, event, FD_ACCEPT);
         assert(result == 0);
 
-        sockaddr_in address = {};
-        address.sin_family = AF_INET;
-        address.sin_addr.s_addr = htonl(INADDR_ANY);
-        address.sin_port = htons(port);
-        if (bind(listenSocket, reinterpret_cast<SOCKADDR*>(&address), sizeof(SOCKADDR)) == SOCKET_ERROR)
-            std::abort();
+        int reuseAddress = 1;
+        setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuseAddress), sizeof(reuseAddress));
+
+        if (family == AF_INET6)
+        {
+            int v6Only = versions == IPVersions::ipv6 ? 1 : 0;
+            setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6Only), sizeof(v6Only));
+        }
+
+        if (family == AF_INET)
+        {
+            sockaddr_in address = {};
+            address.sin_family = AF_INET;
+            address.sin_addr.s_addr = htonl(INADDR_ANY);
+            address.sin_port = htons(port);
+            if (bind(listenSocket, reinterpret_cast<SOCKADDR*>(&address), sizeof(address)) == SOCKET_ERROR)
+                std::abort();
+        }
+        else
+        {
+            sockaddr_in6 address = {};
+            address.sin6_family = AF_INET6;
+            address.sin6_addr = in6addr_any;
+            address.sin6_port = htons(port);
+            if (bind(listenSocket, reinterpret_cast<SOCKADDR*>(&address), sizeof(address)) == SOCKET_ERROR)
+                std::abort();
+        }
 
         if (listen(listenSocket, 1) == SOCKET_ERROR)
             std::abort();
@@ -258,16 +339,44 @@ namespace services
                 if (connectionObserver)
                     connection->SetObserver(connectionObserver);
             },
-            connection->Ipv4Address());
+            connection->Address());
     }
 
     ConnectorWin::ConnectorWin(EventDispatcherWithNetwork& network, services::ClientConnectionObserverFactory& factory)
         : network(network)
         , factory(factory)
     {
-        auto address = std::get<services::IPv4Address>(factory.Address());
+        const auto address = factory.Address();
 
-        connectSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        if (std::holds_alternative<services::IPv4Address>(address))
+        {
+            auto ipv4Address = std::get<services::IPv4Address>(address);
+
+            connectSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+            assert(connectSocket != INVALID_SOCKET);
+            int result = WSAEventSelect(connectSocket, event, FD_CONNECT);
+            assert(result == 0);
+
+            ULONG nonBlock = 1;
+            if (ioctlsocket(connectSocket, FIONBIO, &nonBlock) == SOCKET_ERROR)
+                std::abort();
+
+            sockaddr_in saddress = {};
+            saddress.sin_family = AF_INET;
+            saddress.sin_addr.s_addr = htonl(services::ConvertToUint32(ipv4Address));
+            saddress.sin_port = htons(factory.Port());
+            if (connect(connectSocket, reinterpret_cast<sockaddr*>(&saddress), sizeof(saddress)) == SOCKET_ERROR)
+            {
+                if (GetLastError() != WSAEWOULDBLOCK)
+                    std::abort();
+            }
+
+            return;
+        }
+
+        const auto& ipv6Address = std::get<services::IPv6Address>(address);
+
+        connectSocket = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
         assert(connectSocket != INVALID_SOCKET);
         int result = WSAEventSelect(connectSocket, event, FD_CONNECT);
         assert(result == 0);
@@ -276,10 +385,10 @@ namespace services
         if (ioctlsocket(connectSocket, FIONBIO, &nonBlock) == SOCKET_ERROR)
             std::abort();
 
-        sockaddr_in saddress = {};
-        saddress.sin_family = AF_INET;
-        saddress.sin_addr.s_addr = htonl(services::ConvertToUint32(address));
-        saddress.sin_port = htons(factory.Port());
+        sockaddr_in6 saddress = {};
+        saddress.sin6_family = AF_INET6;
+        saddress.sin6_addr = ToIn6Addr(ipv6Address);
+        saddress.sin6_port = htons(factory.Port());
         if (connect(connectSocket, reinterpret_cast<sockaddr*>(&saddress), sizeof(saddress)) == SOCKET_ERROR)
         {
             if (GetLastError() != WSAEWOULDBLOCK)

--- a/services/network_instantiations/ConnectionWin.cpp
+++ b/services/network_instantiations/ConnectionWin.cpp
@@ -69,7 +69,7 @@ namespace services
             result = closesocket(socket);
             if (result == SOCKET_ERROR)
             {
-                DWORD error = GetLastError();
+                DWORD error = WSAGetLastError();
                 std::abort();
             }
         }
@@ -121,13 +121,14 @@ namespace services
 
         if (address.ss_family == AF_INET)
         {
-            const auto& ipv4Address = reinterpret_cast<const sockaddr_in&>(address);
+            sockaddr_in ipv4Address{};
+            std::memcpy(&ipv4Address, &address, sizeof(ipv4Address));
             return services::ConvertFromUint32(htonl(ipv4Address.sin_addr.s_addr));
         }
 
-        const auto& ipv6Address = reinterpret_cast<const sockaddr_in6&>(address);
-        auto ipv4Address = ToIpv4AddressWhenV4Mapped(ipv6Address.sin6_addr);
-        if (ipv4Address)
+        sockaddr_in6 ipv6Address{};
+        std::memcpy(&ipv6Address, &address, sizeof(ipv6Address));
+        if (auto ipv4Address = ToIpv4AddressWhenV4Mapped(ipv6Address.sin6_addr); ipv4Address)
             return *ipv4Address;
 
         return ToIpv6Address(ipv6Address.sin6_addr);
@@ -367,7 +368,7 @@ namespace services
             saddress.sin_port = htons(factory.Port());
             if (connect(connectSocket, reinterpret_cast<sockaddr*>(&saddress), sizeof(saddress)) == SOCKET_ERROR)
             {
-                if (GetLastError() != WSAEWOULDBLOCK)
+                if (WSAGetLastError() != WSAEWOULDBLOCK)
                     std::abort();
             }
 
@@ -391,7 +392,7 @@ namespace services
         saddress.sin6_port = htons(factory.Port());
         if (connect(connectSocket, reinterpret_cast<sockaddr*>(&saddress), sizeof(saddress)) == SOCKET_ERROR)
         {
-            if (GetLastError() != WSAEWOULDBLOCK)
+            if (WSAGetLastError() != WSAEWOULDBLOCK)
                 std::abort();
         }
     }

--- a/services/network_instantiations/ConnectionWin.cpp
+++ b/services/network_instantiations/ConnectionWin.cpp
@@ -284,13 +284,15 @@ namespace services
         int result = WSAEventSelect(listenSocket, event, FD_ACCEPT);
         assert(result == 0);
 
-        int reuseAddress = 1;
-        setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuseAddress), sizeof(reuseAddress));
+        int exclusiveAddressUse = 1;
+        if (setsockopt(listenSocket, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char*>(&exclusiveAddressUse), sizeof(exclusiveAddressUse)) == SOCKET_ERROR)
+            std::abort();
 
         if (family == AF_INET6)
         {
             int v6Only = versions == IPVersions::ipv6 ? 1 : 0;
-            setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6Only), sizeof(v6Only));
+            if (setsockopt(listenSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6Only), sizeof(v6Only)) == SOCKET_ERROR)
+                std::abort();
         }
 
         if (family == AF_INET)

--- a/services/network_instantiations/ConnectionWin.hpp
+++ b/services/network_instantiations/ConnectionWin.hpp
@@ -30,7 +30,7 @@ namespace services
         void CloseAndDestroy() override;
         void AbortAndDestroy() override;
 
-        IPv4Address Ipv4Address() const;
+        IPAddress Address() const;
         void SetObserver(infra::SharedPtr<services::ConnectionObserver> connectionObserver);
         bool Connected() const;
 
@@ -94,7 +94,7 @@ namespace services
         : public infra::IntrusiveList<ListenerWin>::NodeType
     {
     public:
-        ListenerWin(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory);
+        ListenerWin(EventDispatcherWithNetwork& network, uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions);
         ~ListenerWin();
 
         void Accept();

--- a/services/network_instantiations/EventDispatcherWithNetworkBsd.cpp
+++ b/services/network_instantiations/EventDispatcherWithNetworkBsd.cpp
@@ -71,13 +71,11 @@ namespace services
 
     infra::SharedPtr<void> EventDispatcherWithNetwork::Listen(uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions)
     {
-        assert(versions != IPVersions::ipv6);
-        return infra::MakeSharedOnHeap<ListenerBsd>(*this, port, factory);
+        return infra::MakeSharedOnHeap<ListenerBsd>(*this, port, factory, versions);
     }
 
     void EventDispatcherWithNetwork::Connect(ClientConnectionObserverFactory& factory)
     {
-        assert(std::holds_alternative<IPv4Address>(factory.Address()));
         connectors.emplace_back(*this, factory);
     }
 

--- a/services/network_instantiations/EventDispatcherWithNetworkWin.cpp
+++ b/services/network_instantiations/EventDispatcherWithNetworkWin.cpp
@@ -61,13 +61,11 @@ namespace services
 
     infra::SharedPtr<void> EventDispatcherWithNetwork::Listen(uint16_t port, services::ServerConnectionObserverFactory& factory, IPVersions versions)
     {
-        assert(versions != IPVersions::ipv6);
-        return infra::MakeSharedOnHeap<ListenerWin>(*this, port, factory);
+        return infra::MakeSharedOnHeap<ListenerWin>(*this, port, factory, versions);
     }
 
     void EventDispatcherWithNetwork::Connect(ClientConnectionObserverFactory& factory)
     {
-        assert(std::holds_alternative<IPv4Address>(factory.Address()));
         connectors.emplace_back(*this, factory);
     }
 


### PR DESCRIPTION
## Summary

Adds IPv6 support to the BSD and Windows TCP connection back-ends in `services/network_instantiations`. Previously both implementations asserted out whenever an IPv6 address or `IPVersions::ipv6` was passed to `Listen` / `Connect`; they are now first-class citizens alongside IPv4.

## Changes

- **`ConnectionBsd` / `ConnectionWin`**
  - Replace `IPv4Address Ipv4Address() const` with `IPAddress Address() const`, returning the appropriate variant (IPv4 or IPv6) based on the peer's address family.
  - IPv4-mapped IPv6 peer addresses (`::ffff:a.b.c.d`) are reported as plain `IPv4Address` so existing IPv4 client code keeps working when the listener is dual-stack.
- **`ListenerBsd` / `ListenerWin`**
  - Constructor now takes `IPVersions versions` and creates an `AF_INET` or `AF_INET6` socket accordingly. For IPv6 listeners the `IPV6_V6ONLY` socket option is set based on `versions` (dual-stack when `IPVersions::both`, IPv6-only when `IPVersions::ipv6`).
- **`ConnectorBsd` / `ConnectorWin`**
  - Handle both `IPv4Address` and `IPv6Address` variants from `ClientConnectionObserverFactory::Address()`, creating the matching socket family and `sockaddr_in` / `sockaddr_in6` structure.
- **`EventDispatcherWithNetworkBsd` / `EventDispatcherWithNetworkWin`**
  - Remove the `assert(versions != IPVersions::ipv6)` and `assert(std::holds_alternative<IPv4Address>(...))` guards; forward `versions` to the listener constructor.
- **`ConnectionBsd.cpp` cleanup**
  - Small `AsSockAddr` / `BindSocket` / `ConnectSocket` helpers in an anonymous namespace remove the inline casts.
- **`ConnectionBsd.hpp` cleanup**
  - Drop unused `<list>` and `EventDispatcherWithWeakPtr.hpp` includes.

## API impact

Breaking for direct users of the platform-specific classes:

- `ConnectionBsd::Ipv4Address()` → `ConnectionBsd::Address()` (returns `IPAddress`)
- `ConnectionWin::Ipv4Address()` → `ConnectionWin::Address()` (returns `IPAddress`)
- `ListenerBsd` / `ListenerWin` constructors now require an `IPVersions` argument.

Callers going through the `ConnectionFactory` / `EventDispatcherWithNetwork` interfaces are unaffected at the source level, but can now actually pass `IPVersions::ipv6` / `IPVersions::both` without tripping an assert.
