### PR TITLE
fix: echo (de)serialization for bounded repeated nested messages

### DIFF
--- a/protobuf/echo/Proto.hpp
+++ b/protobuf/echo/Proto.hpp
@@ -164,9 +164,15 @@ namespace services
     };
 
     template<class T>
+    struct MessageDepth<ProtoRepeatedBase<T>>
+    {
+        static constexpr uint32_t value = 1 + MessageDepth<T>::value;
+    };
+
+    template<class T>
     struct MessageDepth<ProtoUnboundedRepeated<T>>
     {
-        static constexpr uint32_t value = 1;
+        static constexpr uint32_t value = 1 + MessageDepth<T>::value;
     };
 
     template<std::size_t Max>
@@ -184,7 +190,7 @@ namespace services
     template<std::size_t Max, class T>
     struct MessageDepth<ProtoRepeated<Max, T>>
     {
-        static constexpr uint32_t value = 1;
+        static constexpr uint32_t value = 1 + MessageDepth<T>::value;
     };
 
     template<uint32_t... V>

--- a/protobuf/echo/ProtoMessageReceiver.hpp
+++ b/protobuf/echo/ProtoMessageReceiver.hpp
@@ -49,7 +49,7 @@ namespace services
         template<class Message>
         void DeserializeField(ProtoMessage<Message>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Message& value);
         template<class ProtoType, class Type>
-        void DeserializeField(ProtoRepeatedBase<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value) const;
+        void DeserializeField(ProtoRepeatedBase<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value);
         template<class ProtoType, class Type>
         void DeserializeField(ProtoUnboundedRepeated<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value) const;
 
@@ -152,7 +152,7 @@ namespace services
     }
 
     template<class ProtoType, class Type>
-    void ProtoMessageReceiverBase::DeserializeField(ProtoRepeatedBase<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value) const
+    void ProtoMessageReceiverBase::DeserializeField(ProtoRepeatedBase<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value)
     {
         parser.ReportFormatResult(!value.full());
         if (!value.full())

--- a/protobuf/echo/ProtoMessageSender.cpp
+++ b/protobuf/echo/ProtoMessageSender.cpp
@@ -3,7 +3,7 @@
 
 namespace services
 {
-    ProtoMessageSenderBase::ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>>& stack)
+    ProtoMessageSenderBase::ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack)
         : stack(stack)
     {}
 
@@ -86,7 +86,7 @@ namespace services
 
     namespace
     {
-        void SerializeRange(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>>& stack, infra::ProtoFormatter& formatter, infra::ConstByteRange value, uint32_t fieldNumber, bool& retry)
+        void SerializeRange(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack, infra::ProtoFormatter& formatter, infra::ConstByteRange value, uint32_t fieldNumber, bool& retry)
         {
             formatter.PutVarInt((fieldNumber << 3) | 2);
             formatter.PutVarInt(value.size());

--- a/protobuf/echo/ProtoMessageSender.cpp
+++ b/protobuf/echo/ProtoMessageSender.cpp
@@ -3,7 +3,7 @@
 
 namespace services
 {
-    ProtoMessageSenderBase::ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack)
+    ProtoMessageSenderBase::ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>& stack)
         : stack(stack)
     {}
 
@@ -86,7 +86,7 @@ namespace services
 
     namespace
     {
-        void SerializeRange(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack, infra::ProtoFormatter& formatter, infra::ConstByteRange value, uint32_t fieldNumber, bool& retry)
+        void SerializeRange(infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>& stack, infra::ProtoFormatter& formatter, infra::ConstByteRange value, uint32_t fieldNumber, bool& retry)
         {
             formatter.PutVarInt((fieldNumber << 3) | 2);
             formatter.PutVarInt(value.size());

--- a/protobuf/echo/ProtoMessageSender.hpp
+++ b/protobuf/echo/ProtoMessageSender.hpp
@@ -9,10 +9,13 @@
 
 namespace services
 {
+    static constexpr std::size_t serializationStepExtraSize = 4 * sizeof(void*);
+    using FieldSerializationStep = infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), serializationStepExtraSize>;
+
     class ProtoMessageSenderBase
     {
     public:
-        explicit ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack);
+        explicit ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>& stack);
 
         void Fill(infra::DataOutputStream output);
         bool BufferEmpty() const;
@@ -54,7 +57,7 @@ namespace services
 
     private:
         infra::BoundedDeque<uint8_t>::WithMaxSize<32> buffer;
-        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack;
+        infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>& stack;
     };
 
     template<class Message>
@@ -66,7 +69,7 @@ namespace services
 
     private:
         const Message& message;
-        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
+        infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
             {
                 return FillForMessage(stream, message, index, retry, finalWriter, errorPolicy);
             } } } };

--- a/protobuf/echo/ProtoMessageSender.hpp
+++ b/protobuf/echo/ProtoMessageSender.hpp
@@ -182,7 +182,15 @@ namespace services
                         return false;
                     }
 
-                    SerializeField(ProtoType(), formatter, value[index], fieldNumber, retry);
+                    auto size = stack.size();
+                    auto result = SerializeField(ProtoType(), formatter, value[index], fieldNumber, retry);
+                    if (size != stack.size())
+                    {
+                        // A nested message was added to the stack, so we need to stop processing the current message until it has been fully sent
+                        ++index;
+                        retry = retry && result;
+                        return false;
+                    }
                 }
 
                 return true;

--- a/protobuf/echo/ProtoMessageSender.hpp
+++ b/protobuf/echo/ProtoMessageSender.hpp
@@ -12,7 +12,7 @@ namespace services
     class ProtoMessageSenderBase
     {
     public:
-        explicit ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>>& stack);
+        explicit ProtoMessageSenderBase(infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack);
 
         void Fill(infra::DataOutputStream output);
         bool BufferEmpty() const;
@@ -54,7 +54,7 @@ namespace services
 
     private:
         infra::BoundedDeque<uint8_t>::WithMaxSize<32> buffer;
-        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>>& stack;
+        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>& stack;
     };
 
     template<class Message>
@@ -66,7 +66,7 @@ namespace services
 
     private:
         const Message& message;
-        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
+        infra::BoundedVector<std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 4 * sizeof(uint8_t*)>>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
             {
                 return FillForMessage(stream, message, index, retry, finalWriter, errorPolicy);
             } } } };
@@ -137,7 +137,7 @@ namespace services
     template<class ProtoType, class Type>
     bool ProtoMessageSenderBase::SerializeField(ProtoRepeatedBase<ProtoType>, const infra::ProtoFormatter&, const infra::BoundedVector<Type>& value, uint32_t fieldNumber, bool& retry) const
     {
-        stack.emplace_back(0, [this, &value, fieldNumber](infra::DataOutputStream& stream, uint32_t& index, const bool&, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
+        stack.emplace_back(0, [this, &value, fieldNumber, &retry](infra::DataOutputStream& stream, uint32_t& index, const bool&, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
             {
                 infra::ProtoFormatter formatter{ stream };
 
@@ -148,7 +148,16 @@ namespace services
                         errorPolicy.ReportResult(false);
                         return false;
                     }
-                    services::SerializeField(ProtoType(), formatter, value[index], fieldNumber);
+
+                    auto size = stack.size();
+                    auto result = SerializeField(ProtoType(), formatter, value[index], fieldNumber, retry);
+                    if (size != stack.size())
+                    {
+                        // A nested message was added to the stack, so we need to stop processing the current message until it has been fully sent
+                        ++index;
+                        retry = retry && result;
+                        return false;
+                    }
                 }
 
                 return true;
@@ -161,7 +170,7 @@ namespace services
     template<class ProtoType, class Type>
     bool ProtoMessageSenderBase::SerializeField(ProtoUnboundedRepeated<ProtoType>, const infra::ProtoFormatter&, const std::vector<Type>& value, uint32_t fieldNumber, bool& retry) const
     {
-        stack.emplace_back(0, [this, &value, fieldNumber](infra::DataOutputStream& stream, uint32_t& index, const bool&, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
+        stack.emplace_back(0, [this, &value, fieldNumber, &retry](infra::DataOutputStream& stream, uint32_t& index, const bool&, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
             {
                 infra::ProtoFormatter formatter{ stream };
 
@@ -172,7 +181,8 @@ namespace services
                         errorPolicy.ReportResult(false);
                         return false;
                     }
-                    services::SerializeField(ProtoType(), formatter, value[index], fieldNumber);
+
+                    SerializeField(ProtoType(), formatter, value[index], fieldNumber, retry);
                 }
 
                 return true;

--- a/protobuf/echo/ProtoMessageSender.hpp
+++ b/protobuf/echo/ProtoMessageSender.hpp
@@ -69,7 +69,7 @@ namespace services
 
     private:
         const Message& message;
-        infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, infra::Function<bool(infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy), 3 * sizeof(uint8_t*)>>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
+        infra::BoundedVector<std::pair<uint32_t, FieldSerializationStep>>::WithMaxSize<MessageDepth<services::ProtoMessage<Message>>::value + 1> stack{ { std::pair<uint32_t, FieldSerializationStep>{ 0, [this](infra::DataOutputStream& stream, uint32_t& index, bool& retry, const infra::StreamWriter& finalWriter, infra::StreamErrorPolicy& errorPolicy)
             {
                 return FillForMessage(stream, message, index, retry, finalWriter, errorPolicy);
             } } } };

--- a/protobuf/echo/test/TestProtoMessageReceiver.cpp
+++ b/protobuf/echo/test/TestProtoMessageReceiver.cpp
@@ -158,6 +158,19 @@ TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_uint32)
     EXPECT_EQ((std::vector<uint32_t>{ { 5, 6 } }), receiver.message.value);
 }
 
+TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_nested_message)
+{
+    services::ProtoMessageReceiver<test_messages::TestNestedRepeatedMessage> receiver;
+
+    infra::StdVectorInputStreamReader::WithStorage data(std::in_place, std::initializer_list<uint8_t>{ 1 << 3, 5, 1 << 3, 6 });
+    receiver.Feed(data);
+
+    test_messages::TestNestedRepeatedMessage expected;
+    expected.message.push_back({ 5 });
+    expected.message.push_back({ 6 });
+    EXPECT_EQ(expected, receiver.message);
+}
+
 TEST(ProtoMessageReceiverTest, parse_incomplete_int)
 {
     services::ProtoMessageReceiver<test_messages::TestInt32> receiver;

--- a/protobuf/echo/test/TestProtoMessageReceiver.cpp
+++ b/protobuf/echo/test/TestProtoMessageReceiver.cpp
@@ -158,16 +158,15 @@ TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_uint32)
     EXPECT_EQ((std::vector<uint32_t>{ { 5, 6 } }), receiver.message.value);
 }
 
-TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_nested_message)
+TEST(ProtoMessageReceiverTest, parse_repeated_nested_message)
 {
     services::ProtoMessageReceiver<test_messages::TestNestedRepeatedMessage> receiver;
 
-    infra::StdVectorInputStreamReader::WithStorage data(std::in_place, std::initializer_list<uint8_t>{ 1 << 3, 5, 1 << 3, 6 });
+    infra::StdVectorInputStreamReader::WithStorage data(std::in_place, std::initializer_list<uint8_t>{ 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5, 10, 2, 8, 5 });
     receiver.Feed(data);
 
     test_messages::TestNestedRepeatedMessage expected;
-    expected.message.push_back({ 5 });
-    expected.message.push_back({ 6 });
+    expected.message.insert(expected.message.end(), 10, static_cast<uint8_t>(5));
     EXPECT_EQ(expected, receiver.message);
 }
 

--- a/protobuf/echo/test/TestProtoMessageSender.cpp
+++ b/protobuf/echo/test/TestProtoMessageSender.cpp
@@ -224,9 +224,14 @@ TEST_F(ProtoMessageSenderTest, format_many_repeated_nested_messages)
     message.message.insert(message.message.end(), 10, static_cast<uint8_t>(5));
     services::ProtoMessageSender sender{ message };
 
+    infra::ByteOutputStream::WithStorage<8> partialStream(infra::noFail);
+    sender.Fill(partialStream);
+    EXPECT_EQ((std::array<uint8_t, 8>{ (1 << 3) | 2, 2, 1 << 3, 5, (1 << 3) | 2, 2, 1 << 3, 5 }), partialStream.Storage());
+    EXPECT_TRUE(partialStream.Failed());
+
     infra::StdVectorOutputStream::WithStorage stream;
     sender.Fill(stream);
-    EXPECT_EQ(infra::ConstructBin().Repeat(10, { (1 << 3) | 2, 2, 1 << 3, 5 }).Vector(), stream.Storage());
+    EXPECT_EQ(infra::ConstructBin().Repeat(8, { (1 << 3) | 2, 2, 1 << 3, 5 }).Vector(), stream.Storage());
     EXPECT_FALSE(stream.Failed());
 }
 

--- a/protobuf/echo/test/TestProtoMessageSender.cpp
+++ b/protobuf/echo/test/TestProtoMessageSender.cpp
@@ -218,6 +218,18 @@ TEST_F(ProtoMessageSenderTest, format_many_repeated_uint32)
     EXPECT_FALSE(stream.Failed());
 }
 
+TEST_F(ProtoMessageSenderTest, format_many_repeated_nested_messages)
+{
+    test_messages::TestNestedRepeatedMessage message;
+    message.message.insert(message.message.end(), 10, static_cast<uint8_t>(5));
+    services::ProtoMessageSender sender{ message };
+
+    infra::StdVectorOutputStream::WithStorage stream;
+    sender.Fill(stream);
+    EXPECT_EQ(infra::ConstructBin().Repeat(10, { (1 << 3) | 2, 2, 1 << 3, 5 }).Vector(), stream.Storage());
+    EXPECT_FALSE(stream.Failed());
+}
+
 TEST_F(ProtoMessageSenderTest, format_many_bytes)
 {
     test_messages::TestBytes message;


### PR DESCRIPTION
This fixes repeated nested messages, which was discovered in #1196. It did not compile.
The fix is by @richardapeters.
I also made the callback a bit more readable, with the stack size defined in one location.

### NOTE: Unbounded repeated nested messages don't seem to work, it doesn't compile. For now considered out of scope.
```
[build] In file included from /workspaces//amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TracingTestMessages.pb.hpp:7,
[build]                  from /workspaces/amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TracingTestMessages.pb.cpp:4:
[build] /workspaces//amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TestMessages.pb.hpp:3867:55: error: ‘TestNestedRepeatedUnboundedMessageNestedUnboundMessage’ is not a member of ‘test_messages::detail’; did you mean ‘TestNestedRepeatedUnboundedMessageNestedUnboundMessageReference’?
[build]  3867 |       using Type = std::vector<test_messages::detail::TestNestedRepeatedUnboundedMessageNestedUnboundMessage>;
[build]       |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[build]       |                                                       TestNestedRepeatedUnboundedMessageNestedUnboundMessageReference
[build] /workspaces/amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TestMessages.pb.hpp:3867:109: error: template argument 1 is invalid
[build]  3867 |       using Type = std::vector<test_messages::detail::TestNestedRepeatedUnboundedMessageNestedUnboundMessage>;
[build]       |                                                                                                             ^
[build] /workspaces/amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TestMessages.pb.hpp:3867:109: error: template argument 2 is invalid
[build] /workspaces/amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TestMessages.pb.hpp:3868:52: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
[build]  3868 |       using DecayedType = infra::MemoryRange<const test_messages::detail::TestNestedRepeatedUnboundedMessageNestedUnboundMessage>;
[build]       |                                                    ^~~~~~~~~~~~~
[build] /workspaces/amp-embedded-infra-lib/build/host/protobuf/echo/test/generated/echo/TestMessages.pb.hpp:3868:129: error: template argument 1 is invalid
[build]  3868 |       using DecayedType = infra::MemoryRange<const test_messages::detail::TestNestedRepeatedUnboundedMessageNestedUnboundMessage>;
[build]       |        
```