### PR TITLE
feat: add DoubleBufferedSerialCommunication

### DIFF
--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -52,13 +52,17 @@ function(add_mbedtls_target_properties)
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
             # see https://github.com/Mbed-TLS/mbedtls/pull/6966
             # mbedtls sets the -Wdocumentation flag, which throws warnings since clang-15
-            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wno-uninitialized-const-pointer -Wno-unterminated-string-initialization)
+            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion)
         endif()
 
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
             # -Wuninitialized-const-pointer / -Wunterminated-string-initialization
             # are treated as errors since clang-22
             if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 22.0.0)
+                list(APPEND _mbedtls_warning_suppressions -Wno-uninitialized-const-pointer -Wno-unterminated-string-initialization)
+            endif()
+        elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+            if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.0.0)
                 list(APPEND _mbedtls_warning_suppressions -Wno-uninitialized-const-pointer -Wno-unterminated-string-initialization)
             endif()
         elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -52,7 +52,7 @@ function(add_mbedtls_target_properties)
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
             # see https://github.com/Mbed-TLS/mbedtls/pull/6966
             # mbedtls sets the -Wdocumentation flag, which throws warnings since clang-15
-            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion)
+            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wuninitialized-const-pointer)
         endif()
 
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -52,7 +52,7 @@ function(add_mbedtls_target_properties)
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
             # see https://github.com/Mbed-TLS/mbedtls/pull/6966
             # mbedtls sets the -Wdocumentation flag, which throws warnings since clang-15
-            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wuninitialized-const-pointer)
+            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wno-uninitialized-const-pointer)
         endif()
 
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -52,7 +52,7 @@ function(add_mbedtls_target_properties)
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
             # see https://github.com/Mbed-TLS/mbedtls/pull/6966
             # mbedtls sets the -Wdocumentation flag, which throws warnings since clang-15
-            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wno-uninitialized-const-pointer)
+            list(APPEND _mbedtls_warning_suppressions -Wno-documentation -Wno-conversion -Wno-uninitialized-const-pointer -Wno-unterminated-string-initialization)
         endif()
 
         if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/services/util/CMakeLists.txt
+++ b/services/util/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(services.util PRIVATE
     DebouncedButton.hpp
     DebugLed.cpp
     DebugLed.hpp
+    DoubleBufferedSerialCommunication.cpp
+    DoubleBufferedSerialCommunication.hpp
     EchoInstantiation.cpp
     EchoInstantiation.hpp
     EchoOnMessageCommunication.cpp

--- a/services/util/DoubleBufferedSerialCommunication.cpp
+++ b/services/util/DoubleBufferedSerialCommunication.cpp
@@ -3,7 +3,8 @@
 namespace services
 {
     DoubleBufferedSerialCommunication::DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, BufferedSerialCommunication& delegate)
-        : buffer(buffer)
+        : hal::BufferedSerialCommunicationObserver(delegate)
+        , buffer(buffer)
         , delegate(delegate)
     {}
 
@@ -39,9 +40,9 @@ namespace services
         if (nowActionOnCompletion != nullptr && !sending)
         {
             sending = true;
-            auto insertingChunk = infra::Head(nowSending, buffer.max_size());
-            buffer.assign(insertingChunk.begin(), insertingChunk.end());
-            nowSending = infra::DiscardHead(nowSending, insertingChunk.size());
+            auto chunk = infra::Head(nowSending, buffer.max_size());
+            buffer.assign(chunk.begin(), chunk.end());
+            nowSending = infra::DiscardHead(nowSending, chunk.size());
 
             if (nowSending.empty())
                 nowActionOnCompletion();

--- a/services/util/DoubleBufferedSerialCommunication.cpp
+++ b/services/util/DoubleBufferedSerialCommunication.cpp
@@ -1,0 +1,58 @@
+#include "services/util/DoubleBufferedSerialCommunication.hpp"
+
+namespace services
+{
+    DoubleBufferedSerialCommunication::DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, BufferedSerialCommunication& delegate)
+        : buffer(buffer)
+        , delegate(delegate)
+    {}
+
+    void DoubleBufferedSerialCommunication::SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion)
+    {
+        really_assert(actionOnCompletion != nullptr);
+        really_assert(nextActionOnCompletion == nullptr);
+
+        nextSend = data;
+        nextActionOnCompletion = actionOnCompletion;
+
+        TrySend();
+    }
+
+    infra::StreamReaderWithRewinding& DoubleBufferedSerialCommunication::Reader()
+    {
+        return delegate.Reader();
+    }
+
+    void DoubleBufferedSerialCommunication::AckReceived()
+    {
+        delegate.AckReceived();
+    }
+
+    void DoubleBufferedSerialCommunication::TrySend()
+    {
+        if (nextActionOnCompletion != nullptr && nowActionOnCompletion == nullptr)
+        {
+            nowSending = nextSend;
+            nowActionOnCompletion = std::move(nextActionOnCompletion);
+        }
+
+        if (nowActionOnCompletion != nullptr && !sending)
+        {
+            sending = true;
+            auto insertingChunk = infra::Head(nowSending, buffer.max_size());
+            buffer.assign(insertingChunk.begin(), insertingChunk.end());
+            nowSending = infra::DiscardHead(nowSending, insertingChunk.size());
+
+            if (nowSending.empty())
+                nowActionOnCompletion();
+
+            delegate.SendData(infra::MakeRange(buffer), [this]()
+                {
+                    sending = false;
+                    buffer.clear();
+
+                    TrySend();
+                });
+        }
+    }
+}

--- a/services/util/DoubleBufferedSerialCommunication.cpp
+++ b/services/util/DoubleBufferedSerialCommunication.cpp
@@ -2,7 +2,7 @@
 
 namespace services
 {
-    DoubleBufferedSerialCommunication::DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, BufferedSerialCommunication& delegate)
+    DoubleBufferedSerialCommunication::DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, hal::BufferedSerialCommunication& delegate)
         : hal::BufferedSerialCommunicationObserver(delegate)
         , buffer(buffer)
         , delegate(delegate)
@@ -31,7 +31,8 @@ namespace services
 
     void DoubleBufferedSerialCommunication::DataReceived()
     {
-        GetObserver().DataReceived();
+        if (HasObserver())
+            GetObserver().DataReceived();
     }
 
     void DoubleBufferedSerialCommunication::TrySend()

--- a/services/util/DoubleBufferedSerialCommunication.cpp
+++ b/services/util/DoubleBufferedSerialCommunication.cpp
@@ -29,6 +29,11 @@ namespace services
         delegate.AckReceived();
     }
 
+    void DoubleBufferedSerialCommunication::DataReceived()
+    {
+        GetObserver().DataReceived();
+    }
+
     void DoubleBufferedSerialCommunication::TrySend()
     {
         if (nextActionOnCompletion != nullptr && nowActionOnCompletion == nullptr)

--- a/services/util/DoubleBufferedSerialCommunication.hpp
+++ b/services/util/DoubleBufferedSerialCommunication.hpp
@@ -23,6 +23,7 @@ namespace services
         void AckReceived() override;
 
     private:
+        // Implementation of BufferedSerialCommunicationObserver
         void DataReceived() override;
 
     private:

--- a/services/util/DoubleBufferedSerialCommunication.hpp
+++ b/services/util/DoubleBufferedSerialCommunication.hpp
@@ -14,7 +14,7 @@ namespace services
         template<std::size_t Size>
         using WithStorage = infra::WithStorage<DoubleBufferedSerialCommunication, infra::BoundedVector<uint8_t>::WithMaxSize<Size>>;
 
-        DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, BufferedSerialCommunication& delegate);
+        DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, hal::BufferedSerialCommunication& delegate);
 
         // Implementation of BufferedSerialCommunication
         void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
@@ -29,8 +29,7 @@ namespace services
 
     private:
         infra::BoundedVector<uint8_t>& buffer;
-        BufferedSerialCommunication& delegate;
-
+        hal::BufferedSerialCommunication& delegate;
         infra::ConstByteRange nextSend;
         infra::AutoResetFunction<void()> nextActionOnCompletion;
 

--- a/services/util/DoubleBufferedSerialCommunication.hpp
+++ b/services/util/DoubleBufferedSerialCommunication.hpp
@@ -1,0 +1,40 @@
+#ifndef SERVICES_DOUBLE_BUFFERED_SERIAL_COMMUNICATION_HPP
+#define SERVICES_DOUBLE_BUFFERED_SERIAL_COMMUNICATION_HPP
+
+#include "hal/interfaces/SerialCommunication.hpp"
+#include "infra/util/BoundedVector.hpp"
+
+namespace services
+{
+    class DoubleBufferedSerialCommunication
+        : public hal::BufferedSerialCommunication
+    {
+    public:
+        template<std::size_t Size>
+        using WithStorage = infra::WithStorage<DoubleBufferedSerialCommunication, infra::BoundedVector<uint8_t>::WithMaxSize<Size>>;
+
+        DoubleBufferedSerialCommunication(infra::BoundedVector<uint8_t>& buffer, BufferedSerialCommunication& delegate);
+
+        // Implementation of BufferedSerialCommunication
+        void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
+        infra::StreamReaderWithRewinding& Reader() override;
+        void AckReceived() override;
+
+    private:
+        void TrySend();
+
+    private:
+        infra::BoundedVector<uint8_t>& buffer;
+        BufferedSerialCommunication& delegate;
+
+        infra::ConstByteRange nextSend;
+        infra::AutoResetFunction<void()> nextActionOnCompletion;
+
+        infra::ConstByteRange nowSending;
+        infra::AutoResetFunction<void()> nowActionOnCompletion;
+
+        bool sending = false;
+    };
+}
+
+#endif

--- a/services/util/DoubleBufferedSerialCommunication.hpp
+++ b/services/util/DoubleBufferedSerialCommunication.hpp
@@ -2,6 +2,7 @@
 #define SERVICES_DOUBLE_BUFFERED_SERIAL_COMMUNICATION_HPP
 
 #include "hal/interfaces/SerialCommunication.hpp"
+#include "infra/util/AutoResetFunction.hpp"
 #include "infra/util/BoundedVector.hpp"
 
 namespace services

--- a/services/util/DoubleBufferedSerialCommunication.hpp
+++ b/services/util/DoubleBufferedSerialCommunication.hpp
@@ -8,6 +8,7 @@ namespace services
 {
     class DoubleBufferedSerialCommunication
         : public hal::BufferedSerialCommunication
+        , private hal::BufferedSerialCommunicationObserver
     {
     public:
         template<std::size_t Size>
@@ -19,6 +20,9 @@ namespace services
         void SendData(infra::ConstByteRange data, infra::Function<void()> actionOnCompletion) override;
         infra::StreamReaderWithRewinding& Reader() override;
         void AckReceived() override;
+
+    private:
+        void DataReceived() override;
 
     private:
         void TrySend();

--- a/services/util/test/CMakeLists.txt
+++ b/services/util/test/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(services.util_test PRIVATE
     TestCyclicStore.cpp
     TestDebouncedButton.cpp
     TestDebugLed.cpp
+    TestDoubleBufferedSerialCommunication.cpp
     TestEchoOnSesame.cpp
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestEchoPolicyDiffieHellman.cpp>
     $<$<BOOL:${EMIL_INCLUDE_MBEDTLS}>:TestEchoPolicySymmetricKey.cpp>

--- a/services/util/test/TestDoubleBufferedSerialCommunication.cpp
+++ b/services/util/test/TestDoubleBufferedSerialCommunication.cpp
@@ -128,8 +128,7 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_while_sending_fir
     infra::Function<void()> onSent1;
     infra::Function<void()> onSent2;
     EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
-    communication.SendData(data1, [&]()
-        {});
+    communication.SendData(data1, [&]() {});
 
     EXPECT_CALL(onDone2, callback());
     EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));

--- a/services/util/test/TestDoubleBufferedSerialCommunication.cpp
+++ b/services/util/test/TestDoubleBufferedSerialCommunication.cpp
@@ -11,14 +11,14 @@ public:
     testing::StrictMock<hal::BufferedSerialCommunicationMock> delegate;
     services::DoubleBufferedSerialCommunication::WithStorage<4> communication{ delegate };
     hal::BufferedSerialCommunicationObserverMock observer{ communication };
-    testing::MockFunction<void(std::string_view checkPointName)> check;
+    testing::MockFunction<void()> check;
 };
 
 TEST_F(DoubleBufferedSerialCommunicationTest, read_and_ack_are_delegated)
 {
     infra::StreamReaderWithRewindingMock reader;
     EXPECT_CALL(delegate, Reader()).WillOnce(testing::ReturnRef(reader));
-    EXPECT_THAT(&reader, testing::Eq(&communication.Reader()));
+    EXPECT_THAT(&reader, testing::Pointer(&communication.Reader()));
 
     EXPECT_CALL(delegate, AckReceived());
     communication.AckReceived();
@@ -39,13 +39,13 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_data_is_delegated_and_reporte
     infra::Function<void()> onSent;
     EXPECT_CALL(onDone, callback());
     EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
-    EXPECT_CALL(check, Call("1"));
+    EXPECT_CALL(check, Call());
     communication.SendData(data, [&]()
         {
             onDone.callback();
         });
 
-    check.Call("1");
+    check.Call();
     onSent();
 }
 
@@ -63,14 +63,14 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_more_data_than_fits_in_the_bu
     EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(dataChunk1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
     EXPECT_CALL(onDone, callback());
     EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(dataChunk2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
-    EXPECT_CALL(check, Call("1"));
+    EXPECT_CALL(check, Call());
     communication.SendData(dataSend, [&]()
         {
             onDone.callback();
         });
 
     onSent1();
-    check.Call("1");
+    check.Call();
     onSent2();
 }
 
@@ -94,9 +94,9 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_after_first)
 
     EXPECT_CALL(onDone2, callback());
     EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
-    EXPECT_CALL(check, Call("1"));
+    EXPECT_CALL(check, Call());
     onSent1();
-    check.Call("1");
+    check.Call();
     onSent2();
 }
 
@@ -114,8 +114,6 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_empty_data_is_reported_done)
             onDone.callback();
         });
 
-    // Verify that the onDone callback has happened before the delegate's onDone is reported
-    testing::Mock::VerifyAndClearExpectations(&onDone);
     onSent();
 }
 
@@ -141,7 +139,5 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_while_sending_fir
         });
 
     onSent1();
-    testing::Mock::VerifyAndClearExpectations(&onDone2);
-
     onSent2();
 }

--- a/services/util/test/TestDoubleBufferedSerialCommunication.cpp
+++ b/services/util/test/TestDoubleBufferedSerialCommunication.cpp
@@ -1,6 +1,5 @@
 #include "hal/interfaces/test_doubles/SerialCommunicationMock.hpp"
 #include "infra/stream/test/StreamMock.hpp"
-#include "infra/util/test_helper/MemoryRangeMatcher.hpp"
 #include "infra/util/test_helper/MockCallback.hpp"
 #include "services/util/DoubleBufferedSerialCommunication.hpp"
 #include "gtest/gtest.h"
@@ -12,13 +11,14 @@ public:
     testing::StrictMock<hal::BufferedSerialCommunicationMock> delegate;
     services::DoubleBufferedSerialCommunication::WithStorage<4> communication{ delegate };
     hal::BufferedSerialCommunicationObserverMock observer{ communication };
+    testing::MockFunction<void(std::string_view checkPointName)> check;
 };
 
 TEST_F(DoubleBufferedSerialCommunicationTest, read_and_ack_are_delegated)
 {
     infra::StreamReaderWithRewindingMock reader;
     EXPECT_CALL(delegate, Reader()).WillOnce(testing::ReturnRef(reader));
-    EXPECT_EQ(&reader, &communication.Reader());
+    EXPECT_THAT(&reader, testing::Eq(&communication.Reader()));
 
     EXPECT_CALL(delegate, AckReceived());
     communication.AckReceived();
@@ -38,14 +38,14 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_data_is_delegated_and_reporte
     testing::StrictMock<infra::MockCallback<void()>> onDone;
     infra::Function<void()> onSent;
     EXPECT_CALL(onDone, callback());
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
+    EXPECT_CALL(check, Call("1"));
     communication.SendData(data, [&]()
         {
             onDone.callback();
         });
 
-    // Verify that the onDone callback has happened before the delegate's onDone is reported
-    testing::Mock::VerifyAndClearExpectations(&onDone);
+    check.Call("1");
     onSent();
 }
 
@@ -60,17 +60,17 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_more_data_than_fits_in_the_bu
     testing::StrictMock<infra::MockCallback<void()>> onDone;
     infra::Function<void()> onSent1;
     infra::Function<void()> onSent2;
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(dataChunk1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(dataChunk1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
     EXPECT_CALL(onDone, callback());
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(dataChunk2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(dataChunk2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    EXPECT_CALL(check, Call("1"));
     communication.SendData(dataSend, [&]()
         {
             onDone.callback();
         });
 
     onSent1();
-    // Verify that the onDone callback has happened before the delegate's onDone is reported
-    testing::Mock::VerifyAndClearExpectations(&onDone);
+    check.Call("1");
     onSent2();
 }
 
@@ -83,7 +83,7 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_after_first)
     testing::StrictMock<infra::MockCallback<void()>> onDone2;
     infra::Function<void()> onSent1;
     infra::Function<void()> onSent2;
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
     communication.SendData(data1, [&]()
         {
             communication.SendData(data2, [&]()
@@ -93,9 +93,10 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_after_first)
         });
 
     EXPECT_CALL(onDone2, callback());
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    EXPECT_CALL(check, Call("1"));
     onSent1();
-    testing::Mock::VerifyAndClearExpectations(&onDone2);
+    check.Call("1");
     onSent2();
 }
 
@@ -107,7 +108,7 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_empty_data_is_reported_done)
     testing::StrictMock<infra::MockCallback<void()>> onDone;
     infra::Function<void()> onSent;
     EXPECT_CALL(onDone, callback());
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
     communication.SendData(data, [&]()
         {
             onDone.callback();
@@ -127,11 +128,11 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_while_sending_fir
     testing::StrictMock<infra::MockCallback<void()>> onDone2;
     infra::Function<void()> onSent1;
     infra::Function<void()> onSent2;
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
     communication.SendData(data1, [&]() {});
 
     EXPECT_CALL(onDone2, callback());
-    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    EXPECT_CALL(delegate, SendData(testing::ElementsAreArray(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
 
     // Before reporting the first send done, request the second data.
     communication.SendData(data2, [&]()

--- a/services/util/test/TestDoubleBufferedSerialCommunication.cpp
+++ b/services/util/test/TestDoubleBufferedSerialCommunication.cpp
@@ -11,6 +11,7 @@ class DoubleBufferedSerialCommunicationTest
 public:
     testing::StrictMock<hal::BufferedSerialCommunicationMock> delegate;
     services::DoubleBufferedSerialCommunication::WithStorage<4> communication{ delegate };
+    hal::BufferedSerialCommunicationObserverMock observer{ communication };
 };
 
 TEST_F(DoubleBufferedSerialCommunicationTest, read_and_ack_are_delegated)
@@ -21,6 +22,12 @@ TEST_F(DoubleBufferedSerialCommunicationTest, read_and_ack_are_delegated)
 
     EXPECT_CALL(delegate, AckReceived());
     communication.AckReceived();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, data_received_is_delegated)
+{
+    EXPECT_CALL(observer, DataReceived());
+    delegate.GetObserver().DataReceived();
 }
 
 TEST_F(DoubleBufferedSerialCommunicationTest, send_data_is_delegated_and_reported_done_immediately_when_it_fits_in_the_buffer)
@@ -89,5 +96,52 @@ TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_after_first)
     EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
     onSent1();
     testing::Mock::VerifyAndClearExpectations(&onDone2);
+    onSent2();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, send_empty_data_is_reported_done)
+{
+    testing::InSequence s;
+
+    static const std::array<uint8_t, 0> data;
+    testing::StrictMock<infra::MockCallback<void()>> onDone;
+    infra::Function<void()> onSent;
+    EXPECT_CALL(onDone, callback());
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
+    communication.SendData(data, [&]()
+        {
+            onDone.callback();
+        });
+
+    // Verify that the onDone callback has happened before the delegate's onDone is reported
+    testing::Mock::VerifyAndClearExpectations(&onDone);
+    onSent();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_while_sending_first)
+{
+    testing::InSequence s;
+
+    static const std::array<uint8_t, 4> data1{ 1, 2, 3, 4 };
+    static const std::array<uint8_t, 2> data2{ 5, 6 };
+    testing::StrictMock<infra::MockCallback<void()>> onDone2;
+    infra::Function<void()> onSent1;
+    infra::Function<void()> onSent2;
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    communication.SendData(data1, [&]()
+        {});
+
+    EXPECT_CALL(onDone2, callback());
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+
+    // Before reporting the first send done, request the second data.
+    communication.SendData(data2, [&]()
+        {
+            onDone2.callback();
+        });
+
+    onSent1();
+    testing::Mock::VerifyAndClearExpectations(&onDone2);
+
     onSent2();
 }

--- a/services/util/test/TestDoubleBufferedSerialCommunication.cpp
+++ b/services/util/test/TestDoubleBufferedSerialCommunication.cpp
@@ -1,0 +1,93 @@
+#include "hal/interfaces/test_doubles/SerialCommunicationMock.hpp"
+#include "infra/stream/test/StreamMock.hpp"
+#include "infra/util/test_helper/MemoryRangeMatcher.hpp"
+#include "infra/util/test_helper/MockCallback.hpp"
+#include "services/util/DoubleBufferedSerialCommunication.hpp"
+#include "gtest/gtest.h"
+
+class DoubleBufferedSerialCommunicationTest
+    : public testing::Test
+{
+public:
+    testing::StrictMock<hal::BufferedSerialCommunicationMock> delegate;
+    services::DoubleBufferedSerialCommunication::WithStorage<4> communication{ delegate };
+};
+
+TEST_F(DoubleBufferedSerialCommunicationTest, read_and_ack_are_delegated)
+{
+    infra::StreamReaderWithRewindingMock reader;
+    EXPECT_CALL(delegate, Reader()).WillOnce(testing::ReturnRef(reader));
+    EXPECT_EQ(&reader, &communication.Reader());
+
+    EXPECT_CALL(delegate, AckReceived());
+    communication.AckReceived();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, send_data_is_delegated_and_reported_done_immediately_when_it_fits_in_the_buffer)
+{
+    testing::InSequence s;
+
+    static const std::array<uint8_t, 4> data{ 1, 2, 3, 4 };
+    testing::StrictMock<infra::MockCallback<void()>> onDone;
+    infra::Function<void()> onSent;
+    EXPECT_CALL(onDone, callback());
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data), testing::_)).WillOnce(testing::SaveArg<1>(&onSent));
+    communication.SendData(data, [&]()
+        {
+            onDone.callback();
+        });
+
+    // Verify that the onDone callback has happened before the delegate's onDone is reported
+    testing::Mock::VerifyAndClearExpectations(&onDone);
+    onSent();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, send_more_data_than_fits_in_the_buffer)
+{
+    testing::InSequence s;
+
+    static const std::array<uint8_t, 6> dataSend{ 1, 2, 3, 4, 5, 6 };
+    static const std::array<uint8_t, 4> dataChunk1{ 1, 2, 3, 4 };
+    static const std::array<uint8_t, 2> dataChunk2{ 5, 6 };
+
+    testing::StrictMock<infra::MockCallback<void()>> onDone;
+    infra::Function<void()> onSent1;
+    infra::Function<void()> onSent2;
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(dataChunk1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    EXPECT_CALL(onDone, callback());
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(dataChunk2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    communication.SendData(dataSend, [&]()
+        {
+            onDone.callback();
+        });
+
+    onSent1();
+    // Verify that the onDone callback has happened before the delegate's onDone is reported
+    testing::Mock::VerifyAndClearExpectations(&onDone);
+    onSent2();
+}
+
+TEST_F(DoubleBufferedSerialCommunicationTest, send_second_data_after_first)
+{
+    testing::InSequence s;
+
+    static const std::array<uint8_t, 4> data1{ 1, 2, 3, 4 };
+    static const std::array<uint8_t, 2> data2{ 5, 6 };
+    testing::StrictMock<infra::MockCallback<void()>> onDone2;
+    infra::Function<void()> onSent1;
+    infra::Function<void()> onSent2;
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data1), testing::_)).WillOnce(testing::SaveArg<1>(&onSent1));
+    communication.SendData(data1, [&]()
+        {
+            communication.SendData(data2, [&]()
+                {
+                    onDone2.callback();
+                });
+        });
+
+    EXPECT_CALL(onDone2, callback());
+    EXPECT_CALL(delegate, SendData(infra::ContentsEqual(data2), testing::_)).WillOnce(testing::SaveArg<1>(&onSent2));
+    onSent1();
+    testing::Mock::VerifyAndClearExpectations(&onDone2);
+    onSent2();
+}


### PR DESCRIPTION
DoubleBufferedSerialCommunication introduces a buffer between sending data and reporting data to be sent, so that business logic can start preparing the next buffer earlier, and reduce time wasted between the end of the previous transmission and the start of the next transmission.