### PR TITLE
feat: decorator for duplicated commands detection

### DIFF
--- a/services/util/Terminal.cpp
+++ b/services/util/Terminal.cpp
@@ -1,8 +1,23 @@
 #include "services/util/Terminal.hpp"
+#include "infra/event/EventDispatcher.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include "infra/util/Tokenizer.hpp"
 
 namespace services
 {
+    namespace
+    {
+        bool NamesConflict(infra::BoundedConstString first, infra::BoundedConstString second)
+        {
+            return !first.empty() && first == second;
+        }
+
+        bool CommandsConflict(const TerminalCommands::CommandInfo& newCommand, const TerminalCommands::CommandInfo& existingCommand)
+        {
+            return NamesConflict(newCommand.longName, existingCommand.longName) || NamesConflict(newCommand.longName, existingCommand.shortName) || NamesConflict(newCommand.shortName, existingCommand.longName) || NamesConflict(newCommand.shortName, existingCommand.shortName);
+        }
+    }
+
     bool TerminalCommands::ProcessCommand(infra::BoundedConstString data)
     {
         infra::Tokenizer tokenizer(data, ' ');
@@ -22,5 +37,43 @@ namespace services
         }
         else
             return false;
+    }
+
+    TerminalWithCommandsDuplicateDetector::TerminalWithCommandsDuplicateDetector(TerminalWithCommands& delegate)
+        : delegate(delegate)
+    {}
+
+    void TerminalWithCommandsDuplicateDetector::RegisterObserver(infra::Observer<TerminalCommands, TerminalWithCommands>* observer)
+    {
+        observer->Attach(delegate);
+
+        if (!evaluationScheduled)
+        {
+            evaluationScheduled = true;
+            infra::EventDispatcher::Instance().Schedule([this]()
+                {
+                    evaluationScheduled = false;
+                    EvaluateDuplicateCommands();
+                });
+        }
+    }
+
+    void TerminalWithCommandsDuplicateDetector::EvaluateDuplicateCommands()
+    {
+        delegate.NotifyObservers([this](TerminalCommands& newObserver)
+            {
+                for (const auto& newCommand : newObserver.Commands())
+                    delegate.NotifyObservers([&newObserver, &newCommand](TerminalCommands& existingObserver)
+                        {
+                            if (&existingObserver != &newObserver)
+                                for (const auto& existingCommand : existingObserver.Commands())
+                                    really_assert_with_msg(!CommandsConflict(newCommand.info, existingCommand.info),
+                                        "Duplicate terminal command '%.*s' (short '%.*s') conflicts with existing command '%.*s' (short '%.*s')",
+                                        static_cast<int>(newCommand.info.longName.size()), newCommand.info.longName.data(),
+                                        static_cast<int>(newCommand.info.shortName.size()), newCommand.info.shortName.data(),
+                                        static_cast<int>(existingCommand.info.longName.size()), existingCommand.info.longName.data(),
+                                        static_cast<int>(existingCommand.info.shortName.size()), existingCommand.info.shortName.data());
+                        });
+            });
     }
 }

--- a/services/util/Terminal.hpp
+++ b/services/util/Terminal.hpp
@@ -109,6 +109,22 @@ namespace services
         : public infra::Subject<TerminalCommands>
     {};
 
+    class TerminalWithCommandsDuplicateDetector
+        : public TerminalWithCommands
+    {
+    public:
+        explicit TerminalWithCommandsDuplicateDetector(TerminalWithCommands& delegate);
+
+        void RegisterObserver(infra::Observer<TerminalCommands, TerminalWithCommands>* observer) override;
+
+    private:
+        void EvaluateDuplicateCommands();
+
+    private:
+        TerminalWithCommands& delegate;
+        bool evaluationScheduled = false;
+    };
+
     template<size_t MaxCommandLength>
     class TerminalWithCommandsImplBase
         : public TerminalWithCommands

--- a/services/util/test/TestTerminal.cpp
+++ b/services/util/test/TestTerminal.cpp
@@ -1,10 +1,15 @@
 #include "hal/interfaces/test_doubles/SerialCommunicationMock.hpp"
 #include "infra/event/test_helper/EventDispatcherWithWeakPtrFixture.hpp"
 #include "infra/stream/OutputStream.hpp"
+#include "infra/util/LogAndAbort.hpp"
 #include "infra/util/test_helper/MockCallback.hpp"
 #include "infra/util/test_helper/MockHelpers.hpp"
 #include "services/util/Terminal.hpp"
 #include "gmock/gmock.h"
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <iostream>
 #include <vector>
 
 class StreamWriterMock
@@ -401,4 +406,132 @@ TEST_F(TerminalWithCommandsTest, unrecognized_command_is_reported)
     communication.dataReceived(std::vector<uint8_t>{ ' ', '\r' });
 
     ExecuteAllActions();
+}
+
+namespace
+{
+    void PrintAbortMessageToStderr(const char* reason, const char* file, int line, const char* format, va_list* args)
+    {
+        std::array<char, 256> buffer;
+        std::vsnprintf(buffer.data(), buffer.size(), format, *args);
+        std::cerr << buffer.data();
+    }
+
+    class DuplicateCommandStub
+        : public services::TerminalCommands
+    {
+    public:
+        DuplicateCommandStub(services::TerminalWithCommands& terminal, infra::BoundedConstString longName, infra::BoundedConstString shortName)
+            : services::TerminalCommands(terminal)
+            , commands{ { { { longName, shortName, "description" }, [](const infra::BoundedConstString&) {} } } }
+        {}
+
+        infra::MemoryRange<const Command> Commands() override
+        {
+            return infra::MakeRange(commands);
+        }
+
+    private:
+        const std::array<Command, 1> commands;
+    };
+}
+
+class TerminalWithCommandsDuplicateDetectorTest
+    : public testing::Test
+    , public infra::EventDispatcherWithWeakPtrFixture
+{
+public:
+    TerminalWithCommandsDuplicateDetectorTest()
+    {
+        infra::RegisterLogAndAbortHook(PrintAbortMessageToStderr);
+    }
+
+    ~TerminalWithCommandsDuplicateDetectorTest() override
+    {
+        infra::RegisterLogAndAbortHook(nullptr);
+    }
+
+    void RegisterConflictingObserversAndDispatch(infra::BoundedConstString newLongName, infra::BoundedConstString newShortName, infra::BoundedConstString existingLongName, infra::BoundedConstString existingShortName)
+    {
+        DuplicateCommandStub newObserver{ detector, newLongName, newShortName };
+        DuplicateCommandStub existingObserver{ detector, existingLongName, existingShortName };
+        ExecuteAllActions();
+    }
+
+    void EvaluateThenRegisterConflictingObserver()
+    {
+        DuplicateCommandStub first{ detector, "alpha", "a" };
+        ExecuteAllActions();
+        DuplicateCommandStub second{ detector, "alpha", "b" };
+        ExecuteAllActions();
+    }
+
+protected:
+    services::TerminalWithCommands terminal;
+    services::TerminalWithCommandsDuplicateDetector detector{ terminal };
+};
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, does_not_abort_when_commands_are_unique)
+{
+    DuplicateCommandStub first{ detector, "alpha", "a" };
+    DuplicateCommandStub second{ detector, "beta", "b" };
+
+    ExecuteAllActions();
+
+    EXPECT_THAT(first.Attached(), testing::IsTrue());
+    EXPECT_THAT(second.Attached(), testing::IsTrue());
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, forwards_registered_observer_to_delegate)
+{
+    DuplicateCommandStub commands{ detector, "alpha", "a" };
+
+    ExecuteAllActions();
+
+    bool processed = terminal.NotifyObservers([](services::TerminalCommands& observer)
+        {
+            return observer.ProcessCommand("alpha");
+        });
+
+    EXPECT_THAT(processed, testing::IsTrue());
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, forwards_unregistered_observer_to_delegate)
+{
+    {
+        DuplicateCommandStub commands{ detector, "alpha", "a" };
+        ExecuteAllActions();
+    }
+
+    bool processed = terminal.NotifyObservers([](services::TerminalCommands& observer)
+        {
+            return observer.ProcessCommand("alpha");
+        });
+
+    EXPECT_THAT(processed, testing::IsFalse());
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_long_name_matches_existing_long_name)
+{
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("alpha", "a", "alpha", "b"), "Duplicate terminal command 'alpha'.*existing command 'alpha'");
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_short_name_matches_existing_short_name)
+{
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("cmdone", "x", "cmdtwo", "x"), "Duplicate terminal command 'cmdone'.*existing command 'cmdtwo'");
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_long_name_matches_existing_short_name)
+{
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("shared", "f", "other", "shared"), "Duplicate terminal command 'shared'.*existing command 'other'");
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_short_name_matches_existing_long_name)
+{
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("other", "shared", "shared", "g"), "Duplicate terminal command 'other'.*existing command 'shared'");
+}
+
+TEST_F(TerminalWithCommandsDuplicateDetectorTest, re_evaluates_when_observer_is_registered_after_previous_evaluation)
+{
+    EXPECT_DEATH(EvaluateThenRegisterConflictingObserver(), "Duplicate terminal command 'alpha'.*existing command 'alpha'");
 }

--- a/services/util/test/TestTerminal.cpp
+++ b/services/util/test/TestTerminal.cpp
@@ -490,6 +490,7 @@ TEST_F(TerminalWithCommandsDuplicateDetectorTest, forwards_unregistered_observer
     EXPECT_THAT(processed, testing::IsFalse());
 }
 
+#ifndef EMIL_MUTATION_TESTING
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_long_name_matches_existing_long_name)
 {
     EXPECT_DEATH(RegisterConflictingObserversAndDispatch("alpha", "a", "alpha", "b"), "");
@@ -514,3 +515,4 @@ TEST_F(TerminalWithCommandsDuplicateDetectorTest, re_evaluates_when_observer_is_
 {
     EXPECT_DEATH(EvaluateThenRegisterConflictingObserver(), "");
 }
+#endif

--- a/services/util/test/TestTerminal.cpp
+++ b/services/util/test/TestTerminal.cpp
@@ -1,15 +1,11 @@
 #include "hal/interfaces/test_doubles/SerialCommunicationMock.hpp"
 #include "infra/event/test_helper/EventDispatcherWithWeakPtrFixture.hpp"
 #include "infra/stream/OutputStream.hpp"
-#include "infra/util/LogAndAbort.hpp"
 #include "infra/util/test_helper/MockCallback.hpp"
 #include "infra/util/test_helper/MockHelpers.hpp"
 #include "services/util/Terminal.hpp"
 #include "gmock/gmock.h"
 #include <array>
-#include <cstdarg>
-#include <cstdio>
-#include <iostream>
 #include <vector>
 
 class StreamWriterMock
@@ -410,13 +406,6 @@ TEST_F(TerminalWithCommandsTest, unrecognized_command_is_reported)
 
 namespace
 {
-    void PrintAbortMessageToStderr(const char* reason, const char* file, int line, const char* format, va_list* args)
-    {
-        std::array<char, 256> buffer;
-        std::vsnprintf(buffer.data(), buffer.size(), format, *args);
-        std::cerr << buffer.data();
-    }
-
     class DuplicateCommandStub
         : public services::TerminalCommands
     {
@@ -441,16 +430,6 @@ class TerminalWithCommandsDuplicateDetectorTest
     , public infra::EventDispatcherWithWeakPtrFixture
 {
 public:
-    TerminalWithCommandsDuplicateDetectorTest()
-    {
-        infra::RegisterLogAndAbortHook(PrintAbortMessageToStderr);
-    }
-
-    ~TerminalWithCommandsDuplicateDetectorTest() override
-    {
-        infra::RegisterLogAndAbortHook(nullptr);
-    }
-
     void RegisterConflictingObserversAndDispatch(infra::BoundedConstString newLongName, infra::BoundedConstString newShortName, infra::BoundedConstString existingLongName, infra::BoundedConstString existingShortName)
     {
         DuplicateCommandStub newObserver{ detector, newLongName, newShortName };
@@ -513,25 +492,25 @@ TEST_F(TerminalWithCommandsDuplicateDetectorTest, forwards_unregistered_observer
 
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_long_name_matches_existing_long_name)
 {
-    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("alpha", "a", "alpha", "b"), "Duplicate terminal command 'alpha'.*existing command 'alpha'");
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("alpha", "a", "alpha", "b"), "");
 }
 
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_short_name_matches_existing_short_name)
 {
-    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("cmdone", "x", "cmdtwo", "x"), "Duplicate terminal command 'cmdone'.*existing command 'cmdtwo'");
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("cmdone", "x", "cmdtwo", "x"), "");
 }
 
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_long_name_matches_existing_short_name)
 {
-    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("shared", "f", "other", "shared"), "Duplicate terminal command 'shared'.*existing command 'other'");
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("shared", "f", "other", "shared"), "");
 }
 
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, aborts_when_new_short_name_matches_existing_long_name)
 {
-    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("other", "shared", "shared", "g"), "Duplicate terminal command 'other'.*existing command 'shared'");
+    EXPECT_DEATH(RegisterConflictingObserversAndDispatch("other", "shared", "shared", "g"), "");
 }
 
 TEST_F(TerminalWithCommandsDuplicateDetectorTest, re_evaluates_when_observer_is_registered_after_previous_evaluation)
 {
-    EXPECT_DEATH(EvaluateThenRegisterConflictingObserver(), "Duplicate terminal command 'alpha'.*existing command 'alpha'");
+    EXPECT_DEATH(EvaluateThenRegisterConflictingObserver(), "");
 }


### PR DESCRIPTION
## Pull request overview

This PR adds a `TerminalWithCommands` decorator that detects conflicting (duplicate) terminal command names across registered `TerminalCommands` observers, aborting at runtime when a conflict is found. It also adds unit tests validating forwarding behavior and duplicate-detection behavior.

**Changes:**
- Introduces `services::TerminalWithCommandsDuplicateDetector` to validate uniqueness of command long/short names across observers.
- Implements deferred (event-dispatched) evaluation after observer registration to catch duplicates introduced during registration bursts.
- Adds tests covering forwarding of observers to the delegate terminal and aborting on various conflict scenarios.