### PR TITLE
fix: increase host network event dispatcher capacity to 1024

### DIFF
--- a/services/network_instantiations/EventDispatcherWithNetworkBsd.hpp
+++ b/services/network_instantiations/EventDispatcherWithNetworkBsd.hpp
@@ -9,7 +9,7 @@
 namespace services
 {
     class EventDispatcherWithNetwork
-        : public infra::EventDispatcherWithWeakPtr::WithSize<50>
+        : public infra::EventDispatcherWithWeakPtr::WithSize<1024>
         , public ConnectionFactory
         , public DatagramFactory
         , public Multicast

--- a/services/network_instantiations/EventDispatcherWithNetworkWin.hpp
+++ b/services/network_instantiations/EventDispatcherWithNetworkWin.hpp
@@ -8,7 +8,7 @@
 namespace services
 {
     class EventDispatcherWithNetwork
-        : public infra::EventDispatcherWithWeakPtr::WithSize<50>
+        : public infra::EventDispatcherWithWeakPtr::WithSize<1024>
         , public ConnectionFactory
         , public DatagramFactoryWithLocalIpBinding
         , public Multicast


### PR DESCRIPTION
The BSD/Windows network event dispatcher schedules one action per ready socket event. When the host consumer is briefly stalled while many events arrive at once, the fixed 50-slot ring overflows and trips the scheduling assert in EventDispatcherWithWeakPtr. Raise the capacity to 1024 so such bursts are absorbed; host builds have ample memory for the larger ring.