### PR TITLE
feat!: change GattClient ECHO interface

### DIFF
--- a/services/ble/Att.hpp
+++ b/services/ble/Att.hpp
@@ -14,6 +14,8 @@ namespace services
         using Uuid = std::variant<Uuid16, Uuid128>;
 
         using Handle = uint16_t;
+
+        static constexpr auto invalidHandle = Handle{ 0 };
     };
 }
 

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -131,51 +131,34 @@ namespace services
         GattClientObserver::Subject().WriteWithoutResponse(handle, data, onDone);
     }
 
-    void ClaimingGattClientAdapter::EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
+    void ClaimingGattClientAdapter::ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
     {
-        characteristicOperationContext.emplace(DescriptorOperation{ onDone, [this](const infra::Function<void(OperationStatus)>& callback)
-                                                   {
-                                                       GattClientObserver::Subject().EnableNotification(characteristicOperationContext->handle, callback);
-                                                   } },
-            handle);
-
-        PerformDescriptorOperation();
+        characteristicOperationContext.emplace(ReadOperation{ onRead, onDone }, handle);
+        characteristicOperationsClaimer.Claim([this]()
+            {
+                const auto& readContext = std::get<ReadOperation>(characteristicOperationContext->operation);
+                GattClientObserver::Subject().ReadDescriptor(characteristicOperationContext->handle, readContext.onRead, [this](OperationStatus result)
+                    {
+                        characteristicOperationsClaimer.Release();
+                        const auto& readContext = std::get<ReadOperation>(characteristicOperationContext->operation);
+                        readContext.onDone(result);
+                    });
+            });
     }
 
-    void ClaimingGattClientAdapter::DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
+    void ClaimingGattClientAdapter::WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
-        characteristicOperationContext.emplace(DescriptorOperation{ onDone,
-                                                   [this](const infra::Function<void(OperationStatus)>& callback)
-                                                   {
-                                                       GattClientObserver::Subject().DisableNotification(characteristicOperationContext->handle, callback);
-                                                   } },
-            handle);
-
-        PerformDescriptorOperation();
-    }
-
-    void ClaimingGattClientAdapter::EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
-    {
-        characteristicOperationContext.emplace(DescriptorOperation{ onDone,
-                                                   [this](const infra::Function<void(OperationStatus)>& callback)
-                                                   {
-                                                       GattClientObserver::Subject().EnableIndication(characteristicOperationContext->handle, callback);
-                                                   } },
-            handle);
-
-        PerformDescriptorOperation();
-    }
-
-    void ClaimingGattClientAdapter::DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
-    {
-        characteristicOperationContext.emplace(DescriptorOperation{ onDone,
-                                                   [this](const infra::Function<void(OperationStatus)>& callback)
-                                                   {
-                                                       GattClientObserver::Subject().DisableIndication(characteristicOperationContext->handle, callback);
-                                                   } },
-            handle);
-
-        PerformDescriptorOperation();
+        characteristicOperationContext.emplace(WriteOperation{ data, onDone }, handle);
+        characteristicOperationsClaimer.Claim([this]()
+            {
+                const auto& writeContext = std::get<WriteOperation>(characteristicOperationContext->operation);
+                GattClientObserver::Subject().WriteDescriptor(characteristicOperationContext->handle, writeContext.data, [this](OperationStatus result)
+                    {
+                        characteristicOperationsClaimer.Release();
+                        const auto& writeContext = std::get<WriteOperation>(characteristicOperationContext->operation);
+                        writeContext.onDone(result);
+                    });
+            });
     }
 
     uint16_t ClaimingGattClientAdapter::EffectiveAttMtuSize() const
@@ -192,20 +175,6 @@ namespace services
                     {
                         attMtuExchangeClaimer.Release();
                         mtuExchangeOnDone(result);
-                    });
-            });
-    }
-
-    void ClaimingGattClientAdapter::PerformDescriptorOperation()
-    {
-        characteristicOperationsClaimer.Claim([this]()
-            {
-                auto descriptorOperationContext = std::get<DescriptorOperation>(characteristicOperationContext->operation);
-                descriptorOperationContext.operation([this](OperationStatus result)
-                    {
-                        characteristicOperationsClaimer.Release();
-                        auto descriptorOperationContext = std::get<DescriptorOperation>(characteristicOperationContext->operation);
-                        descriptorOperationContext.onDone(result);
                     });
             });
     }

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -96,13 +96,13 @@ namespace services
             });
     }
 
-    void ClaimingGattClientAdapter::Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
+    void ClaimingGattClientAdapter::ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
     {
         characteristicOperationContext.emplace(ReadOperation{ onRead, onDone }, handle);
         characteristicOperationsClaimer.Claim([this]()
             {
                 const auto& readContext = std::get<ReadOperation>(characteristicOperationContext->operation);
-                GattClientObserver::Subject().Read(characteristicOperationContext->handle, readContext.onRead, [this](OperationStatus result)
+                GattClientObserver::Subject().ReadCharacteristic(characteristicOperationContext->handle, readContext.onRead, [this](OperationStatus result)
                     {
                         characteristicOperationsClaimer.Release();
                         const auto& readContext = std::get<ReadOperation>(characteristicOperationContext->operation);
@@ -111,13 +111,13 @@ namespace services
             });
     }
 
-    void ClaimingGattClientAdapter::Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void ClaimingGattClientAdapter::WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
         characteristicOperationContext.emplace(WriteOperation{ data, onDone }, handle);
         characteristicOperationsClaimer.Claim([this]()
             {
                 const auto& writeContext = std::get<WriteOperation>(characteristicOperationContext->operation);
-                GattClientObserver::Subject().Write(characteristicOperationContext->handle, writeContext.data, [this](OperationStatus result)
+                GattClientObserver::Subject().WriteCharacteristic(characteristicOperationContext->handle, writeContext.data, [this](OperationStatus result)
                     {
                         characteristicOperationsClaimer.Release();
                         const auto& writeContext = std::get<WriteOperation>(characteristicOperationContext->operation);
@@ -126,9 +126,9 @@ namespace services
             });
     }
 
-    void ClaimingGattClientAdapter::WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void ClaimingGattClientAdapter::WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
-        GattClientObserver::Subject().WriteWithoutResponse(handle, data, onDone);
+        GattClientObserver::Subject().WriteCharacteristicWithoutResponse(handle, data, onDone);
     }
 
     void ClaimingGattClientAdapter::ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -21,31 +21,37 @@ namespace services
 
     void ClaimingGattClientAdapter::StartCharacteristicDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
+        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(HandleRange{ handle, endHandle });
         discoveryClaimer.Claim([this]()
             {
                 auto discoveredCharacteristic = std::get<HandleRange>(*discoveryContext);
                 GattClientObserver::Subject().StartCharacteristicDiscovery(discoveredCharacteristic.startHandle, discoveredCharacteristic.endHandle);
+                discoveryContext.reset();
             });
     }
 
     void ClaimingGattClientAdapter::StartDescriptorDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
+        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(HandleRange{ handle, endHandle });
         discoveryClaimer.Claim([this]()
             {
                 auto discoveredCharacteristic = std::get<HandleRange>(*discoveryContext);
                 GattClientObserver::Subject().StartDescriptorDiscovery(discoveredCharacteristic.startHandle, discoveredCharacteristic.endHandle);
+                discoveryContext.reset();
             });
     }
 
     void ClaimingGattClientAdapter::ServiceDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
+        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredService({ type, handle, endHandle }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredService = std::get<DiscoveredService>(*discoveryContext);
                 observer.ServiceDiscovered(discoveredService.type.get(), discoveredService.handle, discoveredService.endHandle);
+                discoveryContext.reset();
             });
     }
 
@@ -60,11 +66,13 @@ namespace services
 
     void ClaimingGattClientAdapter::CharacteristicDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties)
     {
+        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredCharacteristic({ type, handle, valueHandle, properties }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredCharacteristic = std::get<DiscoveredCharacteristic>(*discoveryContext);
                 observer.CharacteristicDiscovered(discoveredCharacteristic.type.get(), discoveredCharacteristic.handle, discoveredCharacteristic.valueHandle, discoveredCharacteristic.properties);
+                discoveryContext.reset();
             });
     }
 
@@ -79,11 +87,13 @@ namespace services
 
     void ClaimingGattClientAdapter::DescriptorDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle)
     {
+        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredDescriptor({ type, handle }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredDescriptor = std::get<DiscoveredDescriptor>(*discoveryContext);
                 observer.DescriptorDiscovered(discoveredDescriptor.type.get(), discoveredDescriptor.handle);
+                discoveryContext.reset();
             });
     }
 

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -21,37 +21,31 @@ namespace services
 
     void ClaimingGattClientAdapter::StartCharacteristicDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
-        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(HandleRange{ handle, endHandle });
         discoveryClaimer.Claim([this]()
             {
                 auto discoveredCharacteristic = std::get<HandleRange>(*discoveryContext);
                 GattClientObserver::Subject().StartCharacteristicDiscovery(discoveredCharacteristic.startHandle, discoveredCharacteristic.endHandle);
-                discoveryContext.reset();
             });
     }
 
     void ClaimingGattClientAdapter::StartDescriptorDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
-        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(HandleRange{ handle, endHandle });
         discoveryClaimer.Claim([this]()
             {
                 auto discoveredCharacteristic = std::get<HandleRange>(*discoveryContext);
                 GattClientObserver::Subject().StartDescriptorDiscovery(discoveredCharacteristic.startHandle, discoveredCharacteristic.endHandle);
-                discoveryContext.reset();
             });
     }
 
     void ClaimingGattClientAdapter::ServiceDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle)
     {
-        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredService({ type, handle, endHandle }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredService = std::get<DiscoveredService>(*discoveryContext);
                 observer.ServiceDiscovered(discoveredService.type.get(), discoveredService.handle, discoveredService.endHandle);
-                discoveryContext.reset();
             });
     }
 
@@ -66,13 +60,11 @@ namespace services
 
     void ClaimingGattClientAdapter::CharacteristicDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties)
     {
-        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredCharacteristic({ type, handle, valueHandle, properties }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredCharacteristic = std::get<DiscoveredCharacteristic>(*discoveryContext);
                 observer.CharacteristicDiscovered(discoveredCharacteristic.type.get(), discoveredCharacteristic.handle, discoveredCharacteristic.valueHandle, discoveredCharacteristic.properties);
-                discoveryContext.reset();
             });
     }
 
@@ -87,13 +79,11 @@ namespace services
 
     void ClaimingGattClientAdapter::DescriptorDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle)
     {
-        really_assert_with_msg(!discoveryContext.has_value(), "ClaimGatt: %d", discoveryContext->index());
         discoveryContext.emplace(DiscoveredDescriptor({ type, handle }));
         GattClientDiscovery::NotifyObservers([this](auto& observer)
             {
                 auto discoveredDescriptor = std::get<DiscoveredDescriptor>(*discoveryContext);
                 observer.DescriptorDiscovered(discoveredDescriptor.type.get(), discoveredDescriptor.handle);
-                discoveryContext.reset();
             });
     }
 

--- a/services/ble/ClaimingGattClientAdapter.hpp
+++ b/services/ble/ClaimingGattClientAdapter.hpp
@@ -32,9 +32,9 @@ namespace services
         void StartDescriptorDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle) override;
 
         // Implementation of GattClientCharacteristicOperations
-        void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
-        void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
-        void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
+        void ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
         void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
         void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
 

--- a/services/ble/ClaimingGattClientAdapter.hpp
+++ b/services/ble/ClaimingGattClientAdapter.hpp
@@ -35,10 +35,8 @@ namespace services
         void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
         void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
         void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
-        void EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-        void DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-        void EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-        void DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
+        void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
 
         // Implementation of GattClientMtuExchange
         virtual void MtuExchange(const infra::Function<void(OperationStatus)>& onDone) override;
@@ -63,9 +61,6 @@ namespace services
         // Implementation of GapCentralObserver
         void DeviceDiscovered(const GapAdvertisingReport& deviceDiscovered) override;
         void StateChanged(GapState state) override;
-
-    private:
-        void PerformDescriptorOperation();
 
     private:
         struct DiscoveredService
@@ -107,15 +102,9 @@ namespace services
             const infra::Function<void(OperationStatus)> onDone;
         };
 
-        struct DescriptorOperation
-        {
-            const infra::Function<void(OperationStatus)> onDone;
-            infra::Function<void(const infra::Function<void(OperationStatus)>&)> operation;
-        };
-
         struct CharacteristicOperation
         {
-            using Operation = std::variant<ReadOperation, WriteOperation, DescriptorOperation>;
+            using Operation = std::variant<ReadOperation, WriteOperation>;
 
             CharacteristicOperation(Operation operation, AttAttribute::Handle handle)
                 : operation(operation)

--- a/services/ble/Gatt.hpp
+++ b/services/ble/Gatt.hpp
@@ -42,6 +42,8 @@ namespace services
 
     namespace uuid
     {
+        // Bluetooth SIG adopted GATT UUIDs for the Device Information Service and its characteristics.
+        // Source: Bluetooth SIG Assigned Numbers: https://www.bluetooth.com/specifications/assigned-numbers/
         constexpr inline AttAttribute::Uuid16 deviceInformationService{ 0x180A };
         constexpr inline AttAttribute::Uuid16 systemId{ 0x2A23 };
         constexpr inline AttAttribute::Uuid16 modelNumber{ 0x2A24 };

--- a/services/ble/Gatt.hpp
+++ b/services/ble/Gatt.hpp
@@ -14,7 +14,6 @@ namespace services
         struct ClientCharacteristicConfiguration
         {
             static constexpr uint8_t valueHandleOffset = 1;
-            static constexpr uint16_t attributeType = 0x2902;
 
             enum class CharacteristicValue : uint16_t
             {
@@ -44,7 +43,11 @@ namespace services
     {
         // Bluetooth SIG adopted GATT UUIDs for the Device Information Service and its characteristics.
         // Source: Bluetooth SIG Assigned Numbers: https://www.bluetooth.com/specifications/assigned-numbers/
+
+        // Services
         constexpr inline AttAttribute::Uuid16 deviceInformationService{ 0x180A };
+
+        // Characteristics
         constexpr inline AttAttribute::Uuid16 systemId{ 0x2A23 };
         constexpr inline AttAttribute::Uuid16 modelNumber{ 0x2A24 };
         constexpr inline AttAttribute::Uuid16 serialNumber{ 0x2A25 };
@@ -54,6 +57,9 @@ namespace services
         constexpr inline AttAttribute::Uuid16 manufacturerName{ 0x2A29 };
         constexpr inline AttAttribute::Uuid16 ieeeCertification{ 0x2A2A };
         constexpr inline AttAttribute::Uuid16 pnpId{ 0x2A50 };
+
+        // Descriptors
+        constexpr inline AttAttribute::Uuid16 clientCharacteristicConfiguration{ 0x2902 };
     }
 
     class GattCharacteristic

--- a/services/ble/Gatt.hpp
+++ b/services/ble/Gatt.hpp
@@ -15,7 +15,7 @@ namespace services
         {
             static constexpr uint8_t valueHandleOffset = 1;
 
-            enum class CharacteristicValue : uint16_t
+            enum class AttributeValue : uint16_t
             {
                 disable = 0x0000,
                 enableNotification = 0x0001,

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -119,22 +119,21 @@ service GattClient
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
 
     // Characteristic operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
-    // WriteWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
-    rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
+    // WriteCharacteristicWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
     rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
-    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; };
+    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
 }
 
 service GattClientResponse
 {
     option (service_id) = 135;
 
-    // Responses are not sent after connection loss, which is informed via the GAP service
+    // No responses are sent after a connection loss is reported by the GAP service
 
     rpc MtuSizeExchangeComplete(MtuSize) returns (Nothing) { option (method_id) = 1; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -113,7 +113,7 @@ service GattClient
     // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
     // Discovers all descriptors within the given handle range of a characteristic.
-    // The handle range spans from the characteristic's handle + 1 to the next characteristic's handle - 1
+    // The handle range spans from the characteristic's value handle + 1 to the next characteristic's handle - 1
     // (or the service's end handle for the last characteristic in a service).
     // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -63,7 +63,7 @@ message Characteristic
 }
 
 message Descriptr
-//'Descriptor' keyword is not allowed by Echo code generator 
+//'Descriptor' keyword is not allowed by Echo code generator
 {
     bytes uuid = 1 [(bytes_size) = 16];
     Handle handle = 2;
@@ -92,12 +92,24 @@ service GattClient
 
     rpc MtuSizeExchangeRequest(Nothing) returns (Nothing) { option (method_id) = 1; }
 
-    // In the below block, all methods shall be called after the previous one is completed
+    // Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
+    // Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
+    //
+    // Discovers all services on the remote device.
+    // Responses: zero or more ServiceDiscovered, followed by ServiceDiscoveryComplete.
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
+    // Discovers all characteristics within a single service's handle range.
+    // Must be called once per discovered service, sequentially, after ServiceDiscoveryComplete.
+    // Responses: zero or more CharacteristicDiscovered, followed by CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
+    // Discovers all descriptors within the given handle range of a characteristic.
+    // The handle range spans from the characteristic's handle + 1 to the next characteristic's handle - 1
+    // (or the service's end handle for the last characteristic in a service).
+    // Responses: zero or more DescriptorDiscovered, followed by DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 6; }
 
-    // In the below block, the methods with a response, shall be called after the previous one is completed
+    // Characteristic operations are sequential; wait for CharacteristicOperationComplete before issuing the next.
+    // WriteWithoutResponse is fire-and-forget and does not trigger CharacteristicOperationComplete.
     // Example 1: If Read is called, EnableIndication shall only be called after CharacteristicOperationComplete
     // Example 2: If DisableNotification is called, Write shall only be called after CharacteristicOperationComplete
     // Example 3: If EnableNotification is called, EnableIndication shall only be called after CharacteristicOperationComplete
@@ -109,7 +121,7 @@ service GattClient
     rpc EnableIndication(Handle) returns (Nothing) { option (method_id) = 13; };
     rpc DisableIndication(Handle) returns (Nothing) { option (method_id) = 14; };
 
-    // IndicationDone shall be called for every IndicationReceived
+    // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 15; };
 }
 
@@ -121,7 +133,7 @@ service GattClientResponse
 
     rpc ServiceDiscovered(Service) returns (Nothing) { option (method_id) = 2; }
     rpc ServiceDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 3; }
-    
+
     rpc CharacteristicDiscovered(Characteristic) returns (Nothing) { option (method_id) = 4; }
     rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -86,6 +86,13 @@ message OperationResult
     OperationStatus value = 1;
 }
 
+enum CccdSetting
+{
+    none = 0;
+    notificationEnabled = 1;
+    indicationEnabled = 2;
+}
+
 service GattClient
 {
     option (service_id) = 134;
@@ -118,10 +125,8 @@ service GattClient
     rpc Read(Handle) returns (Nothing) { option (method_id) = 8; }
     rpc Write(AttributeData) returns (Nothing) { option (method_id) = 9; }
     rpc WriteWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }
-    rpc EnableNotification(Handle) returns (Nothing) { option (method_id) = 11; };
-    rpc DisableNotification(Handle) returns (Nothing) { option (method_id) = 12; };
-    rpc EnableIndication(Handle) returns (Nothing) { option (method_id) = 13; };
-    rpc DisableIndication(Handle) returns (Nothing) { option (method_id) = 14; };
+    rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 16; }
+    rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 17; }
 
     // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 15; };
@@ -146,8 +151,8 @@ service GattClientResponse
 
     rpc ReadResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
 
-    // Called after completion of characteristic operations with response: Read, Write, Enable/Disable Notification/Indication
-    rpc CharacteristicOperationComplete(OperationResult) returns (Nothing) { option (method_id) = 9; }
+    // Called after completion of characteristic operations with response: Read, Write, ReadDescriptor, WriteDescriptor
+    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 9; }
 
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 10; }
     rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -86,6 +86,7 @@ message OperationResult
     OperationStatus value = 1;
 }
 
+// CCCD (Client Characteristic Configuration Descriptor) bit field values for use with WriteDescriptor
 enum CccdSetting
 {
     none = 0;
@@ -122,9 +123,9 @@ service GattClient
     // Example 1: If Read is called, EnableIndication shall only be called after CharacteristicOperationComplete
     // Example 2: If DisableNotification is called, Write shall only be called after CharacteristicOperationComplete
     // Example 3: If EnableNotification is called, EnableIndication shall only be called after CharacteristicOperationComplete
-    rpc Read(Handle) returns (Nothing) { option (method_id) = 8; }
-    rpc Write(AttributeData) returns (Nothing) { option (method_id) = 9; }
-    rpc WriteWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }
+    rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 8; }
+    rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 9; }
+    rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }
     rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 16; }
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 17; }
 
@@ -136,7 +137,7 @@ service GattClientResponse
 {
     option (service_id) = 135;
 
-    // Responses are not sent after connection loss
+    // Responses are not sent after connection loss, which is informed via the GAP service
 
     rpc MtuSizeExchangeComplete(MtuSize) returns (Nothing) { option (method_id) = 1; }
 
@@ -149,9 +150,10 @@ service GattClientResponse
     rpc DescriptorDiscovered(Descriptr) returns (Nothing) { option (method_id) = 6; }
     rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
-    rpc ReadResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
+    rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
+    rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 12; }
 
-    // Called after completion of characteristic operations with response: Read, Write, ReadDescriptor, WriteDescriptor
+    // Called after completion of operations with response: ReadCharacteristic, WriteCharacteristic, ReadDescriptor, WriteDescriptor
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 9; }
 
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 10; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -111,23 +111,23 @@ service GattClient
     // Discovers all characteristics within a single service's handle range.
     // Must be called once per discovered service, sequentially, after GattClientResponse.ServiceDiscoveryComplete.
     // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
-    rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
+    rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
     // Discovers all descriptors within the given handle range of a characteristic.
     // The handle range spans from the characteristic's handle + 1 to the next characteristic's handle - 1
     // (or the service's end handle for the last characteristic in a service).
     // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
-    rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 6; }
+    rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
 
     // Characteristic operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
     // WriteWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
-    rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 8; }
-    rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 9; }
-    rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }
-    rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 16; }
-    rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 17; }
+    rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
+    rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
+    rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
+    rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
+    rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
-    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 15; };
+    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; };
 }
 
 service GattClientResponse
@@ -148,12 +148,12 @@ service GattClientResponse
     rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
-    rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 12; }
+    rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
     // Called after completion of operations with response: ReadCharacteristic, WriteCharacteristic, ReadDescriptor, WriteDescriptor
-    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 9; }
+    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
-    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 10; }
-    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
+    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
+    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
 }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -99,30 +99,27 @@ service GattClient
     option (service_id) = 134;
 
     // Requests the MTU size to be increased from the default, for better throughput.
-    // The effective MTU size is implementation defined, and is returned in the MtuSizeExchangeComplete response.
+    // The effective MTU size is implementation defined, and is returned in the GattClientResponse.MtuSizeExchangeComplete response.
     rpc MtuSizeExchangeRequest(Nothing) returns (Nothing) { option (method_id) = 1; }
 
     // Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
     // Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
     //
     // Discovers all services on the remote device.
-    // Responses: zero or more ServiceDiscovered, followed by ServiceDiscoveryComplete.
+    // Responses: zero or more GattClientResponse.ServiceDiscovered, followed by GattClientResponse.ServiceDiscoveryComplete.
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
     // Discovers all characteristics within a single service's handle range.
-    // Must be called once per discovered service, sequentially, after ServiceDiscoveryComplete.
-    // Responses: zero or more CharacteristicDiscovered, followed by CharacteristicDiscoveryComplete.
+    // Must be called once per discovered service, sequentially, after GattClientResponse.ServiceDiscoveryComplete.
+    // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
     // Discovers all descriptors within the given handle range of a characteristic.
     // The handle range spans from the characteristic's handle + 1 to the next characteristic's handle - 1
     // (or the service's end handle for the last characteristic in a service).
-    // Responses: zero or more DescriptorDiscovered, followed by DescriptorDiscoveryComplete.
+    // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 6; }
 
-    // Characteristic operations are sequential; wait for OperationComplete before issuing the next.
-    // WriteWithoutResponse is fire-and-forget and does not trigger OperationComplete.
-    // Example 1: If Read is called, EnableIndication shall only be called after OperationComplete
-    // Example 2: If DisableNotification is called, Write shall only be called after OperationComplete
-    // Example 3: If EnableNotification is called, EnableIndication shall only be called after OperationComplete
+    // Characteristic operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
+    // WriteWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 8; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 9; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -36,7 +36,7 @@ message Handle
     uint32 value = 1;
 }
 
-message CharacteristicData
+message AttributeData
 {
     Handle handle = 1;
     bytes data = 2 [(bytes_size) = 512];
@@ -71,7 +71,7 @@ message Descriptr
 
 message ReadResult
 {
-    CharacteristicData data = 1;
+    AttributeData data = 1;
 }
 
 enum OperationStatus
@@ -90,6 +90,8 @@ service GattClient
 {
     option (service_id) = 134;
 
+    // Requests the MTU size to be increased from the default, for better throughput.
+    // The effective MTU size is implementation defined, and is returned in the MtuSizeExchangeComplete response.
     rpc MtuSizeExchangeRequest(Nothing) returns (Nothing) { option (method_id) = 1; }
 
     // Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
@@ -114,8 +116,8 @@ service GattClient
     // Example 2: If DisableNotification is called, Write shall only be called after CharacteristicOperationComplete
     // Example 3: If EnableNotification is called, EnableIndication shall only be called after CharacteristicOperationComplete
     rpc Read(Handle) returns (Nothing) { option (method_id) = 8; }
-    rpc Write(CharacteristicData) returns (Nothing) { option (method_id) = 9; }
-    rpc WriteWithoutResponse(CharacteristicData) returns (Nothing) { option (method_id) = 10; }
+    rpc Write(AttributeData) returns (Nothing) { option (method_id) = 9; }
+    rpc WriteWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }
     rpc EnableNotification(Handle) returns (Nothing) { option (method_id) = 11; };
     rpc DisableNotification(Handle) returns (Nothing) { option (method_id) = 12; };
     rpc EnableIndication(Handle) returns (Nothing) { option (method_id) = 13; };
@@ -128,6 +130,8 @@ service GattClient
 service GattClientResponse
 {
     option (service_id) = 135;
+
+    // Responses are not sent after connection loss
 
     rpc MtuSizeExchangeComplete(MtuSize) returns (Nothing) { option (method_id) = 1; }
 
@@ -145,7 +149,7 @@ service GattClientResponse
     // Called after completion of characteristic operations with response: Read, Write, Enable/Disable Notification/Indication
     rpc CharacteristicOperationComplete(OperationResult) returns (Nothing) { option (method_id) = 9; }
 
-    rpc IndicationReceived(CharacteristicData) returns (Nothing) { option (method_id) = 10; }
-    rpc NotificationReceived(CharacteristicData) returns (Nothing) { option (method_id) = 11; }
+    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 10; }
+    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
 }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -118,8 +118,9 @@ service GattClient
     // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
 
-    // Characteristic operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
+    // Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
     // WriteCharacteristicWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
+    rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
     rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -118,11 +118,11 @@ service GattClient
     // Responses: zero or more DescriptorDiscovered, followed by DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 6; }
 
-    // Characteristic operations are sequential; wait for CharacteristicOperationComplete before issuing the next.
-    // WriteWithoutResponse is fire-and-forget and does not trigger CharacteristicOperationComplete.
-    // Example 1: If Read is called, EnableIndication shall only be called after CharacteristicOperationComplete
-    // Example 2: If DisableNotification is called, Write shall only be called after CharacteristicOperationComplete
-    // Example 3: If EnableNotification is called, EnableIndication shall only be called after CharacteristicOperationComplete
+    // Characteristic operations are sequential; wait for OperationComplete before issuing the next.
+    // WriteWithoutResponse is fire-and-forget and does not trigger OperationComplete.
+    // Example 1: If Read is called, EnableIndication shall only be called after OperationComplete
+    // Example 2: If DisableNotification is called, Write shall only be called after OperationComplete
+    // Example 3: If EnableNotification is called, EnableIndication shall only be called after OperationComplete
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 8; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 9; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 10; }

--- a/services/ble/GattClient.cpp
+++ b/services/ble/GattClient.cpp
@@ -35,32 +35,18 @@ namespace services
         operations->WriteWithoutResponse(valueHandle, data, onDone);
     }
 
-    void GattClientCharacteristic::EnableNotification(const infra::Function<void(OperationStatus)>& onDone)
+    void GattClientCharacteristic::ReadDescriptor(AttAttribute::Handle descriptorHandle, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone)
     {
         really_assert(operations != nullptr);
 
-        operations->EnableNotification(valueHandle, onDone);
+        operations->ReadDescriptor(descriptorHandle, onResponse, onDone);
     }
 
-    void GattClientCharacteristic::DisableNotification(const infra::Function<void(OperationStatus)>& onDone)
+    void GattClientCharacteristic::WriteDescriptor(AttAttribute::Handle descriptorHandle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
         really_assert(operations != nullptr);
 
-        operations->DisableNotification(valueHandle, onDone);
-    }
-
-    void GattClientCharacteristic::EnableIndication(const infra::Function<void(OperationStatus)>& onDone)
-    {
-        really_assert(operations != nullptr);
-
-        operations->EnableIndication(valueHandle, onDone);
-    }
-
-    void GattClientCharacteristic::DisableIndication(const infra::Function<void(OperationStatus)>& onDone)
-    {
-        really_assert(operations != nullptr);
-
-        operations->DisableIndication(valueHandle, onDone);
+        operations->WriteDescriptor(descriptorHandle, data, onDone);
     }
 
     void GattClientCharacteristic::NotificationReceived(AttAttribute::Handle handle, infra::ConstByteRange data)

--- a/services/ble/GattClient.cpp
+++ b/services/ble/GattClient.cpp
@@ -14,25 +14,25 @@ namespace services
         : GattCharacteristic(type, handle, valueHandle, properties)
     {}
 
-    void GattClientCharacteristic::Read(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone)
+    void GattClientCharacteristic::ReadCharacteristic(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone)
     {
         really_assert(operations != nullptr);
 
-        operations->Read(valueHandle, onResponse, onDone);
+        operations->ReadCharacteristic(valueHandle, onResponse, onDone);
     }
 
-    void GattClientCharacteristic::Write(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void GattClientCharacteristic::WriteCharacteristic(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
         really_assert(operations != nullptr);
 
-        operations->Write(valueHandle, data, onDone);
+        operations->WriteCharacteristic(valueHandle, data, onDone);
     }
 
-    void GattClientCharacteristic::WriteWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void GattClientCharacteristic::WriteCharacteristicWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
         really_assert(operations != nullptr);
 
-        operations->WriteWithoutResponse(valueHandle, data, onDone);
+        operations->WriteCharacteristicWithoutResponse(valueHandle, data, onDone);
     }
 
     void GattClientCharacteristic::ReadDescriptor(AttAttribute::Handle descriptorHandle, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone)

--- a/services/ble/GattClient.hpp
+++ b/services/ble/GattClient.hpp
@@ -65,7 +65,6 @@ namespace services
         GattClientCharacteristic(AttAttribute::Uuid type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties);
         GattClientCharacteristic(GattClientCharacteristicOperations& operations, AttAttribute::Uuid type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties);
 
-        // Implementation of GattClientCharacteristicOperations
         virtual void ReadCharacteristic(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteCharacteristic(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteCharacteristicWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);

--- a/services/ble/GattClient.hpp
+++ b/services/ble/GattClient.hpp
@@ -48,9 +48,9 @@ namespace services
         : public infra::Subject<GattClientStackUpdateObserver>
     {
     public:
-        virtual void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
     };
@@ -66,9 +66,9 @@ namespace services
         GattClientCharacteristic(GattClientCharacteristicOperations& operations, AttAttribute::Uuid type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties);
 
         // Implementation of GattClientCharacteristicOperations
-        virtual void Read(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
-        virtual void Write(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
-        virtual void WriteWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
+        virtual void ReadCharacteristic(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
+        virtual void WriteCharacteristic(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
+        virtual void WriteCharacteristicWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
         virtual void ReadDescriptor(AttAttribute::Handle descriptorHandle, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteDescriptor(AttAttribute::Handle descriptorHandle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
 
@@ -157,9 +157,9 @@ namespace services
         virtual void StartCharacteristicDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle) = 0;
         virtual void StartDescriptorDiscovery(AttAttribute::Handle handle, AttAttribute::Handle endHandle) = 0;
 
-        virtual void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
 

--- a/services/ble/GattClient.hpp
+++ b/services/ble/GattClient.hpp
@@ -52,10 +52,8 @@ namespace services
         virtual void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
 
-        virtual void EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
     };
 
     class GattClientCharacteristic
@@ -72,10 +70,8 @@ namespace services
         virtual void Write(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
 
-        virtual void EnableNotification(const infra::Function<void(OperationStatus)>& onDone);
-        virtual void DisableNotification(const infra::Function<void(OperationStatus)>& onDone);
-        virtual void EnableIndication(const infra::Function<void(OperationStatus)>& onDone);
-        virtual void DisableIndication(const infra::Function<void(OperationStatus)>& onDone);
+        virtual void ReadDescriptor(AttAttribute::Handle descriptorHandle, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
+        virtual void WriteDescriptor(AttAttribute::Handle descriptorHandle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
 
         GattCharacteristic::PropertyFlags CharacteristicProperties() const;
         AttAttribute::Handle CharacteristicValueHandle() const;
@@ -165,10 +161,8 @@ namespace services
         virtual void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
-        virtual void DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
+        virtual void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
 
         virtual void MtuExchange(const infra::Function<void(OperationStatus)>& onDone) = 0;
     };

--- a/services/ble/GattClient.hpp
+++ b/services/ble/GattClient.hpp
@@ -51,7 +51,6 @@ namespace services
         virtual void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
-
         virtual void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) = 0;
         virtual void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) = 0;
     };
@@ -66,10 +65,10 @@ namespace services
         GattClientCharacteristic(AttAttribute::Uuid type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties);
         GattClientCharacteristic(GattClientCharacteristicOperations& operations, AttAttribute::Uuid type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties);
 
+        // Implementation of GattClientCharacteristicOperations
         virtual void Read(const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
         virtual void Write(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteWithoutResponse(infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
-
         virtual void ReadDescriptor(AttAttribute::Handle descriptorHandle, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(OperationStatus)>& onDone);
         virtual void WriteDescriptor(AttAttribute::Handle descriptorHandle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone);
 

--- a/services/ble/RetryGattClientCharacteristicsOperations.cpp
+++ b/services/ble/RetryGattClientCharacteristicsOperations.cpp
@@ -8,20 +8,20 @@ namespace services
         , gattClient(gattClient)
     {}
 
-    void RetryGattClientCharacteristicsOperations::Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
+    void RetryGattClientCharacteristicsOperations::ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
     {
-        gattClient.Read(handle, onRead, onDone);
+        gattClient.ReadCharacteristic(handle, onRead, onDone);
     }
 
-    void RetryGattClientCharacteristicsOperations::Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void RetryGattClientCharacteristicsOperations::WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
-        gattClient.Write(handle, data, onDone);
+        gattClient.WriteCharacteristic(handle, data, onDone);
     }
 
-    void RetryGattClientCharacteristicsOperations::WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
+    void RetryGattClientCharacteristicsOperations::WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
         operationWriteWithoutResponse.emplace(Operation{ handle, data, onDone });
-        TryWriteWithoutResponse();
+        TryWriteCharacteristicWithoutResponse();
     }
 
     void RetryGattClientCharacteristicsOperations::ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
@@ -51,15 +51,15 @@ namespace services
             });
     }
 
-    void RetryGattClientCharacteristicsOperations::TryWriteWithoutResponse()
+    void RetryGattClientCharacteristicsOperations::TryWriteCharacteristicWithoutResponse()
     {
-        gattClient.WriteWithoutResponse(operationWriteWithoutResponse->handle, operationWriteWithoutResponse->data, [this](OperationStatus result)
+        gattClient.WriteCharacteristicWithoutResponse(operationWriteWithoutResponse->handle, operationWriteWithoutResponse->data, [this](OperationStatus result)
             {
                 if (result == OperationStatus::retry)
                 {
                     infra::EventDispatcher::Instance().Schedule([this]()
                         {
-                            TryWriteWithoutResponse();
+                            TryWriteCharacteristicWithoutResponse();
                         });
                 }
                 else

--- a/services/ble/RetryGattClientCharacteristicsOperations.cpp
+++ b/services/ble/RetryGattClientCharacteristicsOperations.cpp
@@ -24,24 +24,14 @@ namespace services
         TryWriteWithoutResponse();
     }
 
-    void RetryGattClientCharacteristicsOperations::EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
+    void RetryGattClientCharacteristicsOperations::ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone)
     {
-        gattClient.EnableNotification(handle, onDone);
+        gattClient.ReadDescriptor(handle, onRead, onDone);
     }
 
-    void RetryGattClientCharacteristicsOperations::DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
+    void RetryGattClientCharacteristicsOperations::WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone)
     {
-        gattClient.DisableNotification(handle, onDone);
-    }
-
-    void RetryGattClientCharacteristicsOperations::EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
-    {
-        gattClient.EnableIndication(handle, onDone);
-    }
-
-    void RetryGattClientCharacteristicsOperations::DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone)
-    {
-        gattClient.DisableIndication(handle, onDone);
+        gattClient.WriteDescriptor(handle, data, onDone);
     }
 
     void RetryGattClientCharacteristicsOperations::NotificationReceived(AttAttribute::Handle handle, infra::ConstByteRange data)

--- a/services/ble/RetryGattClientCharacteristicsOperations.hpp
+++ b/services/ble/RetryGattClientCharacteristicsOperations.hpp
@@ -18,11 +18,8 @@ namespace services
         void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
         void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
 
-        void EnableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-        void DisableNotification(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-
-        void EnableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
-        void DisableIndication(AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone) override;
+        void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
 
         // Implementation of GattClientStackUpdateObserver
         void NotificationReceived(AttAttribute::Handle handle, infra::ConstByteRange data) override;

--- a/services/ble/RetryGattClientCharacteristicsOperations.hpp
+++ b/services/ble/RetryGattClientCharacteristicsOperations.hpp
@@ -14,10 +14,9 @@ namespace services
         explicit RetryGattClientCharacteristicsOperations(GattClientCharacteristicOperations& gattClient);
 
         // Implementation of GattClientCharacteristicOperations
-        void Read(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
-        void Write(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
-        void WriteWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
-
+        void ReadCharacteristic(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteCharacteristic(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
+        void WriteCharacteristicWithoutResponse(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
         void ReadDescriptor(AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone) override;
         void WriteDescriptor(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone) override;
 
@@ -26,7 +25,7 @@ namespace services
         void IndicationReceived(AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void()>& onDone) override;
 
     private:
-        void TryWriteWithoutResponse();
+        void TryWriteCharacteristicWithoutResponse();
 
     private:
         struct Operation

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -262,63 +262,38 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_without_response_c
     ExecuteAllActions();
 }
 
-TEST_P(ClaimingGattClientAdapterStatusTest, should_call_enable_notification_characteristic)
+TEST_P(ClaimingGattClientAdapterStatusTest, should_call_read_descriptor)
 {
-    EXPECT_CALL(gattClient, EnableNotification(handle, testing::_))
-        .WillOnce([](services::AttAttribute::Handle passedHandle,
+    const infra::ConstByteRange readResult = infra::MakeRange(std::array<uint8_t, 2>{ 0x01, 0x00 });
+    infra::VerifyingFunction<void(const infra::ConstByteRange&)> onRead{ readResult };
+    infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
+
+    EXPECT_CALL(gattClient, ReadDescriptor(handle, testing::_, testing::_))
+        .WillOnce([&readResult](services::AttAttribute::Handle passedHandle,
+                      infra::Function<void(const infra::ConstByteRange&)> onRead,
                       infra::Function<void(services::OperationStatus)> onDone)
             {
                 EXPECT_EQ(passedHandle, handle);
+                onRead(readResult);
                 onDone(GetParam());
             });
 
-    infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
-    adapter.EnableNotification(handle, verifyOnDone);
+    adapter.ReadDescriptor(handle, onRead, verifyOnDone);
     ExecuteAllActions();
 }
 
-TEST_P(ClaimingGattClientAdapterStatusTest, should_call_disable_notification_characteristic)
+TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_descriptor)
 {
-    EXPECT_CALL(gattClient, DisableNotification(handle, testing::_))
-        .WillOnce([](services::AttAttribute::Handle passedHandle,
-                      infra::Function<void(services::OperationStatus)> onDone)
-            {
-                EXPECT_EQ(passedHandle, handle);
-                onDone(GetParam());
-            });
+    infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 2>{ 0x01, 0x00 });
+
+    EXPECT_CALL(gattClient, WriteDescriptor(handle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([data](services::AttAttribute::Handle passedHandle, infra::ConstByteRange writeData, const infra::Function<void(services::OperationStatus)>& onWriteDone)
+        {
+            EXPECT_EQ(passedHandle, handle);
+            onWriteDone(GetParam());
+        });
 
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
-    adapter.DisableNotification(handle, verifyOnDone);
-    ExecuteAllActions();
-}
-
-TEST_P(ClaimingGattClientAdapterStatusTest, should_call_enable_indication_characteristic)
-{
-    EXPECT_CALL(gattClient, EnableIndication(handle, testing::_))
-        .WillOnce([](services::AttAttribute::Handle passedHandle,
-                      infra::Function<void(services::OperationStatus)> onDone)
-            {
-                EXPECT_EQ(passedHandle, handle);
-                onDone(GetParam());
-            });
-
-    infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
-    adapter.EnableIndication(handle, verifyOnDone);
-    ExecuteAllActions();
-}
-
-TEST_P(ClaimingGattClientAdapterStatusTest, should_call_disable_indication_characteristic)
-{
-    EXPECT_CALL(gattClient, DisableIndication(handle, testing::_))
-        .WillOnce([](services::AttAttribute::Handle passedHandle,
-                      infra::Function<void(services::OperationStatus)> onDone)
-            {
-                EXPECT_EQ(passedHandle, handle);
-                onDone(GetParam());
-            });
-
-    infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
-    adapter.DisableIndication(handle, verifyOnDone);
+    adapter.WriteDescriptor(handle, data, verifyOnDone);
     ExecuteAllActions();
 }
 
@@ -328,8 +303,9 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_block_discovery_while_charact
     adapter.StartCharacteristicDiscovery(handle, endHandle);
     ExecuteAllActions();
 
+    infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 2>{ 0x00, 0x00 });
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
-    adapter.DisableIndication(handle, verifyOnDone);
+    adapter.WriteDescriptor(handle, data, verifyOnDone);
     ExecuteAllActions();
 
     EXPECT_CALL(discoveryObserver, CharacteristicDiscoveryComplete(GetParam()));
@@ -338,9 +314,10 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_block_discovery_while_charact
             observer.CharacteristicDiscoveryComplete(GetParam());
         });
 
-    EXPECT_CALL(gattClient, DisableIndication(handle, testing::_))
-        .WillOnce([](services::AttAttribute::Handle passedHandle,
-                      infra::Function<void(services::OperationStatus)> onDone)
+    EXPECT_CALL(gattClient, WriteDescriptor(handle, infra::ByteRangeContentsEqual(data), testing::_))
+        .WillOnce([data](services::AttAttribute::Handle passedHandle,
+                      infra::ConstByteRange writeData,
+                      const infra::Function<void(services::OperationStatus)>& onDone)
             {
                 EXPECT_EQ(passedHandle, handle);
                 onDone(GetParam());

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -264,7 +264,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_without_response_c
 
 TEST_P(ClaimingGattClientAdapterStatusTest, should_call_read_descriptor)
 {
-    const infra::ConstByteRange readResult = infra::MakeRange(std::array<uint8_t, 2>{ 0x01, 0x00 });
+    const auto readResult = infra::MakeStringByteRange("Ambition is a poor excuse for not having enough sense to be lazy");
     infra::VerifyingFunction<void(const infra::ConstByteRange&)> onRead{ readResult };
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
 
@@ -284,7 +284,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_read_descriptor)
 
 TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_descriptor)
 {
-    infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 2>{ 0x01, 0x00 });
+    const auto data = infra::MakeStringByteRange("The early bird gets the worm, but the second mouse gets the cheese");
 
     EXPECT_CALL(gattClient, WriteDescriptor(handle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([data](services::AttAttribute::Handle passedHandle, infra::ConstByteRange writeData, const infra::Function<void(services::OperationStatus)>& onWriteDone)
         {
@@ -303,7 +303,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_block_discovery_while_charact
     adapter.StartCharacteristicDiscovery(handle, endHandle);
     ExecuteAllActions();
 
-    infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 2>{ 0x00, 0x00 });
+    const auto data = infra::MakeStringByteRange("Everywhere is within walking distance if you have the time");
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
     adapter.WriteDescriptor(handle, data, verifyOnDone);
     ExecuteAllActions();

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -143,16 +143,16 @@ TEST_F(ClaimingGattClientAdapterTest, can_write_without_response_while_awaiting_
     infra::Function<void(services::OperationStatus)> onDone;
     infra::VerifyingFunction<void(const infra::ConstByteRange&)> verifyOnRead{ readResult };
 
-    EXPECT_CALL(gattClient, Read(handle, testing::_, testing::_))
+    EXPECT_CALL(gattClient, ReadCharacteristic(handle, testing::_, testing::_))
         .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&onRead), ::testing::SaveArg<2>(&onDone)));
-    EXPECT_CALL(gattClient, WriteWithoutResponse(handleWrite, testing::_, testing::_)).WillOnce(::testing::InvokeArgument<2>(services::OperationStatus::success));
+    EXPECT_CALL(gattClient, WriteCharacteristicWithoutResponse(handleWrite, testing::_, testing::_)).WillOnce(::testing::InvokeArgument<2>(services::OperationStatus::success));
 
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ operationStatusOk };
-    adapter.Read(handle, verifyOnRead, verifyOnDone);
+    adapter.ReadCharacteristic(handle, verifyOnRead, verifyOnDone);
 
     ExecuteAllActions();
 
-    adapter.WriteWithoutResponse(handleWrite, infra::MakeRange(std::array<uint8_t, 1>({ 42 })), infra::MockFunction<void(services::OperationStatus)>(services::OperationStatus::success));
+    adapter.WriteCharacteristicWithoutResponse(handleWrite, infra::MakeRange(std::array<uint8_t, 1>({ 42 })), infra::MockFunction<void(services::OperationStatus)>(services::OperationStatus::success));
 
     onRead(readResult);
     onDone(operationStatusOk);
@@ -214,7 +214,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_read_characteristic)
     infra::VerifyingFunction<void(const infra::ConstByteRange&)> onRead{ readResult };
     infra::VerifyingFunction<void(services::OperationStatus)> verifyOnDone{ GetParam() };
 
-    EXPECT_CALL(gattClient, Read(handle, testing::_, testing::_))
+    EXPECT_CALL(gattClient, ReadCharacteristic(handle, testing::_, testing::_))
         .WillOnce([&readResult](services::AttAttribute::Handle passedHandle,
                       infra::Function<void(const infra::ConstByteRange&)> onRead,
                       infra::Function<void(services::OperationStatus)> onDone)
@@ -225,7 +225,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_read_characteristic)
                 onDone(GetParam());
             });
 
-    adapter.Read(handle, onRead, verifyOnDone);
+    adapter.ReadCharacteristic(handle, onRead, verifyOnDone);
     ExecuteAllActions();
 }
 
@@ -233,14 +233,14 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_characteristic)
 {
     infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 4>{ 0x01, 0x02, 0x03, 0x04 });
 
-    EXPECT_CALL(gattClient, Write(handle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([data](services::AttAttribute::Handle passedHandle, infra::ConstByteRange writeData, const infra::Function<void(services::OperationStatus)>& onWriteDone)
+    EXPECT_CALL(gattClient, WriteCharacteristic(handle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([data](services::AttAttribute::Handle passedHandle, infra::ConstByteRange writeData, const infra::Function<void(services::OperationStatus)>& onWriteDone)
         {
             EXPECT_EQ(passedHandle, handle);
             onWriteDone(GetParam());
         });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ GetParam() };
-    adapter.Write(handle, data, onDone);
+    adapter.WriteCharacteristic(handle, data, onDone);
     ExecuteAllActions();
 }
 
@@ -248,7 +248,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_without_response_c
 {
     infra::ConstByteRange data = infra::MakeRange(std::array<uint8_t, 4>{ 0x01, 0x02, 0x03, 0x04 });
 
-    EXPECT_CALL(gattClient, WriteWithoutResponse(testing::_, infra::ByteRangeContentsEqual(data), testing::_))
+    EXPECT_CALL(gattClient, WriteCharacteristicWithoutResponse(testing::_, infra::ByteRangeContentsEqual(data), testing::_))
         .WillOnce([](services::AttAttribute::Handle passedHandle,
                       infra::ConstByteRange data,
                       const infra::Function<void(services::OperationStatus)>& onDone)
@@ -258,7 +258,7 @@ TEST_P(ClaimingGattClientAdapterStatusTest, should_call_write_without_response_c
             });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onWriteWithoutResponse{ GetParam() };
-    adapter.WriteWithoutResponse(handle, data, onWriteWithoutResponse);
+    adapter.WriteCharacteristicWithoutResponse(handle, data, onWriteWithoutResponse);
     ExecuteAllActions();
 }
 

--- a/services/ble/test/TestGattClient.cpp
+++ b/services/ble/test/TestGattClient.cpp
@@ -156,7 +156,7 @@ TEST_F(GattClientCharacteristicTest, should_read_characteristic_and_callback_wit
     const auto data = infra::MakeStringByteRange("string");
     infra::VerifyingFunction<void(const infra::ConstByteRange&)> onResponse{ data };
 
-    EXPECT_CALL(operations, Read(characteristicValueHandle, ::testing::_, testing::_))
+    EXPECT_CALL(operations, ReadCharacteristic(characteristicValueHandle, ::testing::_, testing::_))
         .WillOnce([&data](services::AttAttribute::Handle, infra::Function<void(const infra::ConstByteRange&)> onResponse, infra::Function<void(services::OperationStatus)> onDone)
             {
                 onResponse(data);
@@ -164,33 +164,33 @@ TEST_F(GattClientCharacteristicTest, should_read_characteristic_and_callback_wit
             });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.Read(onResponse, onDone);
+    characteristic.ReadCharacteristic(onResponse, onDone);
 }
 
 TEST_F(GattClientCharacteristicTest, should_write_characteristic_and_callback)
 {
     const auto data = infra::MakeStringByteRange("string");
 
-    EXPECT_CALL(operations, Write(characteristicValueHandle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([&data](services::AttAttribute::Handle, infra::ConstByteRange, infra::Function<void(services::OperationStatus)> onDone)
+    EXPECT_CALL(operations, WriteCharacteristic(characteristicValueHandle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([&data](services::AttAttribute::Handle, infra::ConstByteRange, infra::Function<void(services::OperationStatus)> onDone)
         {
             onDone(result);
         });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.Write(data, onDone);
+    characteristic.WriteCharacteristic(data, onDone);
 }
 
 TEST_F(GattClientCharacteristicTest, should_write_without_response_characteristic)
 {
     const auto data = infra::MakeStringByteRange("string");
 
-    EXPECT_CALL(operations, WriteWithoutResponse(characteristicValueHandle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([](services::AttAttribute::Handle handle, infra::ConstByteRange, infra::Function<void(services::OperationStatus)> onDone)
+    EXPECT_CALL(operations, WriteCharacteristicWithoutResponse(characteristicValueHandle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([](services::AttAttribute::Handle handle, infra::ConstByteRange, infra::Function<void(services::OperationStatus)> onDone)
         {
             onDone(result);
         });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.WriteWithoutResponse(data, onDone);
+    characteristic.WriteCharacteristicWithoutResponse(data, onDone);
 }
 
 TEST_F(GattClientCharacteristicTest, should_write_descriptor_and_callback)

--- a/services/ble/test/TestGattClient.cpp
+++ b/services/ble/test/TestGattClient.cpp
@@ -98,6 +98,7 @@ public:
 
     static constexpr services::AttAttribute::Handle characteristicHandle = 0x2;
     static constexpr services::AttAttribute::Handle characteristicValueHandle = 0x3;
+    static constexpr services::AttAttribute::Handle descriptorHandle = 0x4;
     static constexpr auto result = services::OperationStatus::success;
 
     testing::StrictMock<services::GattClientCharacteristicOperationsMock> operations;
@@ -192,46 +193,31 @@ TEST_F(GattClientCharacteristicTest, should_write_without_response_characteristi
     characteristic.WriteWithoutResponse(data, onDone);
 }
 
-TEST_F(GattClientCharacteristicTest, should_enable_notification_characteristic_and_callback)
+TEST_F(GattClientCharacteristicTest, should_write_descriptor_and_callback)
 {
-    EXPECT_CALL(operations, EnableNotification(characteristicValueHandle, ::testing::_)).WillOnce([](services::AttAttribute::Handle, infra::Function<void(services::OperationStatus)> onDone)
+    const auto data = infra::MakeStringByteRange("If you saw a heat wave, would you wave back?");
+
+    EXPECT_CALL(operations, WriteDescriptor(descriptorHandle, infra::ByteRangeContentsEqual(data), testing::_)).WillOnce([&data](services::AttAttribute::Handle, infra::ConstByteRange, infra::Function<void(services::OperationStatus)> onDone)
         {
             onDone(result);
         });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.EnableNotification(onDone);
+    characteristic.WriteDescriptor(descriptorHandle, data, onDone);
 }
 
-TEST_F(GattClientCharacteristicTest, should_disable_notification_characteristic_and_callback)
+TEST_F(GattClientCharacteristicTest, should_read_descriptor_and_callback_with_data_received)
 {
-    EXPECT_CALL(operations, DisableNotification(characteristicValueHandle, ::testing::_)).WillOnce([](services::AttAttribute::Handle, infra::Function<void(services::OperationStatus)> onDone)
-        {
-            onDone(result);
-        });
+    const auto data = infra::MakeStringByteRange("7 percent of all statistics are made up on the spot");
+    infra::VerifyingFunction<void(const infra::ConstByteRange&)> onResponse{ data };
+
+    EXPECT_CALL(operations, ReadDescriptor(descriptorHandle, ::testing::_, testing::_))
+        .WillOnce([&data](services::AttAttribute::Handle, infra::Function<void(const infra::ConstByteRange&)> onResponse, infra::Function<void(services::OperationStatus)> onDone)
+            {
+                onResponse(data);
+                onDone(result);
+            });
 
     infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.DisableNotification(onDone);
-}
-
-TEST_F(GattClientCharacteristicTest, should_enable_indication_characteristic_and_callback)
-{
-    EXPECT_CALL(operations, EnableIndication(characteristicValueHandle, ::testing::_)).WillOnce([](services::AttAttribute::Handle, infra::Function<void(services::OperationStatus)> onDone)
-        {
-            onDone(result);
-        });
-
-    infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.EnableIndication(onDone);
-}
-
-TEST_F(GattClientCharacteristicTest, should_disable_indication_characteristic_and_callback)
-{
-    EXPECT_CALL(operations, DisableIndication(characteristicValueHandle, ::testing::_)).WillOnce([](services::AttAttribute::Handle, infra::Function<void(services::OperationStatus)> onDone)
-        {
-            onDone(result);
-        });
-
-    infra::VerifyingFunction<void(services::OperationStatus)> onDone{ result };
-    characteristic.DisableIndication(onDone);
+    characteristic.ReadDescriptor(descriptorHandle, onResponse, onDone);
 }

--- a/services/ble/test/TestRetryGattClientAdapter.cpp
+++ b/services/ble/test/TestRetryGattClientAdapter.cpp
@@ -33,26 +33,26 @@ TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_read_characteri
 {
     infra::Function<void(const infra::ConstByteRange&)> onReadMock;
 
-    EXPECT_CALL(adapter, Read(handle, testing::Ref(onReadMock), testing::Ref(onDone)));
+    EXPECT_CALL(adapter, ReadCharacteristic(handle, testing::Ref(onReadMock), testing::Ref(onDone)));
 
-    retryAdapter.Read(handle, onReadMock, onDone);
+    retryAdapter.ReadCharacteristic(handle, onReadMock, onDone);
 }
 
 TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_characteristic)
 {
-    EXPECT_CALL(adapter, Write(handle, testing::ElementsAreArray(data), testing::Ref(onDone)));
+    EXPECT_CALL(adapter, WriteCharacteristic(handle, testing::ElementsAreArray(data), testing::Ref(onDone)));
 
-    retryAdapter.Write(handle, data, onDone);
+    retryAdapter.WriteCharacteristic(handle, data, onDone);
 }
 
 TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_without_response_characteristic_and_error)
 {
     infra::VerifyingFunction<void(services::OperationStatus)> errorCallback(services::OperationStatus::error);
 
-    EXPECT_CALL(adapter, WriteWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
+    EXPECT_CALL(adapter, WriteCharacteristicWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
         .WillOnce(testing::InvokeArgument<2>(services::OperationStatus::error));
 
-    retryAdapter.WriteWithoutResponse(handle, data, errorCallback);
+    retryAdapter.WriteCharacteristicWithoutResponse(handle, data, errorCallback);
 }
 
 TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_without_response_characteristic_with_retry)
@@ -60,12 +60,12 @@ TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_without_r
     testing::StrictMock<infra::MockCallback<void(services::OperationStatus)>> callback;
     infra::Function<void(services::OperationStatus)> onDone;
 
-    EXPECT_CALL(adapter, WriteWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
+    EXPECT_CALL(adapter, WriteCharacteristicWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
         .WillRepeatedly(testing::SaveArg<2>(&onDone));
 
     EXPECT_CALL(callback, callback(services::OperationStatus::success));
 
-    retryAdapter.WriteWithoutResponse(handle, data, [&callback](services::OperationStatus status)
+    retryAdapter.WriteCharacteristicWithoutResponse(handle, data, [&callback](services::OperationStatus status)
         {
             callback.callback(status);
         });
@@ -85,10 +85,10 @@ TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_without_r
     infra::Function<void(services::OperationStatus)> onDone;
 
     EXPECT_CALL(callback, callback(services::OperationStatus::error));
-    EXPECT_CALL(adapter, WriteWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
+    EXPECT_CALL(adapter, WriteCharacteristicWithoutResponse(handle, testing::ElementsAreArray(data), testing::_))
         .WillRepeatedly(testing::SaveArg<2>(&onDone));
 
-    retryAdapter.WriteWithoutResponse(handle, data, [&callback](services::OperationStatus status)
+    retryAdapter.WriteCharacteristicWithoutResponse(handle, data, [&callback](services::OperationStatus status)
         {
             callback.callback(status);
         });

--- a/services/ble/test/TestRetryGattClientAdapter.cpp
+++ b/services/ble/test/TestRetryGattClientAdapter.cpp
@@ -100,32 +100,19 @@ TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_without_r
     ExecuteAllActions();
 }
 
-TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_enable_notification_characteristic)
+TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_read_descriptor)
 {
-    EXPECT_CALL(adapter, EnableNotification(handle, testing::Ref(onDone)));
+    infra::Function<void(const infra::ConstByteRange&)> onRead;
+    EXPECT_CALL(adapter, ReadDescriptor(handle, testing::Ref(onRead), testing::Ref(onDone)));
 
-    retryAdapter.EnableNotification(handle, onDone);
+    retryAdapter.ReadDescriptor(handle, onRead, onDone);
 }
 
-TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_disable_notification_characteristic)
+TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_write_descriptor)
 {
-    EXPECT_CALL(adapter, DisableNotification(handle, testing::Ref(onDone)));
+    EXPECT_CALL(adapter, WriteDescriptor(handle, testing::ElementsAreArray(data), testing::Ref(onDone)));
 
-    retryAdapter.DisableNotification(handle, onDone);
-}
-
-TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_enable_indication_characteristic)
-{
-    EXPECT_CALL(adapter, EnableIndication(handle, testing::Ref(onDone)));
-
-    retryAdapter.EnableIndication(handle, onDone);
-}
-
-TEST_F(RetryGattClientCharacteristicsOperationsTest, should_call_disable_indication_characteristic)
-{
-    EXPECT_CALL(adapter, DisableIndication(handle, testing::Ref(onDone)));
-
-    retryAdapter.DisableIndication(handle, onDone);
+    retryAdapter.WriteDescriptor(handle, data, onDone);
 }
 
 TEST_F(RetryGattClientCharacteristicsOperationsTest, should_forward_notification_received)

--- a/services/ble/test_doubles/ClaimingGattClientAdapterMock.hpp
+++ b/services/ble/test_doubles/ClaimingGattClientAdapterMock.hpp
@@ -20,10 +20,8 @@ namespace services
         MOCK_METHOD(void, Read, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, Write, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, EnableNotification, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, DisableNotification, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, EnableIndication, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, DisableIndication, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, ServiceDiscovered, (const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));
         MOCK_METHOD(void, ServiceDiscoveryComplete, (OperationStatus), (override));
         MOCK_METHOD(void, CharacteristicDiscovered, (const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle valueHandle, GattCharacteristic::PropertyFlags properties), (override));

--- a/services/ble/test_doubles/ClaimingGattClientAdapterMock.hpp
+++ b/services/ble/test_doubles/ClaimingGattClientAdapterMock.hpp
@@ -17,9 +17,9 @@ namespace services
         MOCK_METHOD(void, StartServiceDiscovery, (), (override));
         MOCK_METHOD(void, StartCharacteristicDiscovery, (AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));
         MOCK_METHOD(void, StartDescriptorDiscovery, (AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));
-        MOCK_METHOD(void, Read, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, Write, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, ReadCharacteristic, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteCharacteristic, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteCharacteristicWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, ServiceDiscovered, (const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));

--- a/services/ble/test_doubles/GattClientMock.hpp
+++ b/services/ble/test_doubles/GattClientMock.hpp
@@ -31,9 +31,9 @@ namespace services
         : public GattClientCharacteristicOperations
     {
     public:
-        MOCK_METHOD(void, Read, (AttAttribute::Handle, const infra::Function<void(const infra::ConstByteRange&)>&, const infra::Function<void(OperationStatus)>&), (override));
-        MOCK_METHOD(void, Write, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
-        MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
+        MOCK_METHOD(void, ReadCharacteristic, (AttAttribute::Handle, const infra::Function<void(const infra::ConstByteRange&)>&, const infra::Function<void(OperationStatus)>&), (override));
+        MOCK_METHOD(void, WriteCharacteristic, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
+        MOCK_METHOD(void, WriteCharacteristicWithoutResponse, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
 
         MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle, const infra::Function<void(const infra::ConstByteRange&)>&, const infra::Function<void(OperationStatus)>&), (override));
         MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
@@ -87,9 +87,9 @@ namespace services
         MOCK_METHOD(void, StartCharacteristicDiscovery, (AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));
         MOCK_METHOD(void, StartDescriptorDiscovery, (AttAttribute::Handle handle, AttAttribute::Handle endHandle), (override));
 
-        MOCK_METHOD(void, Read, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, Write, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, ReadCharacteristic, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteCharacteristic, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteCharacteristicWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, MtuExchange, (const infra::Function<void(OperationStatus)>& onDone), (override));

--- a/services/ble/test_doubles/GattClientMock.hpp
+++ b/services/ble/test_doubles/GattClientMock.hpp
@@ -35,10 +35,8 @@ namespace services
         MOCK_METHOD(void, Write, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
         MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
 
-        MOCK_METHOD(void, EnableNotification, (AttAttribute::Handle, const infra::Function<void(OperationStatus)>&), (override));
-        MOCK_METHOD(void, DisableNotification, (AttAttribute::Handle, const infra::Function<void(OperationStatus)>&), (override));
-        MOCK_METHOD(void, EnableIndication, (AttAttribute::Handle, const infra::Function<void(OperationStatus)>&), (override));
-        MOCK_METHOD(void, DisableIndication, (AttAttribute::Handle, const infra::Function<void(OperationStatus)>&), (override));
+        MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle, const infra::Function<void(const infra::ConstByteRange&)>&, const infra::Function<void(OperationStatus)>&), (override));
+        MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle, infra::ConstByteRange, const infra::Function<void(OperationStatus)>&), (override));
     };
 
     class GattClientDiscoveryObserverMock
@@ -92,10 +90,8 @@ namespace services
         MOCK_METHOD(void, Read, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, Write, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, WriteWithoutResponse, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, EnableNotification, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, DisableNotification, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, EnableIndication, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
-        MOCK_METHOD(void, DisableIndication, (AttAttribute::Handle handle, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, ReadDescriptor, (AttAttribute::Handle handle, const infra::Function<void(const infra::ConstByteRange&)>& onRead, const infra::Function<void(OperationStatus)>& onDone), (override));
+        MOCK_METHOD(void, WriteDescriptor, (AttAttribute::Handle handle, infra::ConstByteRange data, const infra::Function<void(OperationStatus)>& onDone), (override));
         MOCK_METHOD(void, MtuExchange, (const infra::Function<void(OperationStatus)>& onDone), (override));
     };
 }


### PR DESCRIPTION
Consolidates the GattClient interface and adds a bit more functionality to it. These are breaking changes:
- Replaced `Enable/Disable Notification/Indication`. Replaced with `Read/Write Descriptor`
- Replaced `CharacteristicOperationComplete` with `OperationComplete`
- Renamed `CharacteristicData` to `AttributeData`
- Some method IDs changed.