### PR TITLE
feat: add passkey auth interfaces for gap peripheral

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -153,6 +153,23 @@ message BondsStatus
     uint32 maxBonds = 2;
 }
 
+// Sent during an active PairAndBond procedure when user interaction is required to complete pairing.
+// This will only be triggered when the negotiated pairing method requires it, which is determined by the
+// IO capabilities configured via SetIoCapabilities.
+// Not all pairing methods require user interaction (e.g. Just Works will never trigger this).
+message AuthenticationRequest
+{
+    // Indicates whether this is a Numeric Comparison (LE Secure Connections) or Passkey Entry pairing.
+    // If true: display the passkey to the user for confirmation and respond with NumericComparisonConfirm.
+    // If false: display or enter the passkey and respond with AuthenticateWithPasskey.
+    bool isNumericComparison = 1;
+
+    // The passkey to be displayed to the user.
+    // If isNumericComparison is true: the user confirms this value matches the one displayed on the peer device.
+    // If isNumericComparison is false: the user either reads this value to enter on the peer device, or is prompted to enter the passkey shown on the peer device (in which case this field is not used).
+    uint32 passkey = 2;
+}
+
 // ==================================================
 // GAP PERIPHERAL
 // ==================================================
@@ -339,23 +356,6 @@ service GapPeripheralReadiness {
 // ==================================================
 // GAP CENTRAL
 // ==================================================
-
-// Sent by the central during an active PairAndBond procedure when user interaction is required to complete pairing.
-// This will only be triggered when the negotiated pairing method requires it, which is determined by the
-// IO capabilities configured via GapCentral.SetIoCapabilities.
-// Not all pairing methods require user interaction (e.g. Just Works will never trigger this).
-message AuthenticationRequest
-{
-    // Indicates whether this is a Numeric Comparison (LE Secure Connections) or Passkey Entry pairing.
-    // If true: display the passkey to the user for confirmation and respond with GapCentral.NumericComparisonConfirm.
-    // If false: display or enter the passkey and respond with GapCentral.AuthenticateWithPasskey.
-    bool isNumericComparison = 1;
-
-    // The passkey to be displayed to the user.
-    // If isNumericComparison is true: the user confirms this value matches the one displayed on the peer device.
-    // If isNumericComparison is false: the user either reads this value to enter on the peer device, or is prompted to enter the passkey shown on the peer device (in which case this field is not used).
-    uint32 passkey = 2;
-}
 
 message SecurityModeAndLevel
 {

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -268,6 +268,9 @@ service GapPeripheral
 
     // Results in GapPeripheralResponse.BondInformation
     rpc GetBondInformation(Nothing) returns (Nothing) { option (method_id) = 13; }
+
+    // Allowed in link layer states: connected
+    rpc NumericComparisonConfirm(BoolValue) returns (Nothing) { option (method_id) = 14; }
 }
 
 service GapPeripheralResponse 
@@ -294,6 +297,8 @@ service GapPeripheralResponse
     rpc NumberOfBondsChanged(UInt32Value) returns(Nothing) { option(method_id) = 7; }
 
     rpc BondInformation(BondsStatus) returns(Nothing) { option(method_id) = 8; }
+
+    rpc DisplayPasskey(Passkey) returns (Nothing) { option (method_id) = 9; }
 }
 
 service GapPeripheralReadiness {

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -153,9 +153,9 @@ message BondsStatus
     uint32 maxBonds = 2;
 }
 
-// Sent during an active PairAndBond procedure when user interaction is required to complete pairing.
+// Sent during an active pairing/bonding procedure when user interaction is required to complete pairing.
 // This will only be triggered when the negotiated pairing method requires it, which is determined by the
-// IO capabilities configured via SetIoCapabilities.
+// I/O capabilities configured via GapCentral.SetIoCapabilities or GapPeripheral.SetSecurityPreferences.ioCapabilities.
 // Not all pairing methods require user interaction (e.g. Just Works will never trigger this).
 message AuthenticationRequest
 {

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -321,6 +321,8 @@ service GapPeripheralResponse
     rpc NumberOfBondsChanged(UInt32Value) returns(Nothing) { option(method_id) = 6; }
 
     rpc BondInformation(BondsStatus) returns(Nothing) { option(method_id) = 7; }
+
+    rpc AuthenticationRequired(AuthenticationRequest) returns (Nothing) { option (method_id) = 8; }
 }
 
 // DEPRECATED: Will be removed in the near future. Instead wait for CurrentState(standby) after startup

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -297,6 +297,10 @@ service GapPeripheral
     rpc GetBondInformation(Nothing) returns (Nothing) { option (method_id) = 13; }
 
     // Allowed in link layer states: connected
+    // Confirms or rejects the numeric comparison in response to GapPeripheralResponse.AuthenticationRequired.
+    // Only valid when AuthenticationRequest.isNumericComparison is true.
+    // Must be called within the SMP protocol timeout (30 seconds, Bluetooth Core Specification v6.3, Vol 3, Part H, Section 3.4)
+    // of receiving AuthenticationRequired, otherwise pairing will fail.
     rpc NumericComparisonConfirm(BoolValue) returns (Nothing) { option (method_id) = 14; }
 }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -298,7 +298,7 @@ service GapPeripheralResponse
 
     rpc BondInformation(BondsStatus) returns(Nothing) { option(method_id) = 8; }
 
-    rpc DisplayPasskey(Passkey) returns (Nothing) { option (method_id) = 9; }
+    rpc DisplayPasskey(Passkey) returns(Nothing) { option(method_id) = 9; }
 }
 
 service GapPeripheralReadiness {


### PR DESCRIPTION
NumericComparisonConfirm and AuthenticationRequired interfaces are added to GapPeripheralResponse to facilitate display yes/no io capabilities for peripheral