### PR TITLE
feat: ensure GapPeripheral adheres to contract defined in gap.proto

### DIFF
--- a/services/ble/CMakeLists.txt
+++ b/services/ble/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(services.ble PRIVATE
     Gap.hpp
     GapPeripheralIntervalDecorator.cpp
     GapPeripheralIntervalDecorator.hpp
+    GapPeripheralStateGuardDecorator.cpp
+    GapPeripheralStateGuardDecorator.hpp
     Gatt.cpp
     Gatt.hpp
     GattClient.cpp

--- a/services/ble/GapPeripheralStateGuardDecorator.cpp
+++ b/services/ble/GapPeripheralStateGuardDecorator.cpp
@@ -1,0 +1,71 @@
+#include "services/ble/GapPeripheralStateGuardDecorator.hpp"
+#include "infra/util/ReallyAssert.hpp"
+
+namespace services
+{
+    GapPeripheralStateGuardDecorator::GapPeripheralStateGuardDecorator(GapPeripheral& peripheral, GapPairing& pairing, GapBonding& bonding)
+        : GapPeripheralDecorator(peripheral)
+        , GapPairingDecorator(pairing)
+        , GapBondingDecorator(bonding)
+    {}
+
+    void GapPeripheralStateGuardDecorator::StateChanged(GapState newState)
+    {
+        state = newState;
+        GapPeripheralDecorator::StateChanged(newState);
+    }
+
+    void GapPeripheralStateGuardDecorator::Advertise(GapAdvertisementType type, AdvertisementIntervalMultiplier multiplier)
+    {
+        really_assert(state == GapState::standby);
+        GapPeripheralDecorator::Advertise(type, multiplier);
+    }
+
+    void GapPeripheralStateGuardDecorator::SetAdvertisementData(infra::ConstByteRange data)
+    {
+        really_assert(state == GapState::standby);
+        GapPeripheralDecorator::SetAdvertisementData(data);
+    }
+
+    void GapPeripheralStateGuardDecorator::SetScanResponseData(infra::ConstByteRange data)
+    {
+        really_assert(state == GapState::standby);
+        GapPeripheralDecorator::SetScanResponseData(data);
+    }
+
+    void GapPeripheralStateGuardDecorator::AllowPairing(bool allow)
+    {
+        really_assert(state == GapState::standby);
+        GapPairingDecorator::AllowPairing(allow);
+    }
+
+    void GapPeripheralStateGuardDecorator::SetSecurityMode(SecurityMode mode, SecurityLevel level)
+    {
+        really_assert(state == GapState::standby);
+        GapPairingDecorator::SetSecurityMode(mode, level);
+    }
+
+    void GapPeripheralStateGuardDecorator::SetIoCapabilities(IoCapabilities caps)
+    {
+        really_assert(state == GapState::standby);
+        GapPairingDecorator::SetIoCapabilities(caps);
+    }
+
+    void GapPeripheralStateGuardDecorator::NumericComparisonConfirm(bool accept)
+    {
+        really_assert(state == GapState::standby || state == GapState::connected);
+        GapPairingDecorator::NumericComparisonConfirm(accept);
+    }
+
+    void GapPeripheralStateGuardDecorator::RemoveAllBonds()
+    {
+        really_assert(state == GapState::standby);
+        GapBondingDecorator::RemoveAllBonds();
+    }
+
+    void GapPeripheralStateGuardDecorator::RemoveOldestBond()
+    {
+        really_assert(state == GapState::standby);
+        GapBondingDecorator::RemoveOldestBond();
+    }
+}

--- a/services/ble/GapPeripheralStateGuardDecorator.hpp
+++ b/services/ble/GapPeripheralStateGuardDecorator.hpp
@@ -1,0 +1,37 @@
+#ifndef SERVICES_GAP_PERIPHERAL_STATE_GUARD_DECORATOR_HPP
+#define SERVICES_GAP_PERIPHERAL_STATE_GUARD_DECORATOR_HPP
+
+#include "services/ble/Gap.hpp"
+
+namespace services
+{
+    class GapPeripheralStateGuardDecorator
+        : public GapPeripheralDecorator
+        , public GapPairingDecorator
+        , public GapBondingDecorator
+    {
+    public:
+        GapPeripheralStateGuardDecorator(GapPeripheral& peripheral, GapPairing& pairing, GapBonding& bonding);
+
+        // GapPeripheralDecorator overrides
+        void StateChanged(GapState newState) override;
+        void Advertise(GapAdvertisementType type, AdvertisementIntervalMultiplier multiplier) override;
+        void SetAdvertisementData(infra::ConstByteRange data) override;
+        void SetScanResponseData(infra::ConstByteRange data) override;
+
+        // GapPairingDecorator overrides
+        void AllowPairing(bool allow) override;
+        void SetSecurityMode(SecurityMode mode, SecurityLevel level) override;
+        void SetIoCapabilities(IoCapabilities caps) override;
+        void NumericComparisonConfirm(bool accept) override;
+
+        // GapBondingDecorator overrides
+        void RemoveAllBonds() override;
+        void RemoveOldestBond() override;
+
+    private:
+        GapState state = GapState::standby;
+    };
+}
+
+#endif

--- a/services/ble/test/CMakeLists.txt
+++ b/services/ble/test/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(services.ble_test PRIVATE
     TestGapPairing.cpp
     TestGapPeripheral.cpp
     TestGapPeripheralIntervalDecorator.cpp
+    TestGapPeripheralStateGuardDecorator.cpp
     TestGatt.cpp
     TestGattClient.cpp
     TestClaimingGattClientAdapter.cpp

--- a/services/ble/test/TestGapPeripheralStateGuardDecorator.cpp
+++ b/services/ble/test/TestGapPeripheralStateGuardDecorator.cpp
@@ -1,0 +1,207 @@
+#include "infra/util/test_helper/MemoryRangeMatcher.hpp"
+#include "services/ble/GapPeripheralStateGuardDecorator.hpp"
+#include "services/ble/test_doubles/GapBondingMock.hpp"
+#include "services/ble/test_doubles/GapBondingObserverMock.hpp"
+#include "services/ble/test_doubles/GapPairingMock.hpp"
+#include "services/ble/test_doubles/GapPairingObserverMock.hpp"
+#include "services/ble/test_doubles/GapPeripheralMock.hpp"
+#include "services/ble/test_doubles/GapPeripheralObserverMock.hpp"
+#include "gmock/gmock.h"
+
+class GapPeripheralStateGuardDecoratorTest
+    : public testing::Test
+{
+public:
+    void SetState(services::GapState newState)
+    {
+        EXPECT_CALL(peripheralObserver, StateChanged(newState));
+        stateGuard.StateChanged(newState);
+    }
+
+    testing::StrictMock<services::GapPeripheralMock> peripheral;
+    testing::StrictMock<services::GapPairingMock> pairing;
+    testing::StrictMock<services::GapBondingMock> bonding;
+    services::GapPeripheralStateGuardDecorator stateGuard{ peripheral, pairing, bonding };
+    testing::StrictMock<services::GapPeripheralObserverMock> peripheralObserver{ stateGuard };
+    testing::StrictMock<services::GapPairingObserverMock> pairingObserver{ stateGuard };
+    testing::StrictMock<services::GapBondingObserverMock> bondingObserver{ stateGuard };
+
+    const std::array<uint8_t, 3> data{ 1, 2, 3 };
+};
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, advertise_forwards_in_standby)
+{
+    EXPECT_CALL(peripheral, Advertise(services::GapAdvertisementType::advInd, 100));
+
+    stateGuard.Advertise(services::GapAdvertisementType::advInd, 100);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_advertisement_data_forwards_in_standby)
+{
+    EXPECT_CALL(peripheral, SetAdvertisementData(infra::ContentsEqual(data)));
+
+    stateGuard.SetAdvertisementData(data);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_scan_response_data_forwards_in_standby)
+{
+    EXPECT_CALL(peripheral, SetScanResponseData(infra::ContentsEqual(data)));
+
+    stateGuard.SetScanResponseData(data);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, standby_forwards_in_all_states)
+{
+    EXPECT_CALL(peripheral, Standby()).Times(3);
+
+    stateGuard.Standby();
+
+    SetState(services::GapState::advertising);
+    stateGuard.Standby();
+
+    SetState(services::GapState::connected);
+    stateGuard.Standby();
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, state_changed_is_forwarded_to_observer)
+{
+    EXPECT_CALL(peripheralObserver, StateChanged(services::GapState::advertising));
+
+    stateGuard.StateChanged(services::GapState::advertising);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, allow_pairing_forwards_in_standby)
+{
+    EXPECT_CALL(pairing, AllowPairing(true));
+
+    stateGuard.AllowPairing(true);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_security_mode_forwards_in_standby)
+{
+    EXPECT_CALL(pairing, SetSecurityMode(services::GapPairing::SecurityMode::mode1, services::GapPairing::SecurityLevel::level2));
+
+    stateGuard.SetSecurityMode(services::GapPairing::SecurityMode::mode1, services::GapPairing::SecurityLevel::level2);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_io_capabilities_forwards_in_standby)
+{
+    EXPECT_CALL(pairing, SetIoCapabilities(services::GapPairing::IoCapabilities::displayYesNo));
+
+    stateGuard.SetIoCapabilities(services::GapPairing::IoCapabilities::displayYesNo);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, numeric_comparison_confirm_forwards_in_standby)
+{
+    EXPECT_CALL(pairing, NumericComparisonConfirm(true));
+
+    stateGuard.NumericComparisonConfirm(true);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, numeric_comparison_confirm_forwards_in_connected)
+{
+    SetState(services::GapState::connected);
+
+    EXPECT_CALL(pairing, NumericComparisonConfirm(true));
+
+    stateGuard.NumericComparisonConfirm(true);
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, remove_all_bonds_forwards_in_standby)
+{
+    EXPECT_CALL(bonding, RemoveAllBonds());
+
+    stateGuard.RemoveAllBonds();
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, remove_oldest_bond_forwards_in_standby)
+{
+    EXPECT_CALL(bonding, RemoveOldestBond());
+
+    stateGuard.RemoveOldestBond();
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, advertise_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.Advertise(services::GapAdvertisementType::advInd, 100), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, advertise_asserts_when_connected)
+{
+    SetState(services::GapState::connected);
+
+    EXPECT_DEATH(stateGuard.Advertise(services::GapAdvertisementType::advInd, 100), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_advertisement_data_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.SetAdvertisementData(data), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_scan_response_data_asserts_when_connected)
+{
+    SetState(services::GapState::connected);
+
+    EXPECT_DEATH(stateGuard.SetScanResponseData(data), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, allow_pairing_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.AllowPairing(true), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_security_mode_asserts_when_connected)
+{
+    SetState(services::GapState::connected);
+
+    EXPECT_DEATH(stateGuard.SetSecurityMode(services::GapPairing::SecurityMode::mode1, services::GapPairing::SecurityLevel::level2), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, set_io_capabilities_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.SetIoCapabilities(services::GapPairing::IoCapabilities::displayYesNo), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, numeric_comparison_confirm_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.NumericComparisonConfirm(true), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, remove_all_bonds_asserts_when_connected)
+{
+    SetState(services::GapState::connected);
+
+    EXPECT_DEATH(stateGuard.RemoveAllBonds(), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, remove_oldest_bond_asserts_when_advertising)
+{
+    SetState(services::GapState::advertising);
+
+    EXPECT_DEATH(stateGuard.RemoveOldestBond(), "");
+}
+
+TEST_F(GapPeripheralStateGuardDecoratorTest, methods_allowed_again_after_returning_to_standby)
+{
+    SetState(services::GapState::advertising);
+    SetState(services::GapState::standby);
+
+    EXPECT_CALL(peripheral, Advertise(services::GapAdvertisementType::advInd, 100));
+    stateGuard.Advertise(services::GapAdvertisementType::advInd, 100);
+
+    EXPECT_CALL(pairing, AllowPairing(true));
+    stateGuard.AllowPairing(true);
+
+    EXPECT_CALL(bonding, RemoveAllBonds());
+    stateGuard.RemoveAllBonds();
+}


### PR DESCRIPTION
Depends on https://github.com/philips-software/amp-embedded-infra-lib/pull/1291

This change will add a decorator that is applicable to any HAL-layer. It will ensure that the Gap.proto is the source of truth and incorrect logical behavior will result in assertion.