### PR TITLE
chore: even more flash echo hardening

### DIFF
--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -14,18 +14,18 @@ namespace services
     {
         onStopped = onDone;
 
-        if (!busy)
+        if (!busyWithFlash)
             onStopped();
     }
 
     void FlashEcho::Read(uint32_t address, uint32_t size)
     {
-        really_assert(!busy);
-        busy = true;
+        really_assert(!busyWithFlash);
+        busyWithFlash = true;
 
         flash.ReadBuffer(infra::Head(infra::MakeRange(buffer), size), address, [this, size]()
             {
-                busy = false;
+                busyWithFlash = false;
 
                 if (onStopped)
                     onStopped();
@@ -43,12 +43,12 @@ namespace services
 
     void FlashEcho::Write(uint32_t address, infra::ConstByteRange contents)
     {
-        really_assert(!busy);
-        busy = true;
+        really_assert(!busyWithFlash);
+        busyWithFlash = true;
 
         flash.WriteBuffer(contents, address, [this]()
             {
-                busy = false;
+                busyWithFlash = false;
 
                 if (onStopped)
                     onStopped();
@@ -66,12 +66,12 @@ namespace services
 
     void FlashEcho::EraseSectors(uint32_t sector, uint32_t numberOfSectors)
     {
-        really_assert(!busy);
-        busy = true;
+        really_assert(!busyWithFlash);
+        busyWithFlash = true;
 
         flash.EraseSectors(sector, sector + numberOfSectors, [this]()
             {
-                busy = false;
+                busyWithFlash = false;
                 if (onStopped)
                     onStopped();
                 else

--- a/services/util/FlashEcho.cpp
+++ b/services/util/FlashEcho.cpp
@@ -20,7 +20,7 @@ namespace services
 
     void FlashEcho::Read(uint32_t address, uint32_t size)
     {
-        really_assert(!busyWithFlash);
+        really_assert(!busyWithFlash && !busyWithResponse);
         busyWithFlash = true;
 
         flash.ReadBuffer(infra::Head(infra::MakeRange(buffer), size), address, [this, size]()
@@ -30,20 +30,25 @@ namespace services
                 if (onStopped)
                     onStopped();
                 else
+                {
+                    busyWithResponse = true;
                     flashResult.RequestSend([this, size]()
                         {
+                            busyWithResponse = false;
+
                             flashResult.ReadDone(infra::Head(infra::MakeRange(buffer), size));
                             MethodDone();
 
                             if (onStopped)
                                 onStopped();
                         });
+                }
             });
     }
 
     void FlashEcho::Write(uint32_t address, infra::ConstByteRange contents)
     {
-        really_assert(!busyWithFlash);
+        really_assert(!busyWithFlash && !busyWithResponse);
         busyWithFlash = true;
 
         flash.WriteBuffer(contents, address, [this]()
@@ -53,20 +58,24 @@ namespace services
                 if (onStopped)
                     onStopped();
                 else
+                {
+                    busyWithResponse = true;
                     flashResult.RequestSend([this]()
                         {
+                            busyWithResponse = false;
                             flashResult.WriteDone();
                             MethodDone();
 
                             if (onStopped)
                                 onStopped();
                         });
+                }
             });
     }
 
     void FlashEcho::EraseSectors(uint32_t sector, uint32_t numberOfSectors)
     {
-        really_assert(!busyWithFlash);
+        really_assert(!busyWithFlash && !busyWithResponse);
         busyWithFlash = true;
 
         flash.EraseSectors(sector, sector + numberOfSectors, [this]()
@@ -75,14 +84,18 @@ namespace services
                 if (onStopped)
                     onStopped();
                 else
+                {
+                    busyWithResponse = true;
                     flashResult.RequestSend([this]()
                         {
+                            busyWithResponse = false;
                             flashResult.EraseSectorsDone();
                             MethodDone();
 
                             if (onStopped)
                                 onStopped();
                         });
+                }
             });
     }
 

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -27,6 +27,7 @@ namespace services
         std::array<uint8_t, flash::WriteRequest::contentsSize> buffer;
 
         bool busyWithFlash = false;
+        bool busyWithResponse = false;
         infra::AutoResetFunction<void()> onStopped;
     };
 

--- a/services/util/FlashEcho.hpp
+++ b/services/util/FlashEcho.hpp
@@ -26,7 +26,7 @@ namespace services
 
         std::array<uint8_t, flash::WriteRequest::contentsSize> buffer;
 
-        bool busy = false;
+        bool busyWithFlash = false;
         infra::AutoResetFunction<void()> onStopped;
     };
 

--- a/services/util/test/TestFlashEcho.cpp
+++ b/services/util/test/TestFlashEcho.cpp
@@ -531,4 +531,26 @@ TEST_F(FlashProxyDeathTest, erase_sectors_done_while_idle_aborts)
         "");
 }
 
+class FlashEchoResponseBusyDeathTest
+    : public testing::Test
+{
+public:
+    testing::NiceMock<services::EchoMock> echo;
+    testing::NiceMock<hal::CleanFlashMock> delegate;
+    services::FlashEcho flash{ echo, delegate };
+
+    const std::array<uint8_t, 4> data{ 5, 8, 2, 3 };
+    infra::Function<void()> onDone;
+};
+
+TEST_F(FlashEchoResponseBusyDeathTest, write_while_busy_with_response_aborts)
+{
+    EXPECT_CALL(delegate, WriteBuffer(testing::_, 1234, testing::_)).WillOnce(testing::SaveArg<2>(&onDone));
+    flash.Write(1234, data);
+
+    onDone(); // flash done → busyWithResponse = true, response send queued but not dispatched
+
+    EXPECT_DEATH(flash.Write(1234, data), "");
+}
+
 #endif


### PR DESCRIPTION
This is a follow up to #1225. That PR did not capture all possible cases in how the FlashEcho driver can be busy. And we are seeing cases where this results in a `onGranted` case in drivers using `FlashEcho`. So the issue in likely not in `FlashEcho`, but getting the stack trace on the erroneous call, and not a deferred call, would make this issue easier to solve.