### PR TITLE
refactor: have SesameCobs send bigger chunks

### DIFF
--- a/services/util/SesameCobs.cpp
+++ b/services/util/SesameCobs.cpp
@@ -23,17 +23,17 @@ namespace services
 
     std::size_t SesameCobs::MaxSendMessageSize() const
     {
-        return sendStorage.max_size() - 4 - (sendStorage.max_size() - 4) / 255;
+        return sendStorage.max_size() - (cobsConstantOverhead + scratchSize) - (sendStorage.max_size() - (cobsConstantOverhead + scratchSize)) / (maxFrameSize + 1);
     }
 
     std::size_t SesameCobs::WorstCaseEncodedMessageSize(std::size_t size) const
     {
-        return size + size / 254 + 2;
+        return size + size / maxFrameSize + cobsConstantOverhead;
     }
 
     std::size_t SesameCobs::WorstCaseDecodedMessageSize(std::size_t encodedMessageSize) const
     {
-        return (encodedMessageSize - 2) - (encodedMessageSize - 2) / 254;
+        return (encodedMessageSize - cobsConstantOverhead) - (encodedMessageSize - cobsConstantOverhead) / maxFrameSize;
     }
 
     std::size_t SesameCobs::MessageSize(infra::StreamReader&& message) const
@@ -51,7 +51,7 @@ namespace services
                 else
                 {
                     ++consecutiveNonZero;
-                    if (consecutiveNonZero == 254)
+                    if (consecutiveNonZero == maxFrameSize)
                     {
                         consecutiveNonZero = 0;
                         ++result;
@@ -137,7 +137,7 @@ namespace services
             data.pop_front();
             if (!overheadPositionIsPseudo)
                 ReceivedPayload(infra::MakeByteRange(messageDelimiter));
-            overheadPositionIsPseudo = nextOverhead == 255;
+            overheadPositionIsPseudo = nextOverhead == (maxFrameSize + 1);
         }
     }
 
@@ -216,6 +216,7 @@ namespace services
     void SesameCobs::SendStreamFilled()
     {
         sendingUserData = true;
+        frameSize = 0;
         dataToSend = infra::DiscardHead(infra::MakeRange(sendStorage), 1);
         chunkToSend = infra::Head(infra::MakeRange(sendStorage), 1);
 
@@ -229,7 +230,7 @@ namespace services
     {
         if (resetting)
             FinishReset();
-        else if (dataToSend.empty() && frameSize < 254)
+        else if (dataToSend.empty() && frameSize < maxFrameSize)
             FinishChunk();
         else
             SendChunk();
@@ -253,16 +254,14 @@ namespace services
         frameSize = FindDelimiter();
 
         chunkToSend.back() = frameSize + 1;
-        if (dataToSend.empty())
-            chunkToSend = infra::ByteRange(chunkToSend.begin(), chunkToSend.end() + 1);
-        else
-            chunkToSend = infra::ByteRange(chunkToSend.begin(), dataToSend.begin() + frameSize + (frameSize < 254 ? 1 : 0));
 
-        if (frameSize < 254)
+        chunkToSend = CreateChunkWithTermination();
+
+        if (frameSize < maxFrameSize)
             chunkToSend.back() = 0;
         dataToSend = infra::DiscardHead(dataToSend, frameSize);
 
-        if (dataToSend.empty() || frameSize == 254)
+        if (dataToSend.empty() || frameSize == maxFrameSize)
             return false;
 
         if (dataToSend.front() == 0)
@@ -301,9 +300,17 @@ namespace services
         CheckReadyToSendUserData();
     }
 
+    infra::ByteRange SesameCobs::CreateChunkWithTermination() const
+    {
+        if (dataToSend.empty())
+            return infra::ByteRange(chunkToSend.begin(), chunkToSend.end() + 1);
+        else
+            return infra::ByteRange(chunkToSend.begin(), dataToSend.begin() + frameSize + (frameSize < maxFrameSize ? 1 : 0));
+    }
+
     uint8_t SesameCobs::FindDelimiter() const
     {
-        auto data = infra::Head(dataToSend, 254);
+        auto data = infra::Head(dataToSend, maxFrameSize);
         return static_cast<uint8_t>(std::find(data.begin(), data.end(), messageDelimiter) - data.begin());
     }
 }

--- a/services/util/SesameCobs.cpp
+++ b/services/util/SesameCobs.cpp
@@ -23,7 +23,7 @@ namespace services
 
     std::size_t SesameCobs::MaxSendMessageSize() const
     {
-        return sendStorage.max_size() - 2 - (sendStorage.max_size() - 2) / 255;
+        return sendStorage.max_size() - 4 - (sendStorage.max_size() - 4) / 255;
     }
 
     std::size_t SesameCobs::WorstCaseEncodedMessageSize(std::size_t size) const
@@ -195,7 +195,10 @@ namespace services
     void SesameCobs::CheckReadyToSendUserData()
     {
         if (!sendingUserData && sendReqestedSize != std::nullopt)
+        {
+            sendStorage.push_back(0);
             SesameEncoded::GetObserver().SendMessageStreamAvailable(sendStream.Emplace(std::in_place, sendStorage, *std::exchange(sendReqestedSize, std::nullopt)));
+        }
     }
 
     void SesameCobs::SendSerialData(const infra::ConstByteRange data, const infra::Function<void()>& onSendDataDone)
@@ -213,7 +216,8 @@ namespace services
     void SesameCobs::SendStreamFilled()
     {
         sendingUserData = true;
-        dataToSend = infra::MakeRange(sendStorage);
+        dataToSend = infra::DiscardHead(infra::MakeRange(sendStorage), 1);
+        chunkToSend = infra::Head(infra::MakeRange(sendStorage), 1);
 
         if (sendingFirstPacket)
             SendFirstDelimiter();
@@ -225,42 +229,57 @@ namespace services
     {
         if (resetting)
             FinishReset();
-        else if (dataToSend.empty())
-            SendLastDelimiter();
+        else if (dataToSend.empty() && frameSize < 254)
+            FinishChunk();
         else
-            SendFrame();
+            SendChunk();
     }
 
-    void SesameCobs::SendFrame()
+    void SesameCobs::SendChunk()
     {
-        frameSize = FindDelimiter() + 1;
-        sendSizeEncoded += 1;
-        SendSerialData(infra::MakeByteRange(frameSize), [this]()
+        while (FillChunk())
+        {}
+
+        sendSizeEncoded += chunkToSend.size();
+        SendSerialData(chunkToSend, [this]()
             {
-                --frameSize;
-                if (resetting)
-                    FinishReset();
-                else if (frameSize != 0)
-                    SendData(infra::Head(dataToSend, frameSize));
-                else
-                    SendFrameDone();
+                chunkToSend = infra::Tail(chunkToSend, 1);
+                SendOrDone();
             });
     }
 
-    void SesameCobs::SendFrameDone()
+    bool SesameCobs::FillChunk()
     {
-        if (frameSize == 254)
-            dataToSend = infra::DiscardHead(dataToSend, 254);
+        frameSize = FindDelimiter();
+
+        chunkToSend.back() = frameSize + 1;
+        if (dataToSend.empty())
+            chunkToSend = infra::ByteRange(chunkToSend.begin(), chunkToSend.end() + 1);
         else
-            dataToSend = infra::DiscardHead(dataToSend, frameSize);
+            chunkToSend = infra::ByteRange(chunkToSend.begin(), dataToSend.begin() + frameSize + (frameSize < 254 ? 1 : 0));
+
+        if (frameSize < 254)
+            chunkToSend.back() = 0;
+        dataToSend = infra::DiscardHead(dataToSend, frameSize);
 
         if (dataToSend.empty() || frameSize == 254)
-            SendOrDone();
-        else
-        {
+            return false;
+
+        if (dataToSend.front() == 0)
             dataToSend.pop_front();
-            SendFrame();
-        }
+
+        return true;
+    }
+
+    void SesameCobs::FinishChunk()
+    {
+        sendStorage.clear();
+        dataToSend.clear();
+        SesameEncoded::GetObserver().MessageSent(sendSizeEncoded);
+        sendSizeEncoded = 0;
+
+        sendingUserData = false;
+        CheckReadyToSendUserData();
     }
 
     void SesameCobs::SendFirstDelimiter()
@@ -270,35 +289,6 @@ namespace services
         SendSerialData(infra::MakeByteRange(messageDelimiter), [this]()
             {
                 SendOrDone();
-            });
-    }
-
-    void SesameCobs::SendLastDelimiter()
-    {
-        sendSizeEncoded += 1;
-        SendSerialData(infra::MakeByteRange(messageDelimiter), [this]()
-            {
-                if (resetting)
-                    FinishReset();
-                else
-                {
-                    sendStorage.clear();
-                    dataToSend.clear();
-                    SesameEncoded::GetObserver().MessageSent(sendSizeEncoded);
-                    sendSizeEncoded = 0;
-
-                    sendingUserData = false;
-                    CheckReadyToSendUserData();
-                }
-            });
-    }
-
-    void SesameCobs::SendData(infra::ConstByteRange data)
-    {
-        sendSizeEncoded += data.size();
-        SendSerialData(data, [this]()
-            {
-                SendFrameDone();
             });
     }
 

--- a/services/util/SesameCobs.hpp
+++ b/services/util/SesameCobs.hpp
@@ -18,14 +18,17 @@ namespace services
         , public services::Stoppable
     {
     public:
+        static constexpr uint8_t cobsConstantOverhead = 2; // This is the frame size byte and the closing 0
+        static constexpr uint8_t scratchSize = 2;          // This is added to message storage for filling out frame size bytes
+
         template<std::size_t MaxMessageSize>
         struct EncodedMessageSize
         {
-            static constexpr std::size_t size = MaxMessageSize + MaxMessageSize / 254 + 2;
+            static constexpr std::size_t size = MaxMessageSize + MaxMessageSize / 254 + cobsConstantOverhead;
         };
 
         template<std::size_t MaxMessageSize>
-        static constexpr std::size_t sendBufferSize = MaxMessageSize + 2;
+        static constexpr std::size_t sendBufferSize = MaxMessageSize + scratchSize;
         template<std::size_t MaxMessageSize>
         static constexpr std::size_t receiveBufferSize = EncodedMessageSize<MaxMessageSize>::size;
 
@@ -69,6 +72,7 @@ namespace services
         void FinishChunk();
         void SendFirstDelimiter();
         void FinishReset();
+        infra::ByteRange CreateChunkWithTermination() const;
         uint8_t FindDelimiter() const;
 
     private:
@@ -94,6 +98,8 @@ namespace services
 
         infra::AutoResetFunction<void()> onStopDone;
         infra::AutoResetFunction<void()> onSendDataDone;
+
+        static constexpr uint8_t maxFrameSize = 254;
     };
 }
 

--- a/services/util/SesameCobs.hpp
+++ b/services/util/SesameCobs.hpp
@@ -25,7 +25,7 @@ namespace services
         };
 
         template<std::size_t MaxMessageSize>
-        static constexpr std::size_t sendBufferSize = MaxMessageSize;
+        static constexpr std::size_t sendBufferSize = MaxMessageSize + 2;
         template<std::size_t MaxMessageSize>
         static constexpr std::size_t receiveBufferSize = EncodedMessageSize<MaxMessageSize>::size;
 
@@ -64,11 +64,10 @@ namespace services
         void SendSerialData(const infra::ConstByteRange data, const infra::Function<void()>& onSendDataDone);
         void SendStreamFilled();
         void SendOrDone();
-        void SendFrame();
-        void SendFrameDone();
+        void SendChunk();
+        bool FillChunk();
+        void FinishChunk();
         void SendFirstDelimiter();
-        void SendLastDelimiter();
-        void SendData(infra::ConstByteRange data);
         void FinishReset();
         uint8_t FindDelimiter() const;
 
@@ -89,7 +88,8 @@ namespace services
             {
                 SendStreamFilled();
             } };
-        infra::ConstByteRange dataToSend;
+        infra::ByteRange dataToSend;
+        infra::ByteRange chunkToSend;
         uint8_t frameSize;
 
         infra::AutoResetFunction<void()> onStopDone;

--- a/services/util/test/TestSesameCobs.cpp
+++ b/services/util/test/TestSesameCobs.cpp
@@ -136,7 +136,7 @@ TEST_F(SesameCobsTest, send_data)
     infra::DataOutputStream::WithErrorPolicy stream(*writer);
     stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
 
-    ExpectSendSequence({ { 0 }, { 5 }, { 1, 2, 3, 4 }, { 0 } });
+    ExpectSendSequence({ { 0 }, { 5, 1, 2, 3, 4, 0 } });
 }
 
 TEST_F(SesameCobsTest, send_data_with_0)
@@ -145,7 +145,7 @@ TEST_F(SesameCobsTest, send_data_with_0)
     infra::DataOutputStream::WithErrorPolicy stream(*writer);
     stream << infra::ConstructBin()({ 1, 0, 3, 4 }).Range();
 
-    ExpectSendSequence({ { 0 }, { 2 }, { 1 }, { 3 }, { 3, 4 }, { 0 } });
+    ExpectSendSequence({ { 0 }, { 2, 1, 3, 3, 4, 0 } });
 }
 
 TEST_F(SesameCobsTest, send_data_ending_with_0)
@@ -154,7 +154,16 @@ TEST_F(SesameCobsTest, send_data_ending_with_0)
     infra::DataOutputStream::WithErrorPolicy stream(*writer);
     stream << infra::ConstructBin()({ 5, 6, 0 }).Range();
 
-    ExpectSendSequence({ { 0 }, { 3 }, { 5, 6 }, { 1 }, { 0 } });
+    ExpectSendSequence({ { 0 }, { 3, 5, 6, 1, 0 } });
+}
+
+TEST_F(SesameCobsTest, send_data_exactly_needing_overhead)
+{
+    RequestSendMessage(254, 258);
+    infra::DataOutputStream::WithErrorPolicy stream(*writer);
+    stream << infra::ConstructBin()(std::vector<uint8_t>(254, 3)).Range();
+
+    ExpectSendSequence({ { 0 }, infra::ConstructBin()(255).Repeat(254, 3).Vector(), infra::ConstructBin()(1)(0).Vector() });
 }
 
 TEST_F(SesameCobsTest, send_large_data)
@@ -163,7 +172,7 @@ TEST_F(SesameCobsTest, send_large_data)
     infra::DataOutputStream::WithErrorPolicy stream(*writer);
     stream << infra::ConstructBin()(std::vector<uint8_t>(280, 3)).Range();
 
-    ExpectSendSequence({ { 0 }, { 255 }, std::vector<uint8_t>(254, 3), { 27 }, std::vector<uint8_t>(26, 3), { 0 } });
+    ExpectSendSequence({ { 0 }, infra::ConstructBin()(255).Repeat(254, 3).Vector(), infra::ConstructBin()(27).Repeat(26, 3)(0).Vector() });
 }
 
 TEST_F(SesameCobsTest, send_two_packets)
@@ -173,18 +182,14 @@ TEST_F(SesameCobsTest, send_two_packets)
     stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
 
     ExpectSendDataAndHandle({ 0 });
-    ExpectSendDataAndHandle({ 5 });
-    ExpectSendDataAndHandle({ 1, 2, 3, 4 });
-    ExpectSendDataAndHandle({ 0 });
+    ExpectSendDataAndHandle({ 5, 1, 2, 3, 4, 0 });
     writer = nullptr;
 
     RequestSendMessage(2, 4);
     infra::DataOutputStream::WithErrorPolicy stream2(*writer);
     stream2 << infra::ConstructBin()({ 5, 6 }).Range();
 
-    ExpectSendDataAndHandle({ 3 });
-    ExpectSendDataAndHandle({ 5, 6 });
-    ExpectSendDataAndHandle({ 0 });
+    ExpectSendDataAndHandle({ 3, 5, 6, 0 });
     writer = nullptr;
 }
 
@@ -264,49 +269,6 @@ TEST_F(SesameCobsTest, stop_done_after_first_delimiter_sent)
     onSent();
 }
 
-TEST_F(SesameCobsTest, stop_done_after_frame_sent)
-{
-    infra::VerifyingFunction<void()> onDone;
-
-    EXPECT_CALL(observer, SendMessageStreamAvailable).WillOnce(testing::SaveArg<0>(&writer));
-    communication.RequestSendMessage(4);
-    infra::DataOutputStream::WithErrorPolicy stream(*writer);
-    stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
-
-    ExpectSendData({ 0 });
-    writer = nullptr;
-
-    ExpectSendData({ 5 });
-    onSent();
-
-    communication.Stop(onDone);
-
-    onSent();
-}
-
-TEST_F(SesameCobsTest, stop_done_after_data_sent)
-{
-    infra::VerifyingFunction<void()> onDone;
-
-    EXPECT_CALL(observer, SendMessageStreamAvailable).WillOnce(testing::SaveArg<0>(&writer));
-    communication.RequestSendMessage(4);
-    infra::DataOutputStream::WithErrorPolicy stream(*writer);
-    stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
-
-    ExpectSendData({ 0 });
-    writer = nullptr;
-
-    ExpectSendData({ 5 });
-    onSent();
-
-    ExpectSendData({ 1, 2, 3, 4 });
-    onSent();
-
-    communication.Stop(onDone);
-
-    onSent();
-}
-
 TEST_F(SesameCobsTest, stop_done_after_last_delimiter_sent)
 {
     infra::VerifyingFunction<void()> onDone;
@@ -319,12 +281,7 @@ TEST_F(SesameCobsTest, stop_done_after_last_delimiter_sent)
     ExpectSendData({ 0 });
     writer = nullptr;
 
-    ExpectSendData({ 5 });
-    onSent();
-
-    ExpectSendData({ 1, 2, 3, 4 });
-    onSent();
-    ExpectSendData({ 0 });
+    ExpectSendData({ 5, 1, 2, 3, 4, 0 });
     onSent();
 
     communication.Stop(onDone);
@@ -341,9 +298,7 @@ TEST_F(SesameCobsTest, Reset_invalidates_RequestSendMessage)
     }
 
     ExpectSendDataAndHandle({ 0 });
-    ExpectSendDataAndHandle({ 5 });
-    ExpectSendDataAndHandle({ 1, 2, 3, 4 });
-    ExpectSendDataAndHandle({ 0 });
+    ExpectSendDataAndHandle({ 5, 1, 2, 3, 4, 0 });
     writer = nullptr;
 
     EXPECT_CALL(observer, SendMessageStreamAvailable).WillOnce(testing::SaveArg<0>(&writer));
@@ -361,7 +316,7 @@ TEST_F(SesameCobsTest, Reset_invalidates_RequestSendMessage)
     infra::DataOutputStream::WithErrorPolicy stream(*writer);
     stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
 
-    ExpectSendSequence({ { 0 }, { 5 }, { 1, 2, 3, 4 }, { 0 } });
+    ExpectSendSequence({ { 0 }, { 5, 1, 2, 3, 4, 0 } });
 }
 
 TEST_F(SesameCobsTest, Reset_after_first_delimiter_stops_sending_current_packet)
@@ -388,27 +343,7 @@ TEST_F(SesameCobsTest, Reset_after_frame_stops_sending_current_packet)
     ExpectSendData({ 0 });
     writer = nullptr;
 
-    ExpectSendData({ 5 });
-    onSent();
-
-    communication.Reset();
-    onSent();
-}
-
-TEST_F(SesameCobsTest, Reset_after_data_stops_sending_current_packet)
-{
-    EXPECT_CALL(observer, SendMessageStreamAvailable).WillOnce(testing::SaveArg<0>(&writer));
-    communication.RequestSendMessage(4);
-    infra::DataOutputStream::WithErrorPolicy stream(*writer);
-    stream << infra::ConstructBin()({ 1, 2, 3, 4 }).Range();
-
-    ExpectSendData({ 0 });
-    writer = nullptr;
-
-    ExpectSendData({ 5 });
-    onSent();
-
-    ExpectSendData({ 1, 2, 3, 4 });
+    ExpectSendData({ 5, 1, 2, 3, 4, 0 });
     onSent();
 
     communication.Reset();
@@ -437,7 +372,7 @@ TEST_F(SesameCobsTest, new_request_after_reset_is_handled)
         stream << infra::ConstructBin()({ 1, 2 }).Range();
     }
 
-    ExpectSendSequence({ { 0 }, { 3 }, { 1, 2 }, { 0 } });
+    ExpectSendSequence({ { 0 }, { 3, 1, 2, 0 } });
 }
 
 TEST_F(SesameCobsTest, reset_as_a_result_of_ReceiveData)


### PR DESCRIPTION
Instead of sending frame sizes, content, closing 0 separately, now much bigger chunks are being sent in one UART transfer