### PR TITLE
fix: http path and headers larger than available stream size

### DIFF
--- a/services/network/Http.cpp
+++ b/services/network/Http.cpp
@@ -39,6 +39,29 @@ namespace services
 
             return schemeEnd;
         }
+
+        void WriteFragment(infra::TextOutputStream& stream, infra::BoundedConstString fragment, std::size_t& skip, std::size_t& written)
+        {
+            if (skip >= fragment.size())
+                skip -= fragment.size();
+            else
+            {
+                fragment = fragment.substr(skip);
+                skip = 0;
+
+                auto amount = std::min(stream.Available(), fragment.size());
+                stream << fragment.substr(0, amount);
+                written += amount;
+            }
+        }
+
+        void WriteHeaderLine(infra::TextOutputStream& stream, const HttpHeader& header, std::size_t& skip, std::size_t& written)
+        {
+            WriteFragment(stream, header.Field(), skip, written);
+            WriteFragment(stream, separator, skip, written);
+            WriteFragment(stream, header.Value(), skip, written);
+            WriteFragment(stream, crlf, skip, written);
+        }
     }
 
     HttpHeader::HttpHeader(infra::BoundedConstString field, infra::BoundedConstString value)
@@ -153,47 +176,24 @@ namespace services
     {
         std::size_t written = 0;
 
-        auto writeFragment = [&stream, &skip, &written](infra::BoundedConstString fragment)
-        {
-            if (skip >= fragment.size())
-                skip -= fragment.size();
-            else
-            {
-                fragment = fragment.substr(skip);
-                skip = 0;
-
-                auto amount = std::min(stream.Available(), fragment.size());
-                stream << fragment.substr(0, amount);
-                written += amount;
-            }
-        };
-
-        auto writeHeaderLine = [&writeFragment](const HttpHeader& header)
-        {
-            writeFragment(header.Field());
-            writeFragment(separator);
-            writeFragment(header.Value());
-            writeFragment(crlf);
-        };
-
-        writeFragment(HttpVerbToString(verb));
-        writeFragment(sp);
-        writeFragment(requestTarget);
-        writeFragment(sp);
-        writeFragment(httpVersion);
-        writeFragment(crlf);
+        WriteFragment(stream, HttpVerbToString(verb), skip, written);
+        WriteFragment(stream, sp, skip, written);
+        WriteFragment(stream, requestTarget, skip, written);
+        WriteFragment(stream, sp, skip, written);
+        WriteFragment(stream, httpVersion, skip, written);
+        WriteFragment(stream, crlf, skip, written);
 
         for (const auto& header : headers)
-            writeHeaderLine(header);
+            WriteHeaderLine(stream, header, skip, written);
 
-        writeHeaderLine(hostHeader);
+        WriteHeaderLine(stream, hostHeader, skip, written);
 
         if (contentLengthHeader)
-            writeHeaderLine(*contentLengthHeader);
+            WriteHeaderLine(stream, *contentLengthHeader, skip, written);
         if (chunked)
-            writeHeaderLine(HttpHeader{ "Transfer-Encoding", "chunked" });
+            WriteHeaderLine(stream, HttpHeader{ "Transfer-Encoding", "chunked" }, skip, written);
 
-        writeFragment(crlf);
+        WriteFragment(stream, crlf, skip, written);
 
         return written;
     }

--- a/services/network/Http.cpp
+++ b/services/network/Http.cpp
@@ -101,40 +101,24 @@ namespace services
 
     std::size_t HttpRequestFormatter::Size() const
     {
-        if (!sentHeader)
-            return HttpVerbToString(verb).size() + requestTarget.size() + httpVersion.size() + HeadersSize() + (2 * crlf.size()) + (2 * sp.size()) + content.size();
-        else
-            return content.size();
+        return (HeaderBlockSize() - headerPosition) + content.size();
     }
 
     std::size_t HttpRequestFormatter::Write(infra::TextOutputStream stream) const
     {
-        if (!sentHeader)
-        {
-            stream << verb << sp << requestTarget << sp << httpVersion << crlf;
-
-            for (const auto& header : headers)
-                stream << header << crlf;
-
-            stream << hostHeader << crlf;
-
-            if (contentLengthHeader)
-                stream << *contentLengthHeader << crlf;
-            if (chunked)
-                stream << HttpHeader{ "Transfer-Encoding", "chunked" } << crlf;
-
-            stream << crlf;
-        }
+        auto written = WriteHeader(stream, headerPosition);
 
         auto available = std::min(stream.Available(), content.size());
         stream << content.substr(0, available);
-        return available;
+
+        return written + available;
     }
 
     void HttpRequestFormatter::Consume(std::size_t amount)
     {
-        sentHeader = true;
-        content = content.substr(amount);
+        auto headerAmount = std::min(amount, HeaderBlockSize() - headerPosition);
+        headerPosition += headerAmount;
+        content = content.substr(amount - headerAmount);
     }
 
     void HttpRequestFormatter::AddContentLength(std::size_t size)
@@ -158,6 +142,60 @@ namespace services
         headerSize += hostHeader.Size() + crlf.size();
 
         return headerSize;
+    }
+
+    std::size_t HttpRequestFormatter::HeaderBlockSize() const
+    {
+        return HttpVerbToString(verb).size() + requestTarget.size() + httpVersion.size() + HeadersSize() + (2 * crlf.size()) + (2 * sp.size());
+    }
+
+    std::size_t HttpRequestFormatter::WriteHeader(infra::TextOutputStream& stream, std::size_t skip) const
+    {
+        std::size_t written = 0;
+
+        auto writeFragment = [&stream, &skip, &written](infra::BoundedConstString fragment)
+        {
+            if (skip >= fragment.size())
+                skip -= fragment.size();
+            else
+            {
+                fragment = fragment.substr(skip);
+                skip = 0;
+
+                auto amount = std::min(stream.Available(), fragment.size());
+                stream << fragment.substr(0, amount);
+                written += amount;
+            }
+        };
+
+        auto writeHeaderLine = [&writeFragment](const HttpHeader& header)
+        {
+            writeFragment(header.Field());
+            writeFragment(separator);
+            writeFragment(header.Value());
+            writeFragment(crlf);
+        };
+
+        writeFragment(HttpVerbToString(verb));
+        writeFragment(sp);
+        writeFragment(requestTarget);
+        writeFragment(sp);
+        writeFragment(httpVersion);
+        writeFragment(crlf);
+
+        for (const auto& header : headers)
+            writeHeaderLine(header);
+
+        writeHeaderLine(hostHeader);
+
+        if (contentLengthHeader)
+            writeHeaderLine(*contentLengthHeader);
+        if (chunked)
+            writeHeaderLine(HttpHeader{ "Transfer-Encoding", "chunked" });
+
+        writeFragment(crlf);
+
+        return written;
     }
 
     HttpHeaderParser::HttpHeaderParser(HttpHeaderParserObserver& observer)

--- a/services/network/Http.cpp
+++ b/services/network/Http.cpp
@@ -62,6 +62,21 @@ namespace services
             WriteFragment(stream, header.Value(), skip, written);
             WriteFragment(stream, crlf, skip, written);
         }
+
+        infra::BoundedString::WithStorage<8> ContentLengthValue(std::size_t size)
+        {
+            infra::BoundedString::WithStorage<8> value;
+            infra::StringOutputStream stream(value);
+            stream << size;
+            return value;
+        }
+
+        std::optional<HttpHeader> MakeContentLengthHeader(bool present, infra::BoundedConstString value)
+        {
+            if (present)
+                return HttpHeader{ "Content-Length", value };
+            return std::nullopt;
+        }
     }
 
     HttpHeader::HttpHeader(infra::BoundedConstString field, infra::BoundedConstString value)
@@ -98,21 +113,20 @@ namespace services
         : verb(verb)
         , requestTarget(requestTarget.empty() ? "/" : requestTarget)
         , content(content)
+        , contentLength(content.empty() ? infra::BoundedString::WithStorage<8>{} : ContentLengthValue(content.size()))
+        , contentLengthHeader(MakeContentLengthHeader(!content.empty(), contentLength))
         , hostHeader("Host", hostname)
         , headers(headers)
-    {
-        if (!content.empty())
-            AddContentLength(content.size());
-    }
+    {}
 
     HttpRequestFormatter::HttpRequestFormatter(HttpVerb verb, infra::BoundedConstString hostname, infra::BoundedConstString requestTarget, std::size_t contentSize, const HttpHeaders headers)
         : verb(verb)
         , requestTarget(requestTarget.empty() ? "/" : requestTarget)
+        , contentLength(ContentLengthValue(contentSize))
+        , contentLengthHeader(MakeContentLengthHeader(true, contentLength))
         , hostHeader("Host", hostname)
         , headers(headers)
-    {
-        AddContentLength(contentSize);
-    }
+    {}
 
     HttpRequestFormatter::HttpRequestFormatter(HttpVerb verb, infra::BoundedConstString hostname, infra::BoundedConstString requestTarget, const HttpHeaders headers, Chunked)
         : verb(verb)
@@ -124,7 +138,7 @@ namespace services
 
     std::size_t HttpRequestFormatter::Size() const
     {
-        return (HeaderBlockSize() - headerPosition) + content.size();
+        return (headerBlockSize - headerPosition) + content.size();
     }
 
     std::size_t HttpRequestFormatter::Write(infra::TextOutputStream stream) const
@@ -139,16 +153,9 @@ namespace services
 
     void HttpRequestFormatter::Consume(std::size_t amount)
     {
-        auto headerAmount = std::min(amount, HeaderBlockSize() - headerPosition);
+        auto headerAmount = std::min(amount, headerBlockSize - headerPosition);
         headerPosition += headerAmount;
         content = content.substr(amount - headerAmount);
-    }
-
-    void HttpRequestFormatter::AddContentLength(std::size_t size)
-    {
-        infra::StringOutputStream contentLengthStream(contentLength);
-        contentLengthStream << size;
-        contentLengthHeader.emplace("Content-Length", contentLength);
     }
 
     std::size_t HttpRequestFormatter::HeadersSize() const

--- a/services/network/Http.hpp
+++ b/services/network/Http.hpp
@@ -132,6 +132,8 @@ namespace services
     private:
         void AddContentLength(std::size_t size);
         std::size_t HeadersSize() const;
+        std::size_t HeaderBlockSize() const;
+        std::size_t WriteHeader(infra::TextOutputStream& stream, std::size_t skip) const;
 
     private:
         HttpVerb verb;
@@ -142,7 +144,7 @@ namespace services
         HttpHeader hostHeader;
         const HttpHeaders headers;
         bool chunked{ false };
-        bool sentHeader{ false };
+        std::size_t headerPosition = 0;
     };
 
     class HttpHeaderParserObserver

--- a/services/network/Http.hpp
+++ b/services/network/Http.hpp
@@ -130,7 +130,6 @@ namespace services
         void Consume(std::size_t amount);
 
     private:
-        void AddContentLength(std::size_t size);
         std::size_t HeadersSize() const;
         std::size_t HeaderBlockSize() const;
         std::size_t WriteHeader(infra::TextOutputStream& stream, std::size_t skip) const;
@@ -145,6 +144,7 @@ namespace services
         const HttpHeaders headers;
         bool chunked{ false };
         std::size_t headerPosition = 0;
+        std::size_t headerBlockSize = HeaderBlockSize();
     };
 
     class HttpHeaderParserObserver

--- a/services/network/HttpClientImpl.cpp
+++ b/services/network/HttpClientImpl.cpp
@@ -332,7 +332,7 @@ namespace services
     void HttpClientImpl::ExecuteRequest(HttpVerb verb, infra::BoundedConstString requestTarget, const HttpHeaders headers)
     {
         request.emplace(verb, hostname, requestTarget, headers);
-        ConnectionObserver::Subject().RequestSendStream(request->Size());
+        ConnectionObserver::Subject().RequestSendStream(std::min(request->Size(), ConnectionObserver::Subject().MaxSendStreamSize()));
     }
 
     void HttpClientImpl::ExecuteRequestWithContent(HttpVerb verb, infra::BoundedConstString requestTarget, infra::BoundedConstString content, const HttpHeaders headers)
@@ -345,14 +345,14 @@ namespace services
     {
         request.emplace(verb, hostname, requestTarget, contentSize, headers);
         nextState.Emplace<SendingStateForwardDefinedSizeStream>(*this, contentSize);
-        ConnectionObserver::Subject().RequestSendStream(request->Size());
+        ConnectionObserver::Subject().RequestSendStream(std::min(request->Size(), ConnectionObserver::Subject().MaxSendStreamSize()));
     }
 
     void HttpClientImpl::ExecuteRequestWithContent(HttpVerb verb, infra::BoundedConstString requestTarget, const HttpHeaders headers)
     {
         request.emplace(verb, hostname, requestTarget, headers, chunked);
         nextState.Emplace<SendingStateForwardSendStream>(*this);
-        ConnectionObserver::Subject().RequestSendStream(request->Size());
+        ConnectionObserver::Subject().RequestSendStream(std::min(request->Size(), ConnectionObserver::Subject().MaxSendStreamSize()));
     }
 
     void HttpClientImpl::AbortAndDestroy()

--- a/services/network/test/TestHttpClient.cpp
+++ b/services/network/test/TestHttpClient.cpp
@@ -398,6 +398,30 @@ TEST_F(HttpClientTest, large_Put_request_is_executed)
     EXPECT_EQ("PUT /api/thing HTTP/1.1\r\nHost:localhost\r\nContent-Length:200\r\n\r\n01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", connection.SentDataAsString());
 }
 
+TEST_F(HttpClientTest, header_larger_than_send_stream_is_split_across_multiple_send_streams)
+{
+    connection.maxSendStreamSize = 20;
+
+    Connect();
+    client.Subject().Get("/api/thing");
+
+    ExecuteAllActions();
+    EXPECT_EQ("GET /api/thing HTTP/1.1\r\nHost:localhost\r\n\r\n", connection.SentDataAsString());
+}
+
+TEST_F(HttpClientTest, request_with_headers_larger_than_send_stream_is_executed)
+{
+    connection.maxSendStreamSize = 20;
+
+    Connect();
+    std::array<services::HttpHeader, 2> headers{ services::HttpHeader{ "Authorization", "Basic Y29ubmVjdGl2aXR5OmlzY29vbA==" }, { "Connection", "close" } };
+
+    client.Subject().Get("/api/thing", headers);
+
+    ExecuteAllActions();
+    EXPECT_EQ("GET /api/thing HTTP/1.1\r\nAuthorization:Basic Y29ubmVjdGl2aXR5OmlzY29vbA==\r\nConnection:close\r\nHost:localhost\r\n\r\n", connection.SentDataAsString());
+}
+
 TEST_F(HttpClientTest, Patch_request_is_executed)
 {
     Connect();


### PR DESCRIPTION
This PR fixes HTTP request transmission when the formatted request line + headers exceed the maximum send stream size provided by the connection, ensuring headers (and long request targets) are emitted correctly across multiple send-stream allocations.

**Changes:**
- Cap initial `RequestSendStream()` sizes to `MaxSendStreamSize()` in `HttpClientImpl`, avoiding oversize send-stream requests.
- Make `HttpRequestFormatter` able to write/consume headers incrementally via a running `headerPosition`, enabling header splitting across multiple send streams.
- Add tests that cover headers exceeding the send stream size (including custom headers).