### PR TITLE
feat: move hal/interfaces/BleDtm -> services/ble/Dtm

### DIFF
--- a/hal/interfaces/CMakeLists.txt
+++ b/hal/interfaces/CMakeLists.txt
@@ -16,7 +16,6 @@ target_sources(hal.interfaces PRIVATE
     AsyncGpio.cpp
     AsyncGpio.hpp
     BackupRam.hpp
-    BleDtm.hpp
     Can.hpp
     CommunicationConfigurator.hpp
     DigitalToAnalogPin.hpp

--- a/hal/interfaces/test_doubles/CMakeLists.txt
+++ b/hal/interfaces/test_doubles/CMakeLists.txt
@@ -13,7 +13,6 @@ target_sources(hal.interfaces_test_doubles PRIVATE
     AdcMultiChannelStub.cpp
     AdcMultiChannelStub.hpp
     AnalogToDigitalPinImplMock.hpp
-    BleDtmMock.hpp
     CommunicationConfiguratorMock.hpp
     DigitalToAnalogPinImplMock.hpp
     FileSystemStub.cpp

--- a/services/ble/CMakeLists.txt
+++ b/services/ble/CMakeLists.txt
@@ -24,6 +24,9 @@ target_sources(services.ble PRIVATE
     BondBlobPersistence.hpp
     BondStorageSynchronizer.cpp
     BondStorageSynchronizer.hpp
+    ClaimingGattClientAdapter.cpp
+    ClaimingGattClientAdapter.hpp
+    Dtm.hpp
     Gap.cpp
     Gap.hpp
     GapPeripheralIntervalDecorator.cpp
@@ -32,8 +35,6 @@ target_sources(services.ble PRIVATE
     Gatt.hpp
     GattClient.cpp
     GattClient.hpp
-    ClaimingGattClientAdapter.cpp
-    ClaimingGattClientAdapter.hpp
     GattServer.cpp
     GattServer.hpp
     GattServerCharacteristicImpl.cpp

--- a/services/ble/Dtm.hpp
+++ b/services/ble/Dtm.hpp
@@ -9,10 +9,13 @@ namespace services
     class Dtm
     {
     public:
+    protected:
         Dtm() = default;
+        ~Dtm() = default;
+
+    public:
         Dtm(const Dtm& other) = delete;
         Dtm& operator=(const Dtm& other) = delete;
-        ~Dtm() = default;
 
         virtual bool StartTone(uint8_t rfChannel, uint8_t offset) = 0;
         virtual bool StopTone() = 0;

--- a/services/ble/Dtm.hpp
+++ b/services/ble/Dtm.hpp
@@ -9,7 +9,6 @@ namespace services
 {
     class Dtm
     {
-    public:
     protected:
         Dtm() = default;
         ~Dtm() = default;

--- a/services/ble/Dtm.hpp
+++ b/services/ble/Dtm.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVICES_BLE_DTM_HPP
 #define SERVICES_BLE_DTM_HPP
 
+#include "infra/util/Function.hpp"
 #include <cstdint>
 #include <optional>
 
@@ -22,7 +23,7 @@ namespace services
         virtual bool SetTxPowerLevel(uint8_t txPower) = 0;
         virtual bool StartRxTest(uint8_t frequency, uint8_t phy) = 0;
         virtual bool StartTxTest(uint8_t frequency, uint8_t dataLength, uint8_t packetPayload, uint8_t phy) = 0;
-        virtual std::optional<uint16_t> StopTest() = 0; // In case of error returns std::nullopt.
+        virtual void StopTest(const infra::Function<void(std::optional<uint16_t>)>& onStopped) = 0; // In case of error returns std::nullopt.
     };
 }
 

--- a/services/ble/Dtm.hpp
+++ b/services/ble/Dtm.hpp
@@ -1,18 +1,18 @@
-#ifndef HAL_INTERFACE_BLE_DTM_HPP
-#define HAL_INTERFACE_BLE_DTM_HPP
+#ifndef SERVICES_BLE_DTM_HPP
+#define SERVICES_BLE_DTM_HPP
 
 #include <cstdint>
 #include <optional>
 
-namespace hal
+namespace services
 {
-    class BleDtm
+    class Dtm
     {
     public:
-        BleDtm() = default;
-        BleDtm(const BleDtm& other) = delete;
-        BleDtm& operator=(const BleDtm& other) = delete;
-        ~BleDtm() = default;
+        Dtm() = default;
+        Dtm(const Dtm& other) = delete;
+        Dtm& operator=(const Dtm& other) = delete;
+        ~Dtm() = default;
 
         virtual bool StartTone(uint8_t rfChannel, uint8_t offset) = 0;
         virtual bool StopTone() = 0;

--- a/services/ble/test_doubles/CMakeLists.txt
+++ b/services/ble/test_doubles/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(services.ble_test_doubles INTERFACE
 target_sources(services.ble_test_doubles PRIVATE
     BondStorageSynchronizerMock.hpp
     ClaimingGattClientAdapterMock.hpp
+    DtmMock.hpp
     GapCentralMock.hpp
     GapCentralObserverMock.hpp
     GapPeripheralMock.hpp

--- a/services/ble/test_doubles/DtmMock.hpp
+++ b/services/ble/test_doubles/DtmMock.hpp
@@ -1,6 +1,7 @@
 #ifndef BLE_TEST_DOUBLES_DTM_MOCK_HPP
 #define BLE_TEST_DOUBLES_DTM_MOCK_HPP
 
+#include "infra/util/Function.hpp"
 #include "services/ble/Dtm.hpp"
 #include "gmock/gmock.h"
 #include <cstdint>
@@ -17,7 +18,7 @@ namespace services
         MOCK_METHOD(bool, SetTxPowerLevel, (uint8_t txPower), (override));
         MOCK_METHOD(bool, StartRxTest, (uint8_t frequency, uint8_t phy), (override));
         MOCK_METHOD(bool, StartTxTest, (uint8_t frequency, uint8_t dataLength, uint8_t packetPayload, uint8_t phy), (override));
-        MOCK_METHOD(std::optional<uint16_t>, StopTest, (), (override));
+        MOCK_METHOD(void, StopTest, (const infra::Function<void(std::optional<uint16_t>)>&), (override));
     };
 }
 

--- a/services/ble/test_doubles/DtmMock.hpp
+++ b/services/ble/test_doubles/DtmMock.hpp
@@ -1,15 +1,15 @@
-#ifndef HAL_BLE_DTM_MOCK_HPP
-#define HAL_BLE_DTM_MOCK_HPP
+#ifndef BLE_TEST_DOUBLES_DTM_MOCK_HPP
+#define BLE_TEST_DOUBLES_DTM_MOCK_HPP
 
-#include "hal/interfaces/BleDtm.hpp"
+#include "services/ble/Dtm.hpp"
 #include "gmock/gmock.h"
 #include <cstdint>
 #include <optional>
 
-namespace hal
+namespace services
 {
-    class BleDtmMock
-        : public BleDtm
+    class DtmMock
+        : public Dtm
     {
     public:
         MOCK_METHOD(bool, StartTone, (uint8_t rfChannel, uint8_t offset), (override));


### PR DESCRIPTION
BleDTm is not a HAL interface, but a service interface. Therefor its moved to services/ble and renamed from BleDtm to just Dtm