### PR TITLE
feat: trace binary data as ascii in http client

### DIFF
--- a/services/network/TracingHttpClientImpl.cpp
+++ b/services/network/TracingHttpClientImpl.cpp
@@ -21,7 +21,7 @@ namespace services
         infra::DataInputStream::WithErrorPolicy stream(*reader);
         auto marker = reader->ConstructSaveMarker();
         while (!stream.Empty())
-            tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
+            tracer.Trace() << infra::AsAscii(stream.ContiguousRange());
 
         reader->Rewind(marker);
         HttpClientImpl::BodyReaderAvailable(std::move(reader));
@@ -74,7 +74,7 @@ namespace services
         infra::DataInputStream::WithErrorPolicy stream(*reader);
         auto marker = reader->ConstructSaveMarker();
         while (!stream.Empty())
-            tracer.Trace() << infra::ByteRangeAsString(stream.ContiguousRange());
+            tracer.Trace() << infra::AsAscii(stream.ContiguousRange());
 
         reader->Rewind(marker);
         HttpClientImplWithRedirection::BodyReaderAvailable(std::move(reader));

--- a/services/network/TracingHttpClientImpl.hpp
+++ b/services/network/TracingHttpClientImpl.hpp
@@ -35,7 +35,7 @@ namespace services
 
         private:
             infra::SharedPtr<infra::StreamWriter> writer;
-            TracingStreamWriter tracingWriter;
+            TracingAsciiStreamWriter tracingWriter;
         };
 
     private:
@@ -78,7 +78,7 @@ namespace services
 
         private:
             infra::SharedPtr<infra::StreamWriter> writer;
-            TracingStreamWriter tracingWriter;
+            TracingAsciiStreamWriter tracingWriter;
         };
 
     private:

--- a/services/tracer/TracingOutputStream.cpp
+++ b/services/tracer/TracingOutputStream.cpp
@@ -49,7 +49,7 @@ namespace services
         , tracer(tracer)
     {}
 
-    void TracingAsciiStreamWriter::TracingAsciiStreamWriter::Insert(infra::ConstByteRange range, infra::StreamErrorPolicy& errorPolicy)
+    void TracingAsciiStreamWriter::Insert(infra::ConstByteRange range, infra::StreamErrorPolicy& errorPolicy)
     {
         writer.Insert(range, errorPolicy);
         tracer.Continue() << infra::AsAscii(range);

--- a/services/tracer/TracingOutputStream.cpp
+++ b/services/tracer/TracingOutputStream.cpp
@@ -43,7 +43,15 @@ namespace services
         return writer.Overwrite(marker);
     }
 
-    TracingOutputStream::TracingOutputStream(infra::DataOutputStream& stream, services::Tracer& tracer)
-        : infra::DataOutputStream::WithWriter<TracingStreamWriter>(stream.Writer(), tracer)
+    TracingAsciiStreamWriter::TracingAsciiStreamWriter(infra::StreamWriter& writer, services::Tracer& tracer)
+        : TracingStreamWriter(writer, tracer)
+        , writer(writer)
+        , tracer(tracer)
     {}
+
+    void TracingAsciiStreamWriter::TracingAsciiStreamWriter::Insert(infra::ConstByteRange range, infra::StreamErrorPolicy& errorPolicy)
+    {
+        writer.Insert(range, errorPolicy);
+        tracer.Continue() << infra::AsAscii(range);
+    }
 }

--- a/services/tracer/TracingOutputStream.hpp
+++ b/services/tracer/TracingOutputStream.hpp
@@ -26,14 +26,33 @@ namespace services
         services::Tracer& tracer;
     };
 
-    class TracingOutputStream
-        : public infra::DataOutputStream::WithWriter<TracingStreamWriter>
+    class TracingAsciiStreamWriter
+        : public TracingStreamWriter
     {
     public:
-        TracingOutputStream(infra::DataOutputStream& stream, services::Tracer& tracer);
+        TracingAsciiStreamWriter(infra::StreamWriter& writer, services::Tracer& tracer);
 
-        using DataOutputStream::WithWriter<TracingStreamWriter>::WithWriter;
+        void Insert(infra::ConstByteRange range, infra::StreamErrorPolicy& errorPolicy) override;
+
+    private:
+        infra::StreamWriter& writer;
+        services::Tracer& tracer;
     };
+
+    template<class Writer>
+    class TracingOutputStreamBase
+        : public infra::DataOutputStream::WithWriter<Writer>
+    {
+    public:
+        TracingOutputStreamBase(infra::DataOutputStream& stream, services::Tracer& tracer)
+            : infra::DataOutputStream::WithWriter<Writer>(stream.Writer(), tracer)
+        {}
+
+        using infra::DataOutputStream::WithWriter<Writer>::WithWriter;
+    };
+
+    using TracingOutputStream = TracingOutputStreamBase<TracingStreamWriter>;
+    using TracingAsciiOutputStream = TracingOutputStreamBase<TracingAsciiStreamWriter>;
 }
 
 #endif


### PR DESCRIPTION
## Pull request overview

This PR updates HTTP client tracing so binary payloads are logged as ASCII-safe output, improving readability and preventing issues when tracing non-text/binary data.

**Changes:**
- Introduces `TracingAsciiStreamWriter` and adds `TracingAsciiOutputStream` as a variant that traces written bytes via `infra::AsAscii(...)`.
- Updates `TracingHttpClientImpl` send-stream tracing to use `TracingAsciiStreamWriter` for outgoing data.
- Updates HTTP response body tracing to use `infra::AsAscii(...)` instead of `infra::ByteRangeAsString(...)`.