### PR TITLE
feat: update StdStringInputStream to use std::string_view

### DIFF
--- a/infra/stream/StdStringInputStream.cpp
+++ b/infra/stream/StdStringInputStream.cpp
@@ -1,8 +1,15 @@
 #include "infra/stream/StdStringInputStream.hpp"
+#include "infra/stream/InputStream.hpp"
+#include "infra/stream/StreamErrorPolicy.hpp"
+#include "infra/util/ByteRange.hpp"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
 
 namespace infra
 {
-    StdStringInputStreamReader::StdStringInputStreamReader(const std::string& string)
+    StdStringInputStreamReader::StdStringInputStreamReader(std::string_view string)
         : string(string)
     {}
 
@@ -52,15 +59,15 @@ namespace infra
         return string.size() - offset;
     }
 
-    StdStringInputStream::StdStringInputStream(const std::string& storage)
+    StdStringInputStream::StdStringInputStream(std::string_view storage)
         : TextInputStream::WithReader<StdStringInputStreamReader>(storage)
     {}
 
-    StdStringInputStream::StdStringInputStream(const std::string& storage, const SoftFail&)
+    StdStringInputStream::StdStringInputStream(std::string_view storage, const SoftFail&)
         : TextInputStream::WithReader<StdStringInputStreamReader>(storage, softFail)
     {}
 
-    StdStringInputStream::StdStringInputStream(const std::string& storage, const NoFail&)
+    StdStringInputStream::StdStringInputStream(std::string_view storage, const NoFail&)
         : TextInputStream::WithReader<StdStringInputStreamReader>(storage, noFail)
     {}
 }

--- a/infra/stream/StdStringInputStream.hpp
+++ b/infra/stream/StdStringInputStream.hpp
@@ -27,7 +27,7 @@ namespace infra
         std::size_t Available() const override;
 
     private:
-        uint32_t offset = 0;
+        std::size_t offset = 0;
         std::string_view string;
     };
 

--- a/infra/stream/StdStringInputStream.hpp
+++ b/infra/stream/StdStringInputStream.hpp
@@ -2,9 +2,13 @@
 #define INFRA_STD_STRING_INPUT_STREAM_HPP
 
 #include "infra/stream/InputStream.hpp"
+#include "infra/stream/StreamErrorPolicy.hpp"
+#include "infra/util/ByteRange.hpp"
 #include "infra/util/WithStorage.hpp"
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 namespace infra
 {
@@ -12,7 +16,7 @@ namespace infra
         : public StreamReader
     {
     public:
-        explicit StdStringInputStreamReader(const std::string& string);
+        explicit StdStringInputStreamReader(std::string_view string);
 
     private:
         void Extract(ByteRange range, StreamErrorPolicy& errorPolicy) override;
@@ -24,7 +28,7 @@ namespace infra
 
     private:
         uint32_t offset = 0;
-        const std::string& string;
+        std::string_view string;
     };
 
     class StdStringInputStream
@@ -33,9 +37,9 @@ namespace infra
     public:
         using WithStorage = infra::WithStorage<TextInputStream::WithReader<StdStringInputStreamReader>, std::string>;
 
-        explicit StdStringInputStream(const std::string& storage);
-        StdStringInputStream(const std::string& storage, const SoftFail&);
-        StdStringInputStream(const std::string& storage, const NoFail&);
+        explicit StdStringInputStream(std::string_view storage);
+        StdStringInputStream(std::string_view storage, const SoftFail&);
+        StdStringInputStream(std::string_view storage, const NoFail&);
     };
 }
 


### PR DESCRIPTION
`StdStringInputStream` only reads from string-like object. Therefor `std::string_view` is more lean and also accepts literal strings without creating an 'expensive' `std::string` object.