### PR TITLE
chore: reduce size of traced GapAddressType string

### DIFF
--- a/services/ble/Gap.cpp
+++ b/services/ble/Gap.cpp
@@ -433,9 +433,9 @@ namespace infra
     TextOutputStream& operator<<(TextOutputStream& stream, const services::GapDeviceAddressType& addressType)
     {
         if (addressType == services::GapDeviceAddressType::publicAddress)
-            stream << "Public Device Address";
+            stream << "Public";
         else if (addressType == services::GapDeviceAddressType::randomAddress)
-            stream << "Random Device Address";
+            stream << "Random";
         else
             LOG_AND_ABORT_ENUM(addressType);
 

--- a/services/ble/test/TestGapCentral.cpp
+++ b/services/ble/test/TestGapCentral.cpp
@@ -255,7 +255,7 @@ namespace services
         auto eventAddressTypeRandomDevice = services::GapDeviceAddressType::randomAddress;
         stream << eventAddressTypePublicDevice << " " << eventAddressTypeRandomDevice;
 
-        EXPECT_EQ("Public Device Address Random Device Address", stream.Storage());
+        EXPECT_EQ("Public Random", stream.Storage());
     }
 
     TEST(GapInsertionOperatorStateTest, state_overload_operator)


### PR DESCRIPTION
The fact that it's an `Device Address` is implied by the context of the trace, and is not need to be stated again. Similarly when tracing `GapState` we trace `Standby` and not `Standby Gap State`. And the reason to remove to reduce size of traces to allow the MCU to get back to important work. And there are instances where many tracers might be traced in a short burst (like device discovery).

For example, some of our code currently prints the following, which is excessive.
```
DeviceDiscovered [address: 05:4c:a7:1b:3d:22, type: Random Device Address, rssi: -78, reportType: 3]
```