### PR TITLE
fix: ensure SendStreamAvailable is ignored after observer detach

### DIFF
--- a/services/network/HttpClientCachedConnection.cpp
+++ b/services/network/HttpClientCachedConnection.cpp
@@ -168,7 +168,8 @@ namespace services
 
     void HttpClientCachedConnection::SendStreamAvailable(infra::SharedPtr<infra::StreamWriter>&& writer)
     {
-        Observer().SendStreamAvailable(std::move(writer));
+        if (HttpClient::IsAttached())
+            Observer().SendStreamAvailable(std::move(writer));
     }
 
     void HttpClientCachedConnection::FillContent(infra::StreamWriter& writer) const

--- a/services/network/test/TestHttpClientCachedConnection.cpp
+++ b/services/network/test/TestHttpClientCachedConnection.cpp
@@ -405,6 +405,22 @@ TEST_F(HttpClientCachedConnectionTest, StatusAvailable_after_detach_is_ignored)
     clientSubject.Detach();
 }
 
+TEST_F(HttpClientCachedConnectionTest, SendStreamAvailable_after_detach_is_ignored)
+{
+    CreateConnection(factory);
+
+    FinishRequest();
+    EXPECT_CALL(*clientObserver, Detaching());
+    clientObserver->Detach();
+
+    // Late callbacks may still arrive from the lower layer after detach.
+    infra::StreamWriterMock writer;
+    infra::AccessedBySharedPtr writerAccess(infra::emptyFunction);
+    clientSubject.Observer().SendStreamAvailable(writerAccess.MakeShared(writer));
+
+    clientSubject.Detach();
+}
+
 TEST_F(HttpClientCachedConnectionTest, Close_is_forwarded_to_client)
 {
     CreateConnection(factory);

--- a/services/network/test/TestHttpClientCachedConnection.cpp
+++ b/services/network/test/TestHttpClientCachedConnection.cpp
@@ -413,7 +413,6 @@ TEST_F(HttpClientCachedConnectionTest, SendStreamAvailable_after_detach_is_ignor
     EXPECT_CALL(*clientObserver, Detaching());
     clientObserver->Detach();
 
-    // Late callbacks may still arrive from the lower layer after detach.
     infra::StreamWriterMock writer;
     infra::AccessedBySharedPtr writerAccess(infra::emptyFunction);
     clientSubject.Observer().SendStreamAvailable(writerAccess.MakeShared(writer));


### PR DESCRIPTION
If there is no observer to forward the stream, drop the stream