### PR TITLE
feat: in EchoOnStreams request only as much as needed for the current packet

### DIFF
--- a/protobuf/echo/EchoOnStreams.cpp
+++ b/protobuf/echo/EchoOnStreams.cpp
@@ -33,7 +33,13 @@ namespace services
 
     void EchoOnStreams::Reset()
     {
+        countingSentWriter.OnAllocatable(infra::emptyFunction);
         ResetReading();
+        really_assert(countingSentWriter.Allocatable());
+        countingSentWriter.OnAllocatable([this]()
+            {
+                StreamWriterDone();
+            });
 
         while (!sendRequesters.empty())
             sendRequesters.front().CancelRequestSend();
@@ -139,10 +145,12 @@ namespace services
 
     void EchoOnStreams::TryGrantSend()
     {
-        if (!skipNextStream && countingSentWriter.Allocatable() && sendingProxy == nullptr && !sendRequesters.empty())
+        if (!skipNextStream && sendingProxy == nullptr && !sendRequesters.empty())
         {
             sendingProxy = &sendRequesters.front();
-            sendingProxySize = sendingProxy->CurrentRequestedSize() + 2 * infra::MaxVarIntSize(std::numeric_limits<uint64_t>::max());
+            sendingProxySize = sendingProxy->CurrentRequestedSize()                              // payload
+                               + 2 * infra::MaxVarIntSize(std::numeric_limits<uint64_t>::max()); // echo framing overhead (service and method id)
+
             sendRequesters.pop_front();
             RequestSendStream(sendingProxySize);
         }
@@ -173,6 +181,7 @@ namespace services
                 policy->GrantingSend(*sendingProxy);
             }
 
+            really_assert(countingSentWriter.Allocatable());
             auto countingSentWriterPtr = countingSentWriter.Emplace(std::move(writer), sendingProxySize);
             partlySent = methodSerializer->Serialize(infra::MakeContainedSharedObject(*countingSentWriterPtr->writer, countingSentWriterPtr));
         }

--- a/protobuf/echo/EchoOnStreams.cpp
+++ b/protobuf/echo/EchoOnStreams.cpp
@@ -142,8 +142,9 @@ namespace services
         if (!skipNextStream && sendingProxy == nullptr && !sendRequesters.empty())
         {
             sendingProxy = &sendRequesters.front();
+            sendingProxySize = sendingProxy->CurrentRequestedSize() + 2 * infra::MaxVarIntSize(std::numeric_limits<uint64_t>::max());
             sendRequesters.pop_front();
-            RequestSendStream(sendingProxy->CurrentRequestedSize() + 2 * infra::MaxVarIntSize(std::numeric_limits<uint64_t>::max()));
+            RequestSendStream(sendingProxySize);
         }
     }
 
@@ -172,10 +173,11 @@ namespace services
                 policy->GrantingSend(*sendingProxy);
             }
 
-            partlySent = methodSerializer->Serialize(std::move(writer));
+            auto countingSentWriterPtr = countingSentWriter.Emplace(std::move(writer), sendingProxySize);
+            partlySent = methodSerializer->Serialize(infra::MakeContainedSharedObject(*countingSentWriterPtr->writer, std::move(countingSentWriterPtr)));
 
             if (partlySent)
-                RequestSendStream(sendingProxy->CurrentRequestedSize());
+                RequestSendStream(sendingProxySize);
             else
             {
                 sendingProxy = nullptr;

--- a/protobuf/echo/EchoOnStreams.cpp
+++ b/protobuf/echo/EchoOnStreams.cpp
@@ -139,7 +139,7 @@ namespace services
 
     void EchoOnStreams::TryGrantSend()
     {
-        if (!skipNextStream && sendingProxy == nullptr && !sendRequesters.empty())
+        if (!skipNextStream && countingSentWriter.Allocatable() && sendingProxy == nullptr && !sendRequesters.empty())
         {
             sendingProxy = &sendRequesters.front();
             sendingProxySize = sendingProxy->CurrentRequestedSize() + 2 * infra::MaxVarIntSize(std::numeric_limits<uint64_t>::max());
@@ -174,16 +174,19 @@ namespace services
             }
 
             auto countingSentWriterPtr = countingSentWriter.Emplace(std::move(writer), sendingProxySize);
-            partlySent = methodSerializer->Serialize(infra::MakeContainedSharedObject(*countingSentWriterPtr->writer, std::move(countingSentWriterPtr)));
+            partlySent = methodSerializer->Serialize(infra::MakeContainedSharedObject(*countingSentWriterPtr->writer, countingSentWriterPtr));
+        }
+    }
 
-            if (partlySent)
-                RequestSendStream(sendingProxySize);
-            else
-            {
-                sendingProxy = nullptr;
-                methodSerializer = nullptr;
-                TryGrantSend();
-            }
+    void EchoOnStreams::StreamWriterDone()
+    {
+        if (partlySent)
+            RequestSendStream(sendingProxySize);
+        else
+        {
+            sendingProxy = nullptr;
+            methodSerializer = nullptr;
+            TryGrantSend();
         }
     }
 

--- a/protobuf/echo/EchoOnStreams.hpp
+++ b/protobuf/echo/EchoOnStreams.hpp
@@ -49,6 +49,7 @@ namespace services
     private:
         void TryGrantSend();
 
+        void StreamWriterDone();
         void DataReceivedInReader();
         void StartReceiveMessage();
         void ContinueReceiveMessage();
@@ -87,7 +88,10 @@ namespace services
         infra::IntrusiveList<ServiceProxy> sendRequesters;
         ServiceProxy* sendingProxy = nullptr;
         std::size_t sendingProxySize = 0;
-        infra::NotifyingSharedOptional<CountingSentWriter> countingSentWriter;
+        infra::NotifyingSharedOptional<CountingSentWriter> countingSentWriter{ [this]()
+            {
+                StreamWriterDone();
+            } };
         infra::SharedPtr<MethodSerializer> methodSerializer;
         bool partlySent = false;
         bool skipNextStream = false;

--- a/protobuf/echo/EchoOnStreams.hpp
+++ b/protobuf/echo/EchoOnStreams.hpp
@@ -56,6 +56,28 @@ namespace services
         void LimitedReaderDone();
 
     private:
+        struct CountingSentWriter
+        {
+            CountingSentWriter(infra::SharedPtr<infra::StreamWriter>&& writer, std::size_t& size)
+                : writer(std::move(writer))
+                , size(size)
+            {
+                size -= this->writer->Available();
+            }
+
+            CountingSentWriter(const CountingSentWriter& other) = delete;
+            CountingSentWriter& operator=(const CountingSentWriter& other) = delete;
+
+            ~CountingSentWriter()
+            {
+                size += writer->Available();
+            }
+
+            infra::SharedPtr<infra::StreamWriter> writer;
+            std::size_t& size;
+        };
+
+    private:
         static EchoPolicy defaultPolicy;
 
         services::MethodSerializerFactory& serializerFactory;
@@ -64,6 +86,8 @@ namespace services
 
         infra::IntrusiveList<ServiceProxy> sendRequesters;
         ServiceProxy* sendingProxy = nullptr;
+        std::size_t sendingProxySize = 0;
+        infra::NotifyingSharedOptional<CountingSentWriter> countingSentWriter;
         infra::SharedPtr<MethodSerializer> methodSerializer;
         bool partlySent = false;
         bool skipNextStream = false;

--- a/services/util/test/TestEchoOnSesame.cpp
+++ b/services/util/test/TestEchoOnSesame.cpp
@@ -67,14 +67,14 @@ TEST_F(EchoOnSesameTest, invoke_service_proxy_method_is_split_over_two_packets)
     EXPECT_CALL(sesame, ResetReading());
     sesame.GetObserver().Initialized();
 
-    EXPECT_CALL(sesame, MaxSendMessageSize()).WillRepeatedly(testing::Return(4));
+    EXPECT_CALL(sesame, MaxSendMessageSize()).WillOnce(testing::Return(4)).WillOnce(testing::Return(10000));
     EXPECT_CALL(sesame, RequestSendMessage(4));
     serviceProxy.RequestSend([this]()
         {
             serviceProxy.Method(5);
         });
 
-    EXPECT_CALL(sesame, RequestSendMessage(4));
+    EXPECT_CALL(sesame, RequestSendMessage(94));
     infra::ByteOutputStreamWriter::WithStorage<128> writer;
     infra::LimitedStreamWriter limitedWriter(writer, 4);
     sesame.GetObserver().SendMessageStreamAvailable(infra::UnOwnedSharedPtr(limitedWriter));


### PR DESCRIPTION
By requesting only enough for the current packet, the Sesame stack may send the packet earlier instead of waiting for the maximum size to be available