### PR TITLE
feat: pure stateguard interface for BLE

### DIFF
--- a/services/ble/CMakeLists.txt
+++ b/services/ble/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(services.ble PRIVATE
     GattServerCharacteristicImpl.hpp
     RetryGattClientCharacteristicsOperations.cpp
     RetryGattClientCharacteristicsOperations.hpp
+    StateGuard.hpp
 )
 
 add_subdirectory(test)

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -1,8 +1,10 @@
 #ifndef SERVICES_BLE_STATE_GUARD_HPP
 #define SERVICES_BLE_STATE_GUARD_HPP
 
-#include "infra/util/MemoryRange.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include "services/ble/Gap.hpp"
+#include <algorithm>
+#include <initializer_list>
 
 namespace services
 {
@@ -15,7 +17,37 @@ namespace services
         StateGuard& operator=(const StateGuard& other) = delete;
         virtual ~StateGuard() = default;
 
-        virtual void AssertStateIs(infra::MemoryRange<const GapState> states) const = 0;
+        void AssertStateIs(std::initializer_list<GapState> states) const
+        {
+            auto currentState = DetermineCurrentState();
+
+            really_assert(std::any_of(states.begin(), states.end(), [currentState](auto state)
+                {
+                    return state == currentState;
+                }));
+        }
+
+    protected:
+        virtual GapState DetermineCurrentState() const = 0;
+    };
+
+    template<typename Owner>
+    class StateGuardWithOwner
+        : public StateGuard
+    {
+    public:
+        explicit StateGuardWithOwner(const Owner& owner)
+            : owner(owner)
+        {}
+
+    protected:
+        GapState DetermineCurrentState() const override
+        {
+            return owner.DetermineCurrentState();
+        }
+
+    private:
+        const Owner& owner;
     };
 } // namespace services
 

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVICES_BLE_STATE_GUARD_HPP
 #define SERVICES_BLE_STATE_GUARD_HPP
 
+#include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include "services/ble/Gap.hpp"
 #include <algorithm>
@@ -17,14 +18,32 @@ namespace services
         StateGuard& operator=(const StateGuard& other) = delete;
         virtual ~StateGuard() = default;
 
-        void AssertStateIs(std::initializer_list<GapState> states) const
+        bool StateIs(std::initializer_list<GapState> states) const
         {
             auto currentState = DetermineCurrentState();
-
-            really_assert(std::any_of(states.begin(), states.end(), [currentState](auto state)
+            return std::any_of(states.begin(), states.end(), [currentState](auto state)
                 {
                     return state == currentState;
-                }));
+                });
+        }
+
+        void AssertStateIs(std::initializer_list<GapState> states) const
+        {
+            if (!StateIs(states))
+            {
+                infra::StringOutputStream::WithStorage<16> stream;
+                for (auto it = states.begin(); it != states.end(); ++it)
+                {
+                    if (it != states.begin())
+                        stream << ",";
+                    stream << static_cast<int>(*it);
+                }
+
+                really_assert_with_msg(false,
+                    "GAP state: %d, expected: [%s]",
+                    static_cast<int>(DetermineCurrentState()),
+                    stream.Storage().data());
+            }
         }
 
     protected:

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -40,8 +40,9 @@ namespace services
                 }
 
                 really_assert_with_msg(false,
-                    "GAP state: %d, expected: [%s]",
+                    "Unexpected state found: %d, expected: [%.*s]",
                     static_cast<int>(DetermineCurrentState()),
+                    static_cast<int>(stream.Storage().size()),
                     stream.Storage().data());
             }
         }

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -1,0 +1,22 @@
+#ifndef SERVICES_BLE_STATE_GUARD_HPP
+#define SERVICES_BLE_STATE_GUARD_HPP
+
+#include "infra/util/MemoryRange.hpp"
+#include "services/ble/Gap.hpp"
+
+namespace services
+{
+
+    class StateGuard
+    {
+    public:
+        StateGuard() = default;
+        StateGuard(const StateGuard& other) = delete;
+        StateGuard& operator=(const StateGuard& other) = delete;
+        virtual ~StateGuard() = default;
+
+        virtual void AssertStateIs(infra::MemoryRange<const GapState> states) const = 0;
+    };
+} // namespace services
+
+#endif // SERVICES_BLE_STATE_GUARD_HPP

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -30,25 +30,6 @@ namespace services
     protected:
         virtual GapState DetermineCurrentState() const = 0;
     };
-
-    template<typename Owner>
-    class StateGuardWithOwner
-        : public StateGuard
-    {
-    public:
-        explicit StateGuardWithOwner(const Owner& owner)
-            : owner(owner)
-        {}
-
-    protected:
-        GapState DetermineCurrentState() const override
-        {
-            return owner.DetermineCurrentState();
-        }
-
-    private:
-        const Owner& owner;
-    };
 } // namespace services
 
 #endif // SERVICES_BLE_STATE_GUARD_HPP

--- a/services/ble/test/CMakeLists.txt
+++ b/services/ble/test/CMakeLists.txt
@@ -22,4 +22,5 @@ target_sources(services.ble_test PRIVATE
     TestGapAdvertisementFormatter.cpp
     TestGattServer.cpp
     TestRetryGattClientAdapter.cpp
+    TestStateGuard.cpp
 )

--- a/services/ble/test/TestStateGuard.cpp
+++ b/services/ble/test/TestStateGuard.cpp
@@ -62,9 +62,9 @@ namespace services
         ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::standby));
 
         stateGuard.AssertStateIs({ GapState::standby, GapState::connected });
-#ifndef EMIL_MUTATION_TESTING
     }
 
+#ifndef EMIL_MUTATION_TESTING
     TEST_F(TestStateGuard, assert_state_is_aborts_with_message_for_single_expected_state)
     {
         ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::advertising));

--- a/services/ble/test/TestStateGuard.cpp
+++ b/services/ble/test/TestStateGuard.cpp
@@ -1,0 +1,84 @@
+#include "infra/util/LogAndAbort.hpp"
+#include "services/ble/StateGuard.hpp"
+#include "gmock/gmock.h"
+#include <cstdarg>
+#include <cstdio>
+
+namespace services
+{
+    namespace
+    {
+        class StateGuardMock
+            : public StateGuard
+        {
+        public:
+            MOCK_METHOD(GapState, DetermineCurrentState, (), (const, override));
+        };
+
+        class TestStateGuard
+            : public testing::Test
+        {
+        public:
+            ~TestStateGuard()
+            {
+                infra::RegisterLogAndAbortHook(nullptr);
+            }
+
+            void RegisterStderrHook()
+            {
+                infra::RegisterLogAndAbortHook([]([[maybe_unused]] const char* reason, [[maybe_unused]] const char* file, [[maybe_unused]] int line, const char* format, va_list* args)
+                    {
+                        std::vfprintf(stderr, format, *args);
+                    });
+            }
+
+            testing::NiceMock<StateGuardMock> stateGuard;
+        };
+    }
+
+    TEST_F(TestStateGuard, state_is_returns_true_when_current_state_matches)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::standby));
+
+        EXPECT_THAT(stateGuard.StateIs({ GapState::standby }), testing::IsTrue());
+    }
+
+    TEST_F(TestStateGuard, state_is_returns_true_when_current_state_matches_one_of_many)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::connected));
+
+        EXPECT_THAT(stateGuard.StateIs({ GapState::standby, GapState::connected }), testing::IsTrue());
+    }
+
+    TEST_F(TestStateGuard, state_is_returns_false_when_current_state_does_not_match)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::advertising));
+
+        EXPECT_THAT(stateGuard.StateIs({ GapState::standby, GapState::connected }), testing::IsFalse());
+    }
+
+    TEST_F(TestStateGuard, assert_state_is_does_not_abort_when_state_matches)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::standby));
+
+        stateGuard.AssertStateIs({ GapState::standby, GapState::connected });
+#ifndef EMIL_MUTATION_TESTING
+    }
+
+    TEST_F(TestStateGuard, assert_state_is_aborts_with_message_for_single_expected_state)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::advertising));
+        RegisterStderrHook();
+
+        EXPECT_DEATH(stateGuard.AssertStateIs({ GapState::standby }), "Unexpected state found: 3, expected: \\[0\\]");
+    }
+
+    TEST_F(TestStateGuard, assert_state_is_aborts_with_message_for_multiple_expected_states)
+    {
+        ON_CALL(stateGuard, DetermineCurrentState()).WillByDefault(testing::Return(GapState::initiating));
+        RegisterStderrHook();
+
+        EXPECT_DEATH(stateGuard.AssertStateIs({ GapState::standby, GapState::connected }), "Unexpected state found: 4, expected: \\[0,2\\]");
+    }
+#endif
+}


### PR DESCRIPTION
Created a base StateGuard that can be used on different platforms to "assert you're in one of these states". The BLE spec defines connection handles as 12-bit values which would fit in uint16_t, however they way states are determined differs per platform.