### PR TITLE
docs: note in Gap.proto that addresses are in little endian

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -13,7 +13,7 @@ option java_outer_classname = "GapProto";
 message Address
 {
     // A 48-bit Bluetooth device address, as defined in Bluetooth Core Specification v6.3, Vol 6, Part B, Section 1.3
-    // Encoded as 6 bytes, least-significant byte first (little-endian).
+    // Encoded as a 6-byte Bluetooth device address in least-significant-octet-first order.
     // Example: "AA:BB:CC:DD:EE:FF" is represented as { 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA }.
     bytes address = 1 [(bytes_size) = 6];
 }

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -13,7 +13,8 @@ option java_outer_classname = "GapProto";
 message Address
 {
     // A 48-bit Bluetooth device address, as defined in Bluetooth Core Specification v6.3, Vol 6, Part B, Section 1.3
-    // The address is represented as a 6-byte array in little-endian order.
+    // Encoded as 6 bytes, least-significant byte first (little-endian).
+    // Example: "AA:BB:CC:DD:EE:FF" is represented as { 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA }.
     bytes address = 1 [(bytes_size) = 6];
 }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -13,6 +13,7 @@ option java_outer_classname = "GapProto";
 message Address
 {
     // A 48-bit Bluetooth device address, as defined in Bluetooth Core Specification v6.3, Vol 6, Part B, Section 1.3
+    // The address is represented as a 6-byte array in little-endian order.
     bytes address = 1 [(bytes_size) = 6];
 }
 


### PR DESCRIPTION
A customer struggled to use the Echo interface because they used the wrong endianness by accident. This note should hopefully help customers in the future. And it does seem like our stacks use little endian, and we never swap these addresses around.