### PR TITLE
feat: allow optional providing claimable resource to ClaimingGattClientAdapter

### DIFF
--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -10,7 +10,7 @@ namespace services
         , AttMtuExchangeObserver(attMtuExchange)
         , GapCentralObserver(gapCentral)
         , ownedResource(std::in_place)
-        , resource(ownedResource.value())
+        , resource(*ownedResource)
     {}
 
     ClaimingGattClientAdapter::ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)
@@ -19,6 +19,11 @@ namespace services
         , GapCentralObserver(gapCentral)
         , resource(resource)
     {}
+
+    ClaimingGattClientAdapter ClaimingGattClientAdapter::WithResource(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)
+    {
+        return ClaimingGattClientAdapter(resource, gattClient, attMtuExchange, gapCentral);
+    }
 
     void ClaimingGattClientAdapter::StartServiceDiscovery()
     {

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -10,7 +10,7 @@ namespace services
         , AttMtuExchangeObserver(attMtuExchange)
         , GapCentralObserver(gapCentral)
         , ownedResource(std::in_place)
-        , resource(*ownedResource)
+        , resource(ownedResource.value())
     {}
 
     ClaimingGattClientAdapter::ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)
@@ -19,11 +19,6 @@ namespace services
         , GapCentralObserver(gapCentral)
         , resource(resource)
     {}
-
-    ClaimingGattClientAdapter ClaimingGattClientAdapter::WithResource(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)
-    {
-        return ClaimingGattClientAdapter(resource, gattClient, attMtuExchange, gapCentral);
-    }
 
     void ClaimingGattClientAdapter::StartServiceDiscovery()
     {

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -10,7 +10,7 @@ namespace services
         , AttMtuExchangeObserver(attMtuExchange)
         , GapCentralObserver(gapCentral)
         , ownedResource(std::in_place)
-        , resource(*ownedResource)
+        , resource(ownedResource.value())
     {}
 
     ClaimingGattClientAdapter::ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)

--- a/services/ble/ClaimingGattClientAdapter.cpp
+++ b/services/ble/ClaimingGattClientAdapter.cpp
@@ -9,6 +9,15 @@ namespace services
         : GattClientObserver(gattClient)
         , AttMtuExchangeObserver(attMtuExchange)
         , GapCentralObserver(gapCentral)
+        , ownedResource(std::in_place)
+        , resource(*ownedResource)
+    {}
+
+    ClaimingGattClientAdapter::ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral)
+        : GattClientObserver(gattClient)
+        , AttMtuExchangeObserver(attMtuExchange)
+        , GapCentralObserver(gapCentral)
+        , resource(resource)
     {}
 
     void ClaimingGattClientAdapter::StartServiceDiscovery()

--- a/services/ble/ClaimingGattClientAdapter.hpp
+++ b/services/ble/ClaimingGattClientAdapter.hpp
@@ -25,7 +25,8 @@ namespace services
     {
     public:
         ClaimingGattClientAdapter(GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
-        ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
+
+        static ClaimingGattClientAdapter WithResource(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
 
         // Implementation of GattClientDiscovery
         void StartServiceDiscovery() override;
@@ -46,6 +47,8 @@ namespace services
         uint16_t EffectiveAttMtuSize() const override;
 
     private:
+        ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
+
         // Implementation of GattClientObserver
         void ServiceDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle) override;
         void ServiceDiscoveryComplete(OperationStatus status) override;

--- a/services/ble/ClaimingGattClientAdapter.hpp
+++ b/services/ble/ClaimingGattClientAdapter.hpp
@@ -25,6 +25,7 @@ namespace services
     {
     public:
         ClaimingGattClientAdapter(GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
+        ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
 
         // Implementation of GattClientDiscovery
         void StartServiceDiscovery() override;
@@ -119,7 +120,8 @@ namespace services
         std::optional<CharacteristicOperation> characteristicOperationContext;
         infra::AutoResetFunction<void(OperationStatus)> mtuExchangeOnDone;
 
-        infra::ClaimableResource resource;
+        std::optional<infra::ClaimableResource> ownedResource;
+        infra::ClaimableResource& resource;
         infra::ClaimableResource::Claimer characteristicOperationsClaimer{ resource };
         infra::ClaimableResource::Claimer discoveryClaimer{ resource };
         infra::ClaimableResource::Claimer attMtuExchangeClaimer{ resource };

--- a/services/ble/ClaimingGattClientAdapter.hpp
+++ b/services/ble/ClaimingGattClientAdapter.hpp
@@ -25,8 +25,7 @@ namespace services
     {
     public:
         ClaimingGattClientAdapter(GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
-
-        static ClaimingGattClientAdapter WithResource(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
+        ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
 
         // Implementation of GattClientDiscovery
         void StartServiceDiscovery() override;
@@ -47,8 +46,6 @@ namespace services
         uint16_t EffectiveAttMtuSize() const override;
 
     private:
-        ClaimingGattClientAdapter(infra::ClaimableResource& resource, GattClient& gattClient, AttMtuExchange& attMtuExchange, GapCentral& gapCentral);
-
         // Implementation of GattClientObserver
         void ServiceDiscovered(const AttAttribute::Uuid& type, AttAttribute::Handle handle, AttAttribute::Handle endHandle) override;
         void ServiceDiscoveryComplete(OperationStatus status) override;

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -173,6 +173,23 @@ TEST_F(ClaimingGattClientAdapterTest, should_release_claimer_when_disconnected)
     ExecuteAllActions();
 }
 
+TEST_F(ClaimingGattClientAdapterTest, uses_external_resource_shared_with_other_claimer)
+{
+    infra::ClaimableResource sharedResource;
+    infra::ClaimableResource::Claimer otherClaimer{ sharedResource };
+    services::ClaimingGattClientAdapter adapterWithResource{ sharedResource, gattClient, attMtuExchange, gapCentral };
+
+    otherClaimer.Claim([]() {});
+    ExecuteAllActions();
+
+    adapterWithResource.StartServiceDiscovery();
+    ExecuteAllActions();
+
+    EXPECT_CALL(gattClient, StartServiceDiscovery());
+    otherClaimer.Release();
+    ExecuteAllActions();
+}
+
 class ClaimingGattClientAdapterStatusTest
     : public ClaimingGattClientAdapterTest
     , public testing::WithParamInterface<services::OperationStatus>

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -177,7 +177,7 @@ TEST_F(ClaimingGattClientAdapterTest, uses_external_resource_shared_with_other_c
 {
     infra::ClaimableResource sharedResource;
     infra::ClaimableResource::Claimer otherClaimer{ sharedResource };
-    services::ClaimingGattClientAdapter adapterWithResource{ sharedResource, gattClient, attMtuExchange, gapCentral };
+    auto adapterWithResource = services::ClaimingGattClientAdapter::WithResource(sharedResource, gattClient, attMtuExchange, gapCentral);
 
     otherClaimer.Claim([]() {});
     ExecuteAllActions();

--- a/services/ble/test/TestClaimingGattClientAdapter.cpp
+++ b/services/ble/test/TestClaimingGattClientAdapter.cpp
@@ -177,7 +177,7 @@ TEST_F(ClaimingGattClientAdapterTest, uses_external_resource_shared_with_other_c
 {
     infra::ClaimableResource sharedResource;
     infra::ClaimableResource::Claimer otherClaimer{ sharedResource };
-    auto adapterWithResource = services::ClaimingGattClientAdapter::WithResource(sharedResource, gattClient, attMtuExchange, gapCentral);
+    services::ClaimingGattClientAdapter adapterWithResource{ sharedResource, gattClient, attMtuExchange, gapCentral };
 
     otherClaimer.Claim([]() {});
     ExecuteAllActions();


### PR DESCRIPTION
The `GattClient` is often required by various different constructs, and to keep them all in sync it might be required to have a single resource shared between them all.