### PR TITLE
build: correct scope for mbedtls warning suppression

### DIFF
--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -69,7 +69,7 @@ function(add_mbedtls_target_properties)
             # Warning treated as error when implicit conversion within mbedtls
             list(APPEND _mbedtls_warning_suppressions -Wno-conversion)
             # Warning treated as error since gcc-14
-            if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.0)
+            if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0.0)
                 list(APPEND _mbedtls_warning_suppressions -Wno-unterminated-string-initialization)
             endif()
         elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
@@ -77,7 +77,7 @@ function(add_mbedtls_target_properties)
         endif()
 
         if(_mbedtls_warning_suppressions)
-            target_compile_options(${target} PUBLIC ${_mbedtls_warning_suppressions})
+            target_compile_options(${target} PRIVATE ${_mbedtls_warning_suppressions})
         endif()
 
         target_include_directories(${target} PUBLIC

--- a/external/crypto/mbedtls/CMakeLists.txt
+++ b/external/crypto/mbedtls/CMakeLists.txt
@@ -68,7 +68,7 @@ function(add_mbedtls_target_properties)
         elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
             # Warning treated as error when implicit conversion within mbedtls
             list(APPEND _mbedtls_warning_suppressions -Wno-conversion)
-            # Warning treated as error since gcc-14
+            # Warning treated as error since gcc-15
             if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0.0)
                 list(APPEND _mbedtls_warning_suppressions -Wno-unterminated-string-initialization)
             endif()

--- a/services/network/ConnectionMbedTls.cpp
+++ b/services/network/ConnectionMbedTls.cpp
@@ -305,7 +305,7 @@ namespace services
 
             infra::EventDispatcherWithWeakPtr::Instance().Schedule([requestedSize](const infra::SharedPtr<ConnectionMbedTls>& object)
                 {
-                    infra::SharedPtr<StreamWriterMbedTls> stream = object->streamWriter.Emplace(*object, requestedSize);
+                    infra::SharedPtr<StreamWriterMbedTls> stream = object->streamWriter.Emplace(*object, static_cast<uint32_t>(requestedSize));
                     if (object->Connection::IsAttached())
                         object->Observer().SendStreamAvailable(std::move(stream));
                 },


### PR DESCRIPTION
Not every warning being ignored for mbedtls applies to C++, which triggers warnings when CPP libraries are compiled
Also unterminated-string-initialization has been introduced by GCC 15