### PR TITLE
docs(ble): correct explanation of bond list order that uses LRU 

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -482,7 +482,7 @@ message Bond
 
 message BondList
 {    
-    // Will be sorted by least recently used (LRU), oldest -> newest.
+    // Sorted by least recently used (LRU): least recently used -> most recently used.
     repeated Bond bonds = 1 [(array_size) = 32];
 }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -482,7 +482,8 @@ message Bond
 
 message BondList
 {    
-    repeated Bond bonds = 1 [(array_size) = 32]; // Will be sorted by age, oldest -> newest.
+    // Will be sorted by least recently used (LRU), oldest -> newest.
+    repeated Bond bonds = 1 [(array_size) = 32];
 }
 
 // ==================================================
@@ -604,7 +605,7 @@ service GapCentral
 
     // Allowed states: standby, scanning, connected, initiating
     // Expected response: GapCentralResponse.BondListReceived
-    // Description: Returns the list of bonded devices including their identity address and device name, sorted oldest to newest.
+    // Description: Returns the list of bonded devices.
     rpc GetBondList(Nothing) returns (Nothing) { option (method_id) = 14; }
 
     // Allowed states: standby
@@ -670,7 +671,7 @@ service GapCentralResponse {
 
     // Expected states: standby, scanning, initiating, connected
     // Triggered by: GapCentral.GetBondList
-    // Description: Returns the list of bonded devices sorted oldest to newest.
+    // Description: Returns the list of bonded devices.
     rpc BondListReceived(BondList) returns (Nothing) { option(method_id) = 7; }
 
     // DEPRECATED: Will be removed in the near future.


### PR DESCRIPTION
Our interface defines the oldest bond as the "least recently used" (LRU). For example, see below the original function `RemoveOldestBond`. The new function `GetBondList` is supposed to replace this function, however aging mechanism is not explicitly defined, and previously _sounded_ like FIFO (sorted by bond creation order). This PR just changes the wording so that it's explicit.

https://github.com/philips-software/amp-embedded-infra-lib/blob/90d60de9b90140bd4543387433842b818f21b506/services/ble/Gap.proto#L315-L318