### PR TITLE
chore: abort on duplicate timer service id

### DIFF
--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -1,6 +1,7 @@
 #include "infra/timer/TimerService.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include "infra/util/LogAndAbort.hpp"
+#include <cinttypes>
 
 namespace infra
 {
@@ -10,9 +11,9 @@ namespace infra
         : id(id)
     {
         for (const TimerService& timerService : timerServices)
-            really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %u", id);
-
-        timerServices.push_front(*this);
+            really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %" PRIu32, id);
+        
+        timerServices.push_front(*this); 
     }
 
     TimerService::~TimerService()
@@ -121,7 +122,7 @@ namespace infra
             if (timerService.Id() == id)
                 return timerService;
 
-        LOG_AND_ABORT("No timer service with id: %u", id);
+        LOG_AND_ABORT("No timer service with id: %" PRIu32, id);
     }
 
     void TimerService::ComputeNextTrigger()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -1,5 +1,4 @@
 #include "infra/timer/TimerService.hpp"
-#include "infra/util/ReallyAssert.hpp"
 #include "infra/util/LogAndAbort.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include <cinttypes>

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -6,13 +6,13 @@ namespace infra
 {
     infra::IntrusiveForwardList<TimerService> TimerService::timerServices;
 
-TimerService::TimerService(uint32_t id)
-    : id(id)
-{
-    for (const TimerService& timerService : timerServices)
-        really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %u", id);
-
-    timerServices.push_front(*this);
+    TimerService::TimerService(uint32_t id)
+        : id(id) 
+    {
+        for (const TimerService& timerService : timerServices)
+            really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %u", id);
+        
+        timerServices.push_front(*this); 
     }
 
     TimerService::~TimerService()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -1,6 +1,7 @@
 #include "infra/timer/TimerService.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include "infra/util/LogAndAbort.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include <cinttypes>
 
 namespace infra
@@ -12,8 +13,8 @@ namespace infra
     {
         for (const TimerService& timerService : timerServices)
             really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %" PRIu32, id);
-        
-        timerServices.push_front(*this); 
+
+        timerServices.push_front(*this);
     }
 
     TimerService::~TimerService()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -7,12 +7,12 @@ namespace infra
     infra::IntrusiveForwardList<TimerService> TimerService::timerServices;
 
     TimerService::TimerService(uint32_t id)
-        : id(id) 
+        : id(id)
     {
         for (const TimerService& timerService : timerServices)
             really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %u", id);
-        
-        timerServices.push_front(*this); 
+
+        timerServices.push_front(*this);
     }
 
     TimerService::~TimerService()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -6,11 +6,13 @@ namespace infra
 {
     infra::IntrusiveForwardList<TimerService> TimerService::timerServices;
 
-    TimerService::TimerService(uint32_t id)
-        : id(id)
-    {
-        really_assert(!timerServices.has_element(*this));
-        timerServices.push_front(*this);
+TimerService::TimerService(uint32_t id)
+    : id(id)
+{
+    for (const TimerService& timerService : timerServices)
+        really_assert_with_msg(timerService.Id() != id, "Duplicate timer service id: %u", id);
+
+    timerServices.push_front(*this);
     }
 
     TimerService::~TimerService()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -121,7 +121,7 @@ namespace infra
             if (timerService.Id() == id)
                 return timerService;
 
-        LOG_AND_ABORT("No timer service with id: %d", id);
+        LOG_AND_ABORT("No timer service with id: %u", id);
     }
 
     void TimerService::ComputeNextTrigger()

--- a/infra/timer/TimerService.cpp
+++ b/infra/timer/TimerService.cpp
@@ -1,4 +1,6 @@
 #include "infra/timer/TimerService.hpp"
+#include "infra/util/ReallyAssert.hpp"
+#include "infra/util/LogAndAbort.hpp"
 
 namespace infra
 {
@@ -7,6 +9,7 @@ namespace infra
     TimerService::TimerService(uint32_t id)
         : id(id)
     {
+        really_assert(!timerServices.has_element(*this));
         timerServices.push_front(*this);
     }
 
@@ -116,7 +119,7 @@ namespace infra
             if (timerService.Id() == id)
                 return timerService;
 
-        abort(); // No timer service with the given id found
+        LOG_AND_ABORT("No timer service with id: %d", id);
     }
 
     void TimerService::ComputeNextTrigger()

--- a/infra/timer/test/CMakeLists.txt
+++ b/infra/timer/test/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(infra.timer_test PUBLIC
 
 target_sources(infra.timer_test PRIVATE
     TestDerivedTimerService.cpp
+    TestTimerService.cpp
     TestRetryPolicy.cpp
     TestScalableDerivedTimerService.cpp
     TestTickOnInterruptTimerService.cpp

--- a/infra/timer/test/TestTimerService.cpp
+++ b/infra/timer/test/TestTimerService.cpp
@@ -28,7 +28,7 @@ namespace
 TEST(TimerServiceDeathTest, constructing_already_registered_service_aborts)
 {
     MinimalTimerService service(1);
-    EXPECT_DEATH(::new (&service) MinimalTimerService(1), "");
+    EXPECT_DEATH({ MinimalTimerService otherService(1); (void)otherService; }, "");
 }
 
 TEST(TimerServiceDeathTest, get_timer_service_with_unknown_id_aborts)

--- a/infra/timer/test/TestTimerService.cpp
+++ b/infra/timer/test/TestTimerService.cpp
@@ -27,10 +27,8 @@ namespace
 
 TEST(TimerServiceDeathTest, constructing_already_registered_service_aborts)
 {
-    alignas(MinimalTimerService) unsigned char buffer[sizeof(MinimalTimerService)];
-    auto* service = ::new (buffer) MinimalTimerService(1);
-    EXPECT_DEATH(::new (buffer) MinimalTimerService(1), "");
-    service->~MinimalTimerService();
+    MinimalTimerService service(1);
+    EXPECT_DEATH(::new (&service) MinimalTimerService(1), "");
 }
 
 TEST(TimerServiceDeathTest, get_timer_service_with_unknown_id_aborts)

--- a/infra/timer/test/TestTimerService.cpp
+++ b/infra/timer/test/TestTimerService.cpp
@@ -1,0 +1,41 @@
+#include "infra/timer/TimerService.hpp"
+#include "gtest/gtest.h"
+
+namespace
+{
+    class MinimalTimerService
+        : public infra::TimerService
+    {
+    public:
+        explicit MinimalTimerService(uint32_t id)
+            : infra::TimerService(id)
+        {}
+
+        infra::TimePoint Now() const override
+        {
+            return {};
+        }
+
+        infra::Duration Resolution() const override
+        {
+            return {};
+        }
+    };
+}
+
+#ifndef EMIL_MUTATION_TESTING
+
+TEST(TimerServiceDeathTest, constructing_already_registered_service_aborts)
+{
+    alignas(MinimalTimerService) unsigned char buffer[sizeof(MinimalTimerService)];
+    auto* service = ::new (buffer) MinimalTimerService(1);
+    EXPECT_DEATH(::new (buffer) MinimalTimerService(1), "");
+    service->~MinimalTimerService();
+}
+
+TEST(TimerServiceDeathTest, get_timer_service_with_unknown_id_aborts)
+{
+    EXPECT_DEATH(infra::TimerService::GetTimerService(99), "");
+}
+
+#endif


### PR DESCRIPTION
Changes timer service to abort on duplicate timer ID. Otherwise this issue would silently be ignored, and one timer service silently lost.