### PR TITLE
feat(ble): add BLE bond name storage interface

### DIFF
--- a/services/ble/BondStorageSynchronizer.hpp
+++ b/services/ble/BondStorageSynchronizer.hpp
@@ -28,7 +28,7 @@ namespace services
     {
     protected:
         BondNameStorage() = default;
-         ~BondNameStorage() = default;
+        ~BondNameStorage() = default;
         BondNameStorage(const BondNameStorage& other) = delete;
         BondNameStorage& operator=(const BondNameStorage& other) = delete;
 

--- a/services/ble/BondStorageSynchronizer.hpp
+++ b/services/ble/BondStorageSynchronizer.hpp
@@ -5,6 +5,7 @@
 #include "infra/util/BoundedString.hpp"
 #include "infra/util/Function.hpp"
 #include "services/ble/Gap.hpp"
+#include <cstddef>
 
 namespace services
 {
@@ -34,6 +35,8 @@ namespace services
         virtual infra::BoundedConstString GetDeviceName(GapAddress address) const = 0;
         virtual void RemoveDeviceName(GapAddress address) = 0;
         virtual void RemoveAll() = 0;
+        virtual std::size_t Size() const = 0;
+        virtual std::size_t Capacity() const = 0;
     };
 
     class BondStorage

--- a/services/ble/BondStorageSynchronizer.hpp
+++ b/services/ble/BondStorageSynchronizer.hpp
@@ -28,6 +28,7 @@ namespace services
     {
     protected:
         BondNameStorage() = default;
+         ~BondNameStorage() = default;
         BondNameStorage(const BondNameStorage& other) = delete;
         BondNameStorage& operator=(const BondNameStorage& other) = delete;
 
@@ -35,7 +36,7 @@ namespace services
         virtual void SetBondName(GapAddress address, infra::BoundedConstString name) = 0;
         virtual std::optional<infra::BoundedConstString> GetBondName(GapAddress address) const = 0;
         virtual void RemoveBondName(GapAddress address) = 0;
-        virtual void RemoveAll() = 0;
+        virtual void RemoveAllBondNames() = 0;
         virtual std::size_t Size() const = 0;
         virtual std::size_t Capacity() const = 0;
     };

--- a/services/ble/BondStorageSynchronizer.hpp
+++ b/services/ble/BondStorageSynchronizer.hpp
@@ -6,6 +6,7 @@
 #include "infra/util/Function.hpp"
 #include "services/ble/Gap.hpp"
 #include <cstddef>
+#include <optional>
 
 namespace services
 {
@@ -31,9 +32,9 @@ namespace services
         BondNameStorage& operator=(const BondNameStorage& other) = delete;
 
     public:
-        virtual void SetDeviceName(GapAddress address, infra::BoundedConstString name) = 0;
-        virtual infra::BoundedConstString GetDeviceName(GapAddress address) const = 0;
-        virtual void RemoveDeviceName(GapAddress address) = 0;
+        virtual void SetBondName(GapAddress address, infra::BoundedConstString name) = 0;
+        virtual std::optional<infra::BoundedConstString> GetBondName(GapAddress address) const = 0;
+        virtual void RemoveBondName(GapAddress address) = 0;
         virtual void RemoveAll() = 0;
         virtual std::size_t Size() const = 0;
         virtual std::size_t Capacity() const = 0;

--- a/services/ble/BondStorageSynchronizer.hpp
+++ b/services/ble/BondStorageSynchronizer.hpp
@@ -2,7 +2,9 @@
 #define SERVICES_BOND_STORAGE_SYNCHRONIZER_HPP
 
 #include "hal/interfaces/MacAddress.hpp"
+#include "infra/util/BoundedString.hpp"
 #include "infra/util/Function.hpp"
+#include "services/ble/Gap.hpp"
 
 namespace services
 {
@@ -18,6 +20,20 @@ namespace services
         virtual void RemoveBond(hal::MacAddress address) = 0;
         virtual void RemoveAllBonds() = 0;
         virtual uint32_t GetMaxNumberOfBonds() const = 0;
+    };
+
+    class BondNameStorage
+    {
+    protected:
+        BondNameStorage() = default;
+        BondNameStorage(const BondNameStorage& other) = delete;
+        BondNameStorage& operator=(const BondNameStorage& other) = delete;
+
+    public:
+        virtual void SetDeviceName(GapAddress address, infra::BoundedConstString name) = 0;
+        virtual infra::BoundedConstString GetDeviceName(GapAddress address) const = 0;
+        virtual void RemoveDeviceName(GapAddress address) = 0;
+        virtual void RemoveAll() = 0;
     };
 
     class BondStorage


### PR DESCRIPTION
This adds an interface to store the name of an device as part of a BLE bond. 