### PR TITLE
feat!: refresh GattClient proto interface and solve race conditions

### DIFF
--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -110,7 +110,7 @@ service GattClient
     // Responses: zero or more GattClientResponse.ServiceDiscovered, followed by GattClientResponse.ServiceDiscoveryComplete.
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
     // Discovers all characteristics within a single service's handle range.
-    // Must be called once per discovered service, sequentially, after GattClientResponse.ServiceDiscoveryComplete.
+    // Must be called once per discovered service, after GattClientResponse.ServiceDiscoveryComplete.
     // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
     // Discovers all descriptors within the given handle range of a characteristic.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -62,7 +62,8 @@ message Characteristic
     uint32 properties = 4;
 }
 
-message CharacteristicDescriptor
+//'Descriptor' keyword is not allowed by Echo code generator
+message Descriptr
 {
     bytes uuid = 1 [(bytes_size) = 16];
     Handle handle = 2;
@@ -132,8 +133,8 @@ service GattClient
     //   The handle range should be the service's start and end handles.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
 
-    // Expected response: GattClientResponse.CharacteristicDescriptorDiscoveryComplete
-    // Additional responses: zero or more GattClientResponse.CharacteristicDescriptorDiscovered
+    // Expected response: GattClientResponse.DescriptorDiscoveryComplete
+    // Additional responses: zero or more GattClientResponse.DescriptorDiscovered
     // Description: Discovers all descriptors within the given handle range of a characteristic.
     //   The handle range spans from the characteristic's value handle to the next characteristic's declaration handle - 1
     //   (or the service's end handle for the last characteristic in a service).
@@ -154,10 +155,10 @@ service GattClient
 
     // Expected response: GattClientResponse.OperationComplete
     // Additional responses: GattClientResponse.ReadDescriptorResponse
-    rpc ReadCharacteristicDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
+    rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
 
     // Expected response: GattClientResponse.OperationComplete
-    rpc WriteCharacteristicDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
+    rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
@@ -184,18 +185,18 @@ service GattClientResponse
     rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
 
     // Triggered by: GattClient.StartDescriptorDiscovery (for each discovered descriptor)
-    rpc CharacteristicDescriptorDiscovered(CharacteristicDescriptor) returns (Nothing) { option (method_id) = 6; }
+    rpc DescriptorDiscovered(Descriptr) returns (Nothing) { option (method_id) = 6; }
 
     // Triggered by: GattClient.StartDescriptorDiscovery (on completion)
-    rpc CharacteristicDescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
+    rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
     // Triggered by: GattClient.ReadCharacteristic
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
 
-    // Triggered by: GattClient.ReadCharacteristicDescriptor
+    // Triggered by: GattClient.ReadDescriptor
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadCharacteristicDescriptor, GattClient.WriteCharacteristicDescriptor
+    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadDescriptor, GattClient.WriteDescriptor
     // Description: Reports the outcome of a read or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -143,22 +143,26 @@ service GattClient
 
     // Expected response: GattClientResponse.OperationComplete
     // Additional responses: GattClientResponse.ReadCharacteristicResponse
-    // Description: Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
+    // Description: Reads the value of a characteristic from the GATT server.
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
 
     // Expected response: GattClientResponse.OperationComplete
+    // Description: Writes the value of a characteristic to the GATT server.
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
 
     // Expected response: GattClientResponse.OperationComplete
-    // Description: OperationComplete indicates the request was processed by the GATT client,
+    // Description: Writes the value of a characteristic to the GATT server without requiring a response.
+    //  OperationComplete indicates the request was processed by the GATT client,
     //   but does not guarantee success on the GATT server side.
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
 
     // Expected response: GattClientResponse.OperationComplete
     // Additional responses: GattClientResponse.ReadDescriptorResponse
+    // Description: Reads the value of a descriptor from the GATT server.
     rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
 
     // Expected response: GattClientResponse.OperationComplete
+    // Description: Writes the value of a descriptor to the GATT server.
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
@@ -174,27 +178,35 @@ service GattClientResponse
     rpc MtuSizeExchangeComplete(MtuSize) returns (Nothing) { option (method_id) = 1; }
 
     // Triggered by: GattClient.StartServiceDiscovery (for each discovered service)
+    // Description: Reports a single discovered service, including its UUID and handle range.
     rpc ServiceDiscovered(Service) returns (Nothing) { option (method_id) = 2; }
 
     // Triggered by: GattClient.StartServiceDiscovery (on completion)
+    // Description: Signals that service discovery has finished.
     rpc ServiceDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 3; }
 
     // Triggered by: GattClient.StartCharacteristicDiscovery (for each discovered characteristic)
+    // Description: Reports a single discovered characteristic, including its UUID, handles, and properties.
     rpc CharacteristicDiscovered(Characteristic) returns (Nothing) { option (method_id) = 4; }
 
     // Triggered by: GattClient.StartCharacteristicDiscovery (on completion)
+    // Description: Signals that characteristic discovery has finished.
     rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
 
     // Triggered by: GattClient.StartDescriptorDiscovery (for each discovered descriptor)
+    // Description: Reports a single discovered descriptor, including its UUID and handle.
     rpc DescriptorDiscovered(Descriptr) returns (Nothing) { option (method_id) = 6; }
 
     // Triggered by: GattClient.StartDescriptorDiscovery (on completion)
+    // Description: Signals that descriptor discovery has finished.
     rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
     // Triggered by: GattClient.ReadCharacteristic
+    // Description: Returns the value read from the characteristic.
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
 
     // Triggered by: GattClient.ReadDescriptor
+    // Description: Returns the value read from the descriptor.
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
     // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadDescriptor, GattClient.WriteDescriptor
@@ -202,9 +214,10 @@ service GattClientResponse
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: Remote GATT server sending an indication
-    // Description: Must be acknowledged by calling GattClient.IndicationDone.
+    // Description: Indicates that an attribute value has changed on the GATT server, and must be acknowledged by the client.
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
 
     // Triggered by: Remote GATT server sending a notification
+    // Description: Notifies that an attribute value has changed on the GATT server.
     rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -77,7 +77,7 @@ message ReadResult
 enum OperationStatus
 {
     success = 0;
-    // Returned when WriteWithoutResponse can't be processed due to a busy connection. The operation can be retried.
+    // Returned when WriteCharacteristicWithoutResponse can't be processed due to a busy connection. The operation can be retried.
     retry = 1;
     error = 2;
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -118,7 +118,8 @@ service GattClient
 {
     option (service_id) = 134;
 
-    // Expected response: GattClientResponse.MtuSizeExchangeComplete
+    // Expected response: GattClientResponse.OperationComplete
+    // Additional responses: GattClientResponse.MtuSizeExchangeComplete
     // Description: Requests the MTU size to be increased from the default, for better throughput.
     //   May only be called once per connection.
     //   The effective MTU size is implementation defined.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -123,6 +123,7 @@ service GattClient
     // Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
+    // OperationComplete indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
     rpc ReadCharacteristicDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
     rpc WriteCharacteristicDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -209,7 +209,7 @@ service GattClientResponse
     // Description: Returns the value read from the descriptor.
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadDescriptor, GattClient.WriteDescriptor
+    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
     // Description: Reports the outcome of a read or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -211,20 +211,20 @@ service GattClientResponse
     // Description: Returns the value read from the descriptor.
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Triggered by: GattClient.WriteCharacteristicWithoutResponse
-    // Description: Reports whether a write without response command was successfully queued by the GATT client for transmission to the GATT server.
-    //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
-    rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
-
     // Triggered by: GattClient.MtuSizeExchangeRequest, GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
     // Description: Reports the outcome of a read or write operation.
-    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 11; }
+    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: Remote GATT server sending an indication
     // Description: Indicates that an attribute value has changed on the GATT server, and must be acknowledged by the client.
-    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
+    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
 
     // Triggered by: Remote GATT server sending a notification
     // Description: Notifies that an attribute value has changed on the GATT server.
-    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 13; }
+    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
+
+    // Triggered by: GattClient.WriteCharacteristicWithoutResponse
+    // Description: Reports whether a write without response command was successfully queued by the GATT client for transmission to the GATT server.
+    //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
+    rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 13; }
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -118,6 +118,7 @@ service GattClient
 
     // Expected response: GattClientResponse.MtuSizeExchangeComplete
     // Description: Requests the MTU size to be increased from the default, for better throughput.
+    //   May only be called once per connection.
     //   The effective MTU size is implementation defined.
     rpc MtuSizeExchangeRequest(Nothing) returns (Nothing) { option (method_id) = 1; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -102,7 +102,9 @@ enum CccdSetting
 //  Unless otherwise specified, all methods require an active connection.
 // Callback constraints:
 //  Unless otherwise specified, methods do not by default result in any callbacks on the response service.
-//  Unless otherwise specified, when callbacks are specified for a method, another call of any method is not allowed until the final callback has been received.
+//  An operation is in progress from its invocation until its listed "Expected response" has been received.
+//  At most one operation may be in progress at any time, with the exception of WriteCharacteristicWithoutResponse,
+//  which may overlap with any other in-progress operation except itself.
 //  Non-conformance will result in an assertion.
 // Discovery constraints:
 //  Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
@@ -153,7 +155,6 @@ service GattClient
     // Expected response: GattClientResponse.WriteCharacteristicWithoutResponseComplete
     // Description: Writes the value of a characteristic to the GATT server without requiring a response.
     //   This method does not guarantee that the server has received the value.
-    //   May be called while awaiting a response of another method.
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
 
     // Expected response: GattClientResponse.OperationComplete

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -103,8 +103,7 @@ enum CccdSetting
 // Callback constraints:
 //  Unless otherwise specified, methods do not by default result in any callbacks on the response service.
 //  An operation is in progress from its invocation until its listed "Expected response" has been received.
-//  At most one operation may be in progress at any time, with the exception of WriteCharacteristicWithoutResponse,
-//  which may overlap with any other in-progress operation except itself.
+//  Unless otherwise specified, only one operation may be in progress at any time.
 //  Non-conformance will result in an assertion.
 // Discovery constraints:
 //  Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
@@ -156,6 +155,7 @@ service GattClient
     // Expected response: GattClientResponse.WriteCharacteristicWithoutResponseComplete
     // Description: Writes the value of a characteristic to the GATT server without requiring a response.
     //   This method does not guarantee that the server has received the value.
+    //   May be called while other operations are in progress, except for another WriteCharacteristicWithoutResponse operation.
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
 
     // Expected response: GattClientResponse.OperationComplete
@@ -168,6 +168,7 @@ service GattClient
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
+    //   May be called while other operations are in progresss.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
 }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -105,6 +105,7 @@ service GattClient
 
     // Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
     // Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
+    // The maximum number of items which will be returned depends on the configuration.
     //
     // Discovers all services on the remote device.
     // Responses: zero or more GattClientResponse.ServiceDiscovered, followed by GattClientResponse.ServiceDiscoveryComplete.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -127,7 +127,7 @@ service GattClient
 
     // Expected response: GattClientResponse.ServiceDiscoveryComplete
     // Additional responses: zero or more GattClientResponse.ServiceDiscovered
-    // Description: Discovers all services on the remote device.
+    // Description: Discovers all services.
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
 
     // Expected response: GattClientResponse.CharacteristicDiscoveryComplete

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -111,6 +111,7 @@ service GattClient
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
     // Discovers all characteristics within a single service's handle range.
     // Must be called once per discovered service, after GattClientResponse.ServiceDiscoveryComplete.
+    // The handle range should be the service's start and end handles.
     // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
     // Discovers all descriptors within the given handle range of a characteristic.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -167,9 +167,9 @@ service GattClient
     // Description: Writes the value of a descriptor to the GATT server.
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
-    // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
-    //   May be called while other operations are in progresss.
-    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
+// Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
+//   May be called while other operations are in progress.
+rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
 }
 
 service GattClientResponse
@@ -213,7 +213,7 @@ service GattClientResponse
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
     // Triggered by: GattClient.MtuSizeExchangeRequest, GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
-    // Description: Reports the outcome of a read or write operation.
+// Description: Reports the outcome of an MTU exchange, read, or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: Remote GATT server sending an indication

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -111,8 +111,8 @@ enum CccdSetting
 //  Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
 //  The maximum number of items returned depends on the configuration.
 // Connection loss:
-//  Any pending discovery or read/write operation is implicitly cancelled.
-//  For any pending operation, a corresponding response with an error status is guaranteed.
+//  Any pending operation (discovery, MTU exchange, or read/write) is implicitly cancelled.
+//  For any pending operation, the listed "Expected response" is guaranteed to be delivered with an error status.
 // ==================================================
 service GattClient
 {

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -211,20 +211,20 @@ service GattClientResponse
     // Description: Returns the value read from the descriptor.
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
-    // Description: Reports the outcome of a read or write operation.
-    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
-
     // Triggered by: GattClient.WriteCharacteristicWithoutResponse
     // Description: Reports whether a write without response command was successfully queued by the GATT client for transmission to the GATT server.
     //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
-    rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 13; }
+    rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
+
+    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
+    // Description: Reports the outcome of a read or write operation.
+    rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 11; }
 
     // Triggered by: Remote GATT server sending an indication
     // Description: Indicates that an attribute value has changed on the GATT server, and must be acknowledged by the client.
-    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
+    rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
 
     // Triggered by: Remote GATT server sending a notification
     // Description: Notifies that an attribute value has changed on the GATT server.
-    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
+    rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 13; }
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -114,7 +114,7 @@ service GattClient
     // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
     // Discovers all descriptors within the given handle range of a characteristic.
-    // The handle range spans from the characteristic's value handle + 1 to the next characteristic's handle - 1
+    // The handle range spans from the characteristic's value handle to the next characteristic's declaration handle - 1
     // (or the service's end handle for the last characteristic in a service).
     // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -57,7 +57,7 @@ message Service
 message Characteristic
 {
     bytes uuid = 1 [(bytes_size) = 16];
-    Handle handle = 2;
+    Handle declarationHandle = 2;
     Handle valueHandle = 3;
     uint32 properties = 4;
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -216,7 +216,7 @@ service GattClientResponse
     //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
     rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
-    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
+    // Triggered by: GattClient.MtuSizeExchangeRequest, GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
     // Description: Reports the outcome of a read or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 11; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -214,9 +214,8 @@ service GattClientResponse
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: GattClient.WriteCharacteristicWithoutResponse
-    // Description: Reports whether a write without response command was succesfully sent to the GATT server.
-    //  Success indicates the request was processed by the GATT client,
-    //   but does not guarantee success on the GATT server side.
+    // Description: Reports whether a write without response command was successfully sent to the GATT client.
+    //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
     rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 13; }
 
     // Triggered by: Remote GATT server sending an indication

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -62,7 +62,7 @@ message Characteristic
     uint32 properties = 4;
 }
 
-//'Descriptor' keyword is not allowed by Echo code generator
+// 'Descriptor' keyword is not allowed by Echo code generator
 message Descriptr
 {
     bytes uuid = 1 [(bytes_size) = 16];

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -62,8 +62,7 @@ message Characteristic
     uint32 properties = 4;
 }
 
-message Descriptr
-//'Descriptor' keyword is not allowed by Echo code generator
+message CharacteristicDescriptor
 {
     bytes uuid = 1 [(bytes_size) = 16];
     Handle handle = 2;
@@ -124,8 +123,8 @@ service GattClient
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
-    rpc ReadDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
-    rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
+    rpc ReadCharacteristicDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
+    rpc WriteCharacteristicDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
     // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
@@ -145,8 +144,8 @@ service GattClientResponse
     rpc CharacteristicDiscovered(Characteristic) returns (Nothing) { option (method_id) = 4; }
     rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
 
-    rpc DescriptorDiscovered(Descriptr) returns (Nothing) { option (method_id) = 6; }
-    rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
+    rpc CharacteristicDescriptorDiscovered(CharacteristicDescriptor) returns (Nothing) { option (method_id) = 6; }
+    rpc CharacteristicDescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -102,7 +102,7 @@ enum CccdSetting
 //  Unless otherwise specified, all methods require an active connection.
 // Callback constraints:
 //  Unless otherwise specified, methods do not by default result in any callbacks on the response service.
-//  When a callback is specified for a method, another call of any method is not allowed until the callback has been received.
+//  Unless otherwise specified, when callbacks are specified for a method, another call of any method is not allowed until the final callback has been received.
 //  Non-conformance will result in an assertion.
 // Discovery constraints:
 //  Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
@@ -150,10 +150,10 @@ service GattClient
     // Description: Writes the value of a characteristic to the GATT server.
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
 
-    // Expected response: GattClientResponse.OperationComplete
+    // Expected response: GattClientResponse.WriteCharacteristicWithoutResponseComplete
     // Description: Writes the value of a characteristic to the GATT server without requiring a response.
-    //  OperationComplete indicates the request was processed by the GATT client,
-    //   but does not guarantee success on the GATT server side.
+    //   This method does not guarantee that the server has received the value.
+    //   May be called while awaiting a response of another method.
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
 
     // Expected response: GattClientResponse.OperationComplete
@@ -212,6 +212,12 @@ service GattClientResponse
     // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadDescriptor, GattClient.WriteDescriptor
     // Description: Reports the outcome of a read or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
+
+    // Triggered by: GattClient.WriteCharacteristicWithoutResponse
+    // Description: Reports whether a write without response command was succesfully sent to the GATT server.
+    //  Success indicates the request was processed by the GATT client,
+    //   but does not guarantee success on the GATT server side.
+    rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 13; }
 
     // Triggered by: Remote GATT server sending an indication
     // Description: Indicates that an attribute value has changed on the GATT server, and must be acknowledged by the client.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -183,7 +183,7 @@ service GattClientResponse
 
     // Triggered by: GattClient.StartServiceDiscovery (on completion)
     // Description: Signals that service discovery has finished.
-    rpc ServiceDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 3; }
+    rpc ServiceDiscoveryComplete(OperationResult) returns (Nothing) { option (method_id) = 3; }
 
     // Triggered by: GattClient.StartCharacteristicDiscovery (for each discovered characteristic)
     // Description: Reports a single discovered characteristic, including its UUID, handles, and properties.
@@ -191,7 +191,7 @@ service GattClientResponse
 
     // Triggered by: GattClient.StartCharacteristicDiscovery (on completion)
     // Description: Signals that characteristic discovery has finished.
-    rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
+    rpc CharacteristicDiscoveryComplete(OperationResult) returns (Nothing) { option (method_id) = 5; }
 
     // Triggered by: GattClient.StartDescriptorDiscovery (for each discovered descriptor)
     // Description: Reports a single discovered descriptor, including its UUID and handle.
@@ -199,7 +199,7 @@ service GattClientResponse
 
     // Triggered by: GattClient.StartDescriptorDiscovery (on completion)
     // Description: Signals that descriptor discovery has finished.
-    rpc DescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
+    rpc DescriptorDiscoveryComplete(OperationResult) returns (Nothing) { option (method_id) = 7; }
 
     // Triggered by: GattClient.ReadCharacteristic
     // Description: Returns the value read from the characteristic.

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -150,7 +150,7 @@ service GattClientResponse
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Called after completion of characteristic operations
+    // Called after completion of characteristic and descriptor operations
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -77,6 +77,7 @@ message ReadResult
 enum OperationStatus
 {
     success = 0;
+    // Returned when WriteWithoutResponse can't be processed due to a busy connection. The operation can be retried.
     retry = 1;
     error = 2;
 }
@@ -119,7 +120,6 @@ service GattClient
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
 
     // Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
-    // WriteCharacteristicWithoutResponse is fire-and-forget and does not trigger GattClientResponse.OperationComplete.
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
@@ -150,10 +150,9 @@ service GattClientResponse
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Called after completion of operations with response: ReadCharacteristic, WriteCharacteristic, ReadDescriptor, WriteDescriptor
+    // Called after completion of characteristic operations
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
     rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
 }
-

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -94,41 +94,72 @@ enum CccdSetting
     indicationEnabled = 2;
 }
 
+// ==================================================
+// GATT CLIENT SERVICE DEFINITION
+// ==================================================
+// State constraints:
+//  Unless otherwise specified, all methods require an active connection.
+// Callback constraints:
+//  Unless otherwise specified, methods do not by default result in any callbacks on the response service.
+//  When a callback is specified for a method, another call of any method is not allowed until the callback has been received.
+//  Non-conformance will result in an assertion.
+// Discovery constraints:
+//  Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
+//  Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
+//  The maximum number of items returned depends on the configuration.
+// Connection loss:
+//  Any pending discovery or read/write operation is implicitly cancelled.
+//  For any pending operation, a corresponding response with an error status is guaranteed.
+// ==================================================
 service GattClient
 {
     option (service_id) = 134;
 
-    // Requests the MTU size to be increased from the default, for better throughput.
-    // The effective MTU size is implementation defined, and is returned in the GattClientResponse.MtuSizeExchangeComplete response.
+    // Expected response: GattClientResponse.MtuSizeExchangeComplete
+    // Description: Requests the MTU size to be increased from the default, for better throughput.
+    //   The effective MTU size is implementation defined.
     rpc MtuSizeExchangeRequest(Nothing) returns (Nothing) { option (method_id) = 1; }
 
-    // Discovery must follow the sequence: Service -> Characteristic -> Descriptor.
-    // Each step must complete (indicated by the corresponding *Complete response) before initiating the next.
-    // The maximum number of items which will be returned depends on the configuration.
-    //
-    // Discovers all services on the remote device.
-    // Responses: zero or more GattClientResponse.ServiceDiscovered, followed by GattClientResponse.ServiceDiscoveryComplete.
+    // Expected response: GattClientResponse.ServiceDiscoveryComplete
+    // Additional responses: zero or more GattClientResponse.ServiceDiscovered
+    // Description: Discovers all services on the remote device.
     rpc StartServiceDiscovery(Nothing) returns (Nothing) { option (method_id) = 2; }
-    // Discovers all characteristics within a single service's handle range.
-    // Must be called once per discovered service, after GattClientResponse.ServiceDiscoveryComplete.
-    // The handle range should be the service's start and end handles.
-    // Responses: zero or more GattClientResponse.CharacteristicDiscovered, followed by GattClientResponse.CharacteristicDiscoveryComplete.
+
+    // Expected response: GattClientResponse.CharacteristicDiscoveryComplete
+    // Additional responses: zero or more GattClientResponse.CharacteristicDiscovered
+    // Description: Discovers all characteristics within a single service's handle range.
+    //   Must be called once per discovered service, after GattClientResponse.ServiceDiscoveryComplete.
+    //   The handle range should be the service's start and end handles.
     rpc StartCharacteristicDiscovery(HandleRange) returns (Nothing) { option (method_id) = 3; }
-    // Discovers all descriptors within the given handle range of a characteristic.
-    // The handle range spans from the characteristic's value handle to the next characteristic's declaration handle - 1
-    // (or the service's end handle for the last characteristic in a service).
-    // Responses: zero or more GattClientResponse.DescriptorDiscovered, followed by GattClientResponse.DescriptorDiscoveryComplete.
+
+    // Expected response: GattClientResponse.CharacteristicDescriptorDiscoveryComplete
+    // Additional responses: zero or more GattClientResponse.CharacteristicDescriptorDiscovered
+    // Description: Discovers all descriptors within the given handle range of a characteristic.
+    //   The handle range spans from the characteristic's value handle to the next characteristic's declaration handle - 1
+    //   (or the service's end handle for the last characteristic in a service).
     rpc StartDescriptorDiscovery(HandleRange) returns (Nothing) { option (method_id) = 4; }
 
-    // Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
+    // Expected response: GattClientResponse.OperationComplete
+    // Additional responses: GattClientResponse.ReadCharacteristicResponse
+    // Description: Read/write operations are sequential; wait for GattClientResponse.OperationComplete before issuing the next.
     rpc ReadCharacteristic(Handle) returns (Nothing) { option (method_id) = 5; }
+
+    // Expected response: GattClientResponse.OperationComplete
     rpc WriteCharacteristic(AttributeData) returns (Nothing) { option (method_id) = 6; }
-    // OperationComplete indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side
+
+    // Expected response: GattClientResponse.OperationComplete
+    // Description: OperationComplete indicates the request was processed by the GATT client,
+    //   but does not guarantee success on the GATT server side.
     rpc WriteCharacteristicWithoutResponse(AttributeData) returns (Nothing) { option (method_id) = 7; }
+
+    // Expected response: GattClientResponse.OperationComplete
+    // Additional responses: GattClientResponse.ReadDescriptorResponse
     rpc ReadCharacteristicDescriptor(Handle) returns (Nothing) { option (method_id) = 8; }
+
+    // Expected response: GattClientResponse.OperationComplete
     rpc WriteCharacteristicDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
-    // IndicationDone must be called for every IndicationReceived to acknowledge the indication.
+    // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
     rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
 }
 
@@ -136,25 +167,42 @@ service GattClientResponse
 {
     option (service_id) = 135;
 
-    // No responses are sent after a connection loss is reported by the GAP service
-
+    // Triggered by: GattClient.MtuSizeExchangeRequest
+    // Description: Reports the negotiated MTU size.
     rpc MtuSizeExchangeComplete(MtuSize) returns (Nothing) { option (method_id) = 1; }
 
+    // Triggered by: GattClient.StartServiceDiscovery (for each discovered service)
     rpc ServiceDiscovered(Service) returns (Nothing) { option (method_id) = 2; }
+
+    // Triggered by: GattClient.StartServiceDiscovery (on completion)
     rpc ServiceDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 3; }
 
+    // Triggered by: GattClient.StartCharacteristicDiscovery (for each discovered characteristic)
     rpc CharacteristicDiscovered(Characteristic) returns (Nothing) { option (method_id) = 4; }
+
+    // Triggered by: GattClient.StartCharacteristicDiscovery (on completion)
     rpc CharacteristicDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 5; }
 
+    // Triggered by: GattClient.StartDescriptorDiscovery (for each discovered descriptor)
     rpc CharacteristicDescriptorDiscovered(CharacteristicDescriptor) returns (Nothing) { option (method_id) = 6; }
+
+    // Triggered by: GattClient.StartDescriptorDiscovery (on completion)
     rpc CharacteristicDescriptorDiscoveryComplete(Nothing) returns (Nothing) { option (method_id) = 7; }
 
+    // Triggered by: GattClient.ReadCharacteristic
     rpc ReadCharacteristicResponse(ReadResult) returns (Nothing) { option (method_id) = 8; }
+
+    // Triggered by: GattClient.ReadCharacteristicDescriptor
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
-    // Called after completion of characteristic and descriptor operations
+    // Triggered by: GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.WriteCharacteristicWithoutResponse, GattClient.ReadCharacteristicDescriptor, GattClient.WriteCharacteristicDescriptor
+    // Description: Reports the outcome of a read or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
+    // Triggered by: Remote GATT server sending an indication
+    // Description: Must be acknowledged by calling GattClient.IndicationDone.
     rpc IndicationReceived(AttributeData) returns (Nothing) { option (method_id) = 11; }
+
+    // Triggered by: Remote GATT server sending a notification
     rpc NotificationReceived(AttributeData) returns (Nothing) { option (method_id) = 12; }
 }

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -215,7 +215,7 @@ service GattClientResponse
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: GattClient.WriteCharacteristicWithoutResponse
-    // Description: Reports whether a write without response command was successfully sent to the GATT client.
+    // Description: Reports whether a write without response command was successfully queued by the GATT client for transmission to the GATT server.
     //  Success indicates the request was processed by the GATT client, but does not guarantee success on the GATT server side.
     rpc WriteCharacteristicWithoutResponseComplete(OperationResult) returns (Nothing) { option (method_id) = 13; }
 

--- a/services/ble/Gatt.proto
+++ b/services/ble/Gatt.proto
@@ -167,9 +167,9 @@ service GattClient
     // Description: Writes the value of a descriptor to the GATT server.
     rpc WriteDescriptor(AttributeData) returns (Nothing) { option (method_id) = 9; }
 
-// Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
-//   May be called while other operations are in progress.
-rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
+    // Description: Must be called for every GattClientResponse.IndicationReceived to acknowledge the indication.
+    //   May be called while other operations are in progress.
+    rpc IndicationDone(Nothing) returns (Nothing) { option (method_id) = 10; }
 }
 
 service GattClientResponse
@@ -213,7 +213,7 @@ service GattClientResponse
     rpc ReadDescriptorResponse(ReadResult) returns (Nothing) { option (method_id) = 9; }
 
     // Triggered by: GattClient.MtuSizeExchangeRequest, GattClient.ReadCharacteristic, GattClient.WriteCharacteristic, GattClient.ReadDescriptor, GattClient.WriteDescriptor
-// Description: Reports the outcome of an MTU exchange, read, or write operation.
+    // Description: Reports the outcome of an MTU exchange, read, or write operation.
     rpc OperationComplete(OperationResult) returns (Nothing) { option (method_id) = 10; }
 
     // Triggered by: Remote GATT server sending an indication


### PR DESCRIPTION
Updates GattClient(Response) with improved documentation to remove ambiguities, and improves the interface to be able to give some more guarantees and solve race conditions.

# Proto Ducky findings used for this task
<img width="981" height="851" alt="image" src="https://github.com/user-attachments/assets/8626473a-6644-472f-8d82-c0be1c3211c6" />

