### PR TITLE
chore: ensure mbedtls optimizes when using DebugOptimized build

### DIFF
--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -88,5 +88,6 @@ add_mbedtls_target_properties(mbedcrypto mbedx509 mbedtls)
 set_target_properties(apidoc lib PROPERTIES FOLDER External/MbedTLS)
 
 # Without optimization bignum_core fails to compile due to lack of assembly registers
-target_compile_options(mbedcrypto PRIVATE $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:Debug>:-O2>>)
-target_compile_options(mbedcrypto PRIVATE $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:DebugOptimized>:-O2>>)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(mbedcrypto PRIVATE $<$<CONFIG:Debug,DebugOptimized>:-O2>)
+endif()

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -89,3 +89,4 @@ set_target_properties(apidoc lib PROPERTIES FOLDER External/MbedTLS)
 
 # Without optimization bignum_core fails to compile due to lack of assembly registers
 target_compile_options(mbedcrypto PRIVATE $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:Debug>:-O2>>)
+target_compile_options(mbedcrypto PRIVATE $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:DebugOptimized>:-O2>>)


### PR DESCRIPTION
Ensure the mbedtls compiler always optimizes, even when building a `DebugOptimized` preset.