### PR TITLE
chore: differentiate onGranted failures between Echo and Claimable

### DIFF
--- a/infra/event/ClaimableResource.hpp
+++ b/infra/event/ClaimableResource.hpp
@@ -99,7 +99,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::Claim(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ClaimableResource Claim already pending");
 
         this->onGranted = onGranted;
         this->isQueued = true;
@@ -109,7 +109,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::ClaimUrgent(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ClaimableResource ClaimUrgent already pending");
 
         this->onGranted = onGranted;
         this->isQueued = true;

--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -36,7 +36,7 @@ namespace services
 
     void ServiceProxy::RequestSend(infra::Function<void()> onGranted, uint32_t requestedSize)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ServiceProxy RequestSend already pending");
         this->onGranted = onGranted;
         currentRequestedSize = requestedSize;
         echo.RequestSend(*this);


### PR DESCRIPTION
This makes the failure messages unique between Echo and Claimable so that it's clearly visible in crash logs what went wrong. The stack trace itself is sometimes not enough proof to clearly discern where the issue occured.

Related to #1247