### PR TITLE
chore: fix deserialization in ProtoBuf of unbounded repeated booleans

### DIFF
--- a/protobuf/echo/ProtoMessageReceiver.hpp
+++ b/protobuf/echo/ProtoMessageReceiver.hpp
@@ -51,7 +51,9 @@ namespace services
         template<class ProtoType, class Type>
         void DeserializeField(ProtoRepeatedBase<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value);
         template<class ProtoType, class Type>
-        void DeserializeField(ProtoUnboundedRepeated<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value) const;
+        void DeserializeField(ProtoUnboundedRepeated<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value);
+        template<class Type>
+        void DeserializeField(ProtoUnboundedRepeated<ProtoBool>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value);
 
         void ConsumeUnknownField(infra::ProtoParser::PartialField& field);
 
@@ -163,10 +165,19 @@ namespace services
     }
 
     template<class ProtoType, class Type>
-    void ProtoMessageReceiverBase::DeserializeField(ProtoUnboundedRepeated<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value) const
+    void ProtoMessageReceiverBase::DeserializeField(ProtoUnboundedRepeated<ProtoType>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value)
     {
         value.emplace_back();
         DeserializeField(ProtoType(), parser, field, value.back());
+    }
+
+    template<class Type>
+    void ProtoMessageReceiverBase::DeserializeField(ProtoUnboundedRepeated<ProtoBool>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value)
+    {
+        value.emplace_back();
+        bool result;
+        DeserializeField(ProtoBool(), parser, field, result); // std::vector<bool>().back() is not a reference to a bool, hence this workaround
+        value.back() = result;
     }
 
     template<class Message>

--- a/protobuf/echo/ProtoMessageReceiver.hpp
+++ b/protobuf/echo/ProtoMessageReceiver.hpp
@@ -175,7 +175,7 @@ namespace services
     void ProtoMessageReceiverBase::DeserializeField(ProtoUnboundedRepeated<ProtoBool>, infra::ProtoParser& parser, infra::ProtoParser::PartialFieldVariant& field, Type& value)
     {
         value.emplace_back();
-        bool result;
+        bool result = false;
         DeserializeField(ProtoBool(), parser, field, result); // std::vector<bool>().back() is not a reference to a bool, hence this workaround
         value.back() = result;
     }

--- a/protobuf/echo/test/TestProtoMessageReceiver.cpp
+++ b/protobuf/echo/test/TestProtoMessageReceiver.cpp
@@ -251,6 +251,7 @@ TEST(ProtoMessageReceiverTest, parse_repeated_everything)
 
     infra::StdVectorInputStreamReader::WithStorage data;
     receiver.Feed(data);
+    EXPECT_EQ(test_messages::TestRepeatedEverything{}, receiver.message);
 }
 
 TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_everything)
@@ -259,4 +260,5 @@ TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_everything)
 
     infra::StdVectorInputStreamReader::WithStorage data;
     receiver.Feed(data);
+    EXPECT_EQ(test_messages::TestUnboundedRepeatedEverything{}, receiver.message);
 }

--- a/protobuf/echo/test/TestProtoMessageReceiver.cpp
+++ b/protobuf/echo/test/TestProtoMessageReceiver.cpp
@@ -244,3 +244,19 @@ TEST(ProtoMessageReceiverTest, parse_more_nested_message)
 
     EXPECT_EQ((test_messages::TestMoreNestedMessage({ 5 }, { 10 })), receiver.message);
 }
+
+TEST(ProtoMessageReceiverTest, parse_repeated_everything)
+{
+    services::ProtoMessageReceiver<test_messages::TestRepeatedEverything> receiver;
+
+    infra::StdVectorInputStreamReader::WithStorage data;
+    receiver.Feed(data);
+}
+
+TEST(ProtoMessageReceiverTest, parse_unbounded_repeated_everything)
+{
+    services::ProtoMessageReceiver<test_messages::TestUnboundedRepeatedEverything> receiver;
+
+    infra::StdVectorInputStreamReader::WithStorage data;
+    receiver.Feed(data);
+}

--- a/protobuf/echo/test/TestProtoMessageSender.cpp
+++ b/protobuf/echo/test/TestProtoMessageSender.cpp
@@ -251,3 +251,21 @@ TEST_F(ProtoMessageSenderTest, format_many_bytes)
     EXPECT_EQ((std::vector<uint8_t>{ 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 }), stream.Storage());
     EXPECT_FALSE(stream.Failed());
 }
+
+TEST_F(ProtoMessageSenderTest, format_repeated_everything)
+{
+    test_messages::TestRepeatedEverything message;
+    services::ProtoMessageSender sender{ message };
+
+    infra::ByteOutputStream::WithStorage<0> stream(infra::noFail);
+    sender.Fill(stream);
+}
+
+TEST_F(ProtoMessageSenderTest, format_unbounded_repeated_everything)
+{
+    test_messages::TestUnboundedRepeatedEverything message;
+    services::ProtoMessageSender sender{ message };
+
+    infra::ByteOutputStream::WithStorage<0> stream(infra::noFail);
+    sender.Fill(stream);
+}

--- a/protobuf/echo/test/TestProtoMessageSender.cpp
+++ b/protobuf/echo/test/TestProtoMessageSender.cpp
@@ -257,8 +257,9 @@ TEST_F(ProtoMessageSenderTest, format_repeated_everything)
     test_messages::TestRepeatedEverything message;
     services::ProtoMessageSender sender{ message };
 
-    infra::ByteOutputStream::WithStorage<0> stream(infra::noFail);
+    infra::StdVectorOutputStream::WithStorage stream(infra::noFail);
     sender.Fill(stream);
+    EXPECT_EQ(std::vector<uint8_t>{}, stream.Storage());
 }
 
 TEST_F(ProtoMessageSenderTest, format_unbounded_repeated_everything)
@@ -266,6 +267,7 @@ TEST_F(ProtoMessageSenderTest, format_unbounded_repeated_everything)
     test_messages::TestUnboundedRepeatedEverything message;
     services::ProtoMessageSender sender{ message };
 
-    infra::ByteOutputStream::WithStorage<0> stream(infra::noFail);
+    infra::StdVectorOutputStream::WithStorage stream(infra::noFail);
     sender.Fill(stream);
+    EXPECT_EQ(std::vector<uint8_t>{}, stream.Storage());
 }


### PR DESCRIPTION
Deserialization of unbounded repeated booleans in Protobuf messages did not compile, due to std::vector<bool>::back() not returning a reference to a boolean