### PR TITLE
docs(echo): mention that GapCentral Device Discovery does not filter for duplicates

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -495,8 +495,8 @@ service GapCentral
 
     // Allowed states: standby
     // Starts scanning for advertising peripheral devices until Standby is called.
-    // Discovered devices will be reported via GapCentralResponse.DeviceDiscovered.
-    // It's recommended to add a DeviceDiscoveryFilter, otherwise devices might be missed due to too many being discovered.
+    // Each discovered advertising report that matches the filter will be reported via GapCentralResponse.DeviceDiscovered.
+    // It's recommended to add a DeviceDiscoveryFilter, otherwise reports might be dropped due to too many devices being found.
     // Results in GapCentralResponse.CurrentState with state scanning
     rpc StartDeviceDiscovery(Nothing) returns (Nothing) { option (method_id) = 3; }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -495,7 +495,7 @@ service GapCentral
 
     // Allowed states: standby
     // Starts scanning for advertising peripheral devices until Standby is called.
-    // Each discovered advertising report that matches the filter will be reported via GapCentralResponse.DeviceDiscovered.
+    // Each advertising report that matches the filter will be reported via GapCentralResponse.DeviceDiscovered.
     // It's recommended to add a DeviceDiscoveryFilter, otherwise reports might be dropped due to too many devices being found.
     // Results in GapCentralResponse.CurrentState with state scanning
     rpc StartDeviceDiscovery(Nothing) returns (Nothing) { option (method_id) = 3; }


### PR DESCRIPTION
This is important information for customers using this interface, and was previously dependent on the implementation. Currently, all our supported centrals will behave like this, once this code reaches our upstream controllers.