### PR TITLE
chore: introduce TargetTypeId for infra::Function

### DIFF
--- a/infra/event/ClaimableResource.hpp
+++ b/infra/event/ClaimableResource.hpp
@@ -99,7 +99,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::Claim(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert_with_msg(!this->onGranted, "ClaimableResource::Claim onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::Claim onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetType(), onGranted.TargetType());
 
         this->onGranted = onGranted;
         this->isQueued = true;
@@ -109,7 +109,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::ClaimUrgent(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert_with_msg(!this->onGranted, "ClaimableResource::ClaimUrgent onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::ClaimUrgent onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetType(), onGranted.TargetType());
 
         this->onGranted = onGranted;
         this->isQueued = true;

--- a/infra/event/ClaimableResource.hpp
+++ b/infra/event/ClaimableResource.hpp
@@ -99,7 +99,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::Claim(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::Claim onGranted already pending (overlapping claim); claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
 
         this->onGranted = onGranted;
         this->isQueued = true;
@@ -109,7 +109,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::ClaimUrgent(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::ClaimUrgent onGranted already pending (overlapping claim); claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
 
         this->onGranted = onGranted;
         this->isQueued = true;

--- a/infra/event/ClaimableResource.hpp
+++ b/infra/event/ClaimableResource.hpp
@@ -99,7 +99,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::Claim(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert_with_msg(!this->onGranted, "ClaimableResource::Claim onGranted already pending (overlapping claim); claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::Claim onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
 
         this->onGranted = onGranted;
         this->isQueued = true;
@@ -109,7 +109,7 @@ namespace infra
     template<std::size_t ExtraSize>
     void ClaimableResource::ClaimerWithSize<ExtraSize>::ClaimUrgent(const infra::Function<void(), ExtraSize>& onGranted)
     {
-        really_assert_with_msg(!this->onGranted, "ClaimableResource::ClaimUrgent onGranted already pending (overlapping claim); claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ClaimableResource::ClaimUrgent onGranted already pending; claimer=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
 
         this->onGranted = onGranted;
         this->isQueued = true;

--- a/infra/util/AutoResetFunction.hpp
+++ b/infra/util/AutoResetFunction.hpp
@@ -39,8 +39,8 @@ namespace infra
         void Swap(AutoResetFunction& other) noexcept;
 
         // Returns an opaque pointer that uniquely identifies the type of the currently stored
-        // callable (or nullptr when empty). Intended for diagnostics only; see Function::TargetTypeId.
-        const void* TargetTypeId() const;
+        // callable (or nullptr when empty). Intended for diagnostics only; see Function::TargetType.
+        const void* TargetType() const;
 
     private:
         Function<Result(Args...), ExtraSize> function;
@@ -125,9 +125,9 @@ namespace infra
     }
 
     template<std::size_t ExtraSize, class Result, class... Args>
-    const void* AutoResetFunction<Result(Args...), ExtraSize>::TargetTypeId() const
+    const void* AutoResetFunction<Result(Args...), ExtraSize>::TargetType() const
     {
-        return function.TargetTypeId();
+        return function.TargetType();
     }
 
     template<std::size_t ExtraSize, class Result, class... Args>

--- a/infra/util/AutoResetFunction.hpp
+++ b/infra/util/AutoResetFunction.hpp
@@ -38,6 +38,10 @@ namespace infra
         infra::Function<Result(Args...), ExtraSize> Clone() const;
         void Swap(AutoResetFunction& other) noexcept;
 
+        // Returns an opaque pointer that uniquely identifies the type of the currently stored
+        // callable (or nullptr when empty). Intended for diagnostics only; see Function::TargetTypeId.
+        const void* TargetTypeId() const;
+
     private:
         Function<Result(Args...), ExtraSize> function;
     };
@@ -118,6 +122,12 @@ namespace infra
     void AutoResetFunction<Result(Args...), ExtraSize>::Swap(AutoResetFunction& other) noexcept
     {
         function.Swap(other.function);
+    }
+
+    template<std::size_t ExtraSize, class Result, class... Args>
+    const void* AutoResetFunction<Result(Args...), ExtraSize>::TargetTypeId() const
+    {
+        return function.TargetTypeId();
     }
 
     template<std::size_t ExtraSize, class Result, class... Args>

--- a/infra/util/Function.hpp
+++ b/infra/util/Function.hpp
@@ -121,6 +121,12 @@ namespace infra
 
         void Swap(Function& other) noexcept;
 
+        // Returns an opaque pointer that uniquely identifies the type of the currently stored
+        // callable (or nullptr when empty). Intended for diagnostics only: the value can be looked
+        // up in the linker map to identify the stored lambda/function, even in optimized builds
+        // where the call stack is not recoverable.
+        const void* TargetTypeId() const;
+
     private:
         template<class F>
         void Assign(F f);
@@ -440,6 +446,15 @@ namespace infra
     bool Function<Result(Args...), ExtraSize>::Initialized() const
     {
         return invokerFunctions.virtualMethodTable != ReinterpretAbortOnExecuteSentinelTable();
+    }
+
+    template<std::size_t ExtraSize, class Result, class... Args>
+    const void* Function<Result(Args...), ExtraSize>::TargetTypeId() const
+    {
+        if (!Initialized())
+            return nullptr;
+
+        return invokerFunctions.virtualMethodTable;
     }
 
     template<std::size_t ExtraSize, class Result, class... Args>

--- a/infra/util/Function.hpp
+++ b/infra/util/Function.hpp
@@ -121,11 +121,11 @@ namespace infra
 
         void Swap(Function& other) noexcept;
 
-        // Returns an opaque pointer that uniquely identifies the type of the currently stored
-        // callable (or nullptr when empty). Intended for diagnostics only: the value can be looked
-        // up in the linker map to identify the stored lambda/function, even in optimized builds
-        // where the call stack is not recoverable.
-        const void* TargetTypeId() const;
+        // Mirrors the role of std::function::target_type, but returns an opaque pointer
+        // (or nullptr when empty) rather than a std::type_info. Intended for diagnostics only:
+        // the value can be looked up in the linker map to identify the stored lambda/function,
+        // even in optimized builds where the call stack is not recoverable.
+        const void* TargetType() const;
 
     private:
         template<class F>
@@ -449,7 +449,7 @@ namespace infra
     }
 
     template<std::size_t ExtraSize, class Result, class... Args>
-    const void* Function<Result(Args...), ExtraSize>::TargetTypeId() const
+    const void* Function<Result(Args...), ExtraSize>::TargetType() const
     {
         if (!Initialized())
             return nullptr;

--- a/infra/util/test/TestAutoResetFunction.cpp
+++ b/infra/util/test/TestAutoResetFunction.cpp
@@ -28,6 +28,28 @@ TEST(AutoResetFunctionTest, IsResetAfterInvoke)
     EXPECT_FALSE(f);
 }
 
+TEST(AutoResetFunctionTest, TargetTypeIdIsNullWhenEmpty)
+{
+    infra::AutoResetFunction<void()> f;
+    EXPECT_EQ(nullptr, f.TargetTypeId());
+}
+
+TEST(AutoResetFunctionTest, TargetTypeIdIsClearedAfterInvoke)
+{
+    infra::MockCallback<void()> m;
+    infra::AutoResetFunction<void()> f([&m]()
+        {
+            m.callback();
+        });
+
+    EXPECT_NE(nullptr, f.TargetTypeId());
+
+    EXPECT_CALL(m, callback());
+    f();
+
+    EXPECT_EQ(nullptr, f.TargetTypeId());
+}
+
 TEST(AutoResetFunctionTest, ReAssignDuringInvoke)
 {
     infra::MockCallback<void()> a;

--- a/infra/util/test/TestAutoResetFunction.cpp
+++ b/infra/util/test/TestAutoResetFunction.cpp
@@ -28,13 +28,13 @@ TEST(AutoResetFunctionTest, IsResetAfterInvoke)
     EXPECT_FALSE(f);
 }
 
-TEST(AutoResetFunctionTest, TargetTypeIdIsNullWhenEmpty)
+TEST(AutoResetFunctionTest, TargetTypeIsNullWhenEmpty)
 {
     infra::AutoResetFunction<void()> f;
-    EXPECT_EQ(nullptr, f.TargetTypeId());
+    EXPECT_EQ(nullptr, f.TargetType());
 }
 
-TEST(AutoResetFunctionTest, TargetTypeIdIsClearedAfterInvoke)
+TEST(AutoResetFunctionTest, TargetTypeIsClearedAfterInvoke)
 {
     infra::MockCallback<void()> m;
     infra::AutoResetFunction<void()> f([&m]()
@@ -42,12 +42,12 @@ TEST(AutoResetFunctionTest, TargetTypeIdIsClearedAfterInvoke)
             m.callback();
         });
 
-    EXPECT_NE(nullptr, f.TargetTypeId());
+    EXPECT_NE(nullptr, f.TargetType());
 
     EXPECT_CALL(m, callback());
     f();
 
-    EXPECT_EQ(nullptr, f.TargetTypeId());
+    EXPECT_EQ(nullptr, f.TargetType());
 }
 
 TEST(AutoResetFunctionTest, ReAssignDuringInvoke)

--- a/infra/util/test/TestFunction.cpp
+++ b/infra/util/test/TestFunction.cpp
@@ -21,28 +21,28 @@ TEST(FunctionTest, TestConstructedNotEmpty)
     EXPECT_TRUE(static_cast<bool>(f));
 }
 
-TEST(FunctionTest, TestTargetTypeIdIsNullWhenEmpty)
+TEST(FunctionTest, TestTargetTypeIsNullWhenEmpty)
 {
     infra::Function<void()> f;
-    EXPECT_EQ(nullptr, f.TargetTypeId());
+    EXPECT_EQ(nullptr, f.TargetType());
 }
 
-TEST(FunctionTest, TestTargetTypeIdIsNotNullWhenAssigned)
+TEST(FunctionTest, TestTargetTypeIsNotNullWhenAssigned)
 {
     infra::Function<void()> f([]() {});
-    EXPECT_NE(nullptr, f.TargetTypeId());
+    EXPECT_NE(nullptr, f.TargetType());
 }
 
-TEST(FunctionTest, TestTargetTypeIdIsStableForSameStoredType)
+TEST(FunctionTest, TestTargetTypeIsStableForSameStoredType)
 {
     auto callable = []() {};
     infra::Function<void()> f(callable);
     infra::Function<void()> g(callable);
 
-    EXPECT_EQ(f.TargetTypeId(), g.TargetTypeId());
+    EXPECT_EQ(f.TargetType(), g.TargetType());
 }
 
-TEST(FunctionTest, TestTargetTypeIdDiffersForDifferentStoredTypes)
+TEST(FunctionTest, TestTargetTypeDiffersForDifferentStoredTypes)
 {
     int x = 0;
     infra::Function<void()> f([]() {});
@@ -51,16 +51,16 @@ TEST(FunctionTest, TestTargetTypeIdDiffersForDifferentStoredTypes)
             ++x;
         });
 
-    EXPECT_NE(f.TargetTypeId(), g.TargetTypeId());
+    EXPECT_NE(f.TargetType(), g.TargetType());
 }
 
-TEST(FunctionTest, TestTargetTypeIdIsClearedAfterReset)
+TEST(FunctionTest, TestTargetTypeIsClearedAfterReset)
 {
     infra::Function<void()> f([]() {});
-    EXPECT_NE(nullptr, f.TargetTypeId());
+    EXPECT_NE(nullptr, f.TargetType());
 
     f = nullptr;
-    EXPECT_EQ(nullptr, f.TargetTypeId());
+    EXPECT_EQ(nullptr, f.TargetType());
 }
 
 void function()

--- a/infra/util/test/TestFunction.cpp
+++ b/infra/util/test/TestFunction.cpp
@@ -21,6 +21,48 @@ TEST(FunctionTest, TestConstructedNotEmpty)
     EXPECT_TRUE(static_cast<bool>(f));
 }
 
+TEST(FunctionTest, TestTargetTypeIdIsNullWhenEmpty)
+{
+    infra::Function<void()> f;
+    EXPECT_EQ(nullptr, f.TargetTypeId());
+}
+
+TEST(FunctionTest, TestTargetTypeIdIsNotNullWhenAssigned)
+{
+    infra::Function<void()> f([]() {});
+    EXPECT_NE(nullptr, f.TargetTypeId());
+}
+
+TEST(FunctionTest, TestTargetTypeIdIsStableForSameStoredType)
+{
+    auto callable = []() {};
+    infra::Function<void()> f(callable);
+    infra::Function<void()> g(callable);
+
+    EXPECT_EQ(f.TargetTypeId(), g.TargetTypeId());
+}
+
+TEST(FunctionTest, TestTargetTypeIdDiffersForDifferentStoredTypes)
+{
+    int x = 0;
+    infra::Function<void()> f([]() {});
+    infra::Function<void()> g([&x]()
+        {
+            ++x;
+        });
+
+    EXPECT_NE(f.TargetTypeId(), g.TargetTypeId());
+}
+
+TEST(FunctionTest, TestTargetTypeIdIsClearedAfterReset)
+{
+    infra::Function<void()> f([]() {});
+    EXPECT_NE(nullptr, f.TargetTypeId());
+
+    f = nullptr;
+    EXPECT_EQ(nullptr, f.TargetTypeId());
+}
+
 void function()
 {}
 

--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -36,7 +36,7 @@ namespace services
 
     void ServiceProxy::RequestSend(infra::Function<void()> onGranted, uint32_t requestedSize)
     {
-        really_assert(!this->onGranted);
+        really_assert_with_msg(!this->onGranted, "ServiceProxy::RequestSend onGranted already pending (overlapping send); proxy=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
         this->onGranted = onGranted;
         currentRequestedSize = requestedSize;
         echo.RequestSend(*this);

--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -36,7 +36,7 @@ namespace services
 
     void ServiceProxy::RequestSend(infra::Function<void()> onGranted, uint32_t requestedSize)
     {
-        really_assert_with_msg(!this->onGranted, "ServiceProxy::RequestSend onGranted already pending; proxy=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ServiceProxy::RequestSend onGranted already pending; proxy=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetType(), onGranted.TargetType());
         this->onGranted = onGranted;
         currentRequestedSize = requestedSize;
         echo.RequestSend(*this);

--- a/protobuf/echo/Echo.cpp
+++ b/protobuf/echo/Echo.cpp
@@ -36,7 +36,7 @@ namespace services
 
     void ServiceProxy::RequestSend(infra::Function<void()> onGranted, uint32_t requestedSize)
     {
-        really_assert_with_msg(!this->onGranted, "ServiceProxy::RequestSend onGranted already pending (overlapping send); proxy=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
+        really_assert_with_msg(!this->onGranted, "ServiceProxy::RequestSend onGranted already pending; proxy=%p pending=%p incoming=%p", static_cast<const void*>(this), this->onGranted.TargetTypeId(), onGranted.TargetTypeId());
         this->onGranted = onGranted;
         currentRequestedSize = requestedSize;
         echo.RequestSend(*this);


### PR DESCRIPTION
This pull request adds diagnostics improvements and new functionality to the `infra::Function` and `infra::AutoResetFunction` classes, making it easier to debug issues related to overlapping claims and function assignments. It introduces a new method to uniquely identify the type of the stored callable and enhances assertion messages to provide more context during failures. Comprehensive tests are also added to verify the new functionality.

Diagnostics and Debugging Improvements:

* Added a `TargetTypeId()` method to both `infra::Function` and `infra::AutoResetFunction` that returns an opaque pointer uniquely identifying the type of the currently stored callable, or `nullptr` if empty. This is intended for diagnostics and can help identify the exact lambda or function stored, even in optimized builds. [[1]](diffhunk://#diff-aa6d4dca1075a1363a706028ef5a00eda4e76ba796597aa755eff2ae1cea6a94R124-R129) [[2]](diffhunk://#diff-aa6d4dca1075a1363a706028ef5a00eda4e76ba796597aa755eff2ae1cea6a94R451-R459) [[3]](diffhunk://#diff-ff569d328340bcea8e3af91cb0e5e3cd02f78e8ae4e30300b35d9fdb7abd6d41R41-R44) [[4]](diffhunk://#diff-ff569d328340bcea8e3af91cb0e5e3cd02f78e8ae4e30300b35d9fdb7abd6d41R127-R132)

Assertion Enhancements:

* Updated assertion checks in `ClaimableResource::ClaimerWithSize::Claim`, `ClaimableResource::ClaimerWithSize::ClaimUrgent`, and `ServiceProxy::RequestSend` to use `really_assert_with_msg`, providing detailed messages that include the object pointer and the type IDs of both the pending and incoming callables. This helps diagnose overlapping claim issues more effectively. [[1]](diffhunk://#diff-fa718b24b4886d840362e81b64e1647028eb9e56db044b4ac69fdc3d54731fb1L102-R102) [[2]](diffhunk://#diff-fa718b24b4886d840362e81b64e1647028eb9e56db044b4ac69fdc3d54731fb1L112-R112) [[3]](diffhunk://#diff-684c4bb585117b8e4b0735212015c6a5c72d21e1e214afc6e86b178f922a54efL39-R39)

Testing:

* Added comprehensive unit tests for `TargetTypeId()` in both `infra::Function` and `infra::AutoResetFunction`, covering cases such as empty functions, assignment, type stability, type differences, and clearing after reset or invocation. [[1]](diffhunk://#diff-8229d7735305699b897ba6e7584feadd112dae8e04f9a9f4eefe74e6c034e2d6R24-R65) [[2]](diffhunk://#diff-ea852000452571e15fe5733a9058faa6b04e8a081777e310082fc0767a3c031dR31-R52)


### Example: Interpreting the assert messages resulting from the changes in this PR

When a one-shot callback slot receives a second callback before the first ran
(an overlapping send/claim), the assert prints three addresses:

```text
Assertion failed! [ClaimableResource::Claim onGranted already pending;
                   claimer=0x280522fc pending=0x14171688 incoming=0x1417167c]
```

| Field      | Meaning                                          | Region          | Resolve with |
| ---------- | ------------------------------------------------ | --------------- | ------------ |
| `pending`  | callback already holding the slot                | flash `.rodata` | `addr2line`  |
| `incoming` | callback that tried to overwrite it              | flash `.rodata` | `addr2line`  |
| `claimer`  | the object whose slot collided                   | RAM             | `nm`         |

> Use the `.out` from the **failing build** (or its `.map`), and the toolchain matching the target

```bash
# example binary
BIN=<./application_path>.out
```

### 1. `pending` and `incoming` — the two callbacks

Each address is the callback's type identity; `addr2line` maps it back to the
function that created the callback:

```bash
addr2line -e "$BIN" -fC 0x14171688   # pending
addr2line -e "$BIN" -fC 0x1417167c   # incoming
```

```text
# pending
...StaticVirtualMethodTable<services::FlashMultipleAccess::EraseSectors(...)::$_0>()::table
FlashMultipleAccess.cpp:0

# incoming
...StaticVirtualMethodTable<services::FlashMultipleAccess::WriteBuffer(...)::$_0>()::table
FlashMultipleAccess.cpp:0
```

Read as a sentence: *an `EraseSectors` callback was still pending when a
`WriteBuffer` callback came in* → erase/write overlapped on one flash accessor.

### 2. `claimer` — the object

`nm` only knows top-level statics, so this finds the **enclosing object**, not
the exact member — enough for a general direction:

```bash
nm -nSC "$BIN" | awk -v t=$((0x280522fc)) '
  { a=("0x"$1)+0; s=("0x"$2)+0 }
  s>0 && a<=t && t<a+s { print; exit }'
```

```text
28051c80 00006500 b mainThread(void*)::$_4::operator()(bool) const::firmwareUpdate
```

So the claimer sits inside the static `firmwareUpdate`. Combined with
`pending`/`incoming` naming `FlashMultipleAccess`, it's that object's
`flashDownload` member's claimer (the only `FlashMultipleAccess` on the
erase→write path).