### PR TITLE
chore: really_assert if 'SynchronousFlashRegion' is defined correctly

### DIFF
--- a/services/synchronous_util/CMakeLists.txt
+++ b/services/synchronous_util/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(services.synchronous_util ${EMIL_EXCLUDE_FROM_ALL} STATIC)
 target_link_libraries(services.synchronous_util PUBLIC
     hal.interfaces
     hal.synchronous_interfaces
+    infra.util
 )
 
 target_sources(services.synchronous_util PRIVATE

--- a/services/synchronous_util/SynchronousFlashRegion.cpp
+++ b/services/synchronous_util/SynchronousFlashRegion.cpp
@@ -9,7 +9,7 @@ namespace services
         , numberOfSectors(numberOfSectors)
         , masterAddressOfStartSector(master.AddressOfSector(startSector))
     {
-        really_assert(startSector + numberOfSectors <= master.NumberOfSectors());
+        really_assert(startSector <= master.NumberOfSectors() && numberOfSectors <= master.NumberOfSectors() - startSector);
     }
 
     uint32_t SynchronousFlashRegion::NumberOfSectors() const

--- a/services/synchronous_util/SynchronousFlashRegion.cpp
+++ b/services/synchronous_util/SynchronousFlashRegion.cpp
@@ -1,4 +1,5 @@
 #include "services/synchronous_util/SynchronousFlashRegion.hpp"
+#include "infra/util/ReallyAssert.hpp"
 
 namespace services
 {
@@ -8,7 +9,7 @@ namespace services
         , numberOfSectors(numberOfSectors)
         , masterAddressOfStartSector(master.AddressOfSector(startSector))
     {
-        assert(startSector + numberOfSectors <= master.NumberOfSectors());
+        really_assert(startSector + numberOfSectors <= master.NumberOfSectors());
     }
 
     uint32_t SynchronousFlashRegion::NumberOfSectors() const


### PR DESCRIPTION
Previously this was a regular `assert`, which was missed for a month already because nobody uses debug builds.