### PR TITLE
docs(ble): note that a bond's device name can be empty

### DIFF
--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -480,8 +480,9 @@ message Bond
     AddressWithType addressWithType = 1;
     
     // Device Name from GAP (Generic Access) service.
+    // Read from the peer on bond created and on every successful encryption change.
     // Not unique; truncated to 32 bytes.
-    // Can be empty if the device does not have a name or has not been read yet.
+    // Can be empty if read name is empty, or has not been read yet.
     bytes deviceName = 2 [(bytes_size) = 32];
 }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -482,7 +482,7 @@ message Bond
     // Device Name from GAP (Generic Access) service.
     // Read from the peer on bond created and on every successful encryption change.
     // Not unique; truncated to 32 bytes.
-    // Can be empty if read name is empty, or has not been read yet.
+    // Can be empty if device has an empty name, or has not been read yet.
     bytes deviceName = 2 [(bytes_size) = 32];
 }
 

--- a/services/ble/Gap.proto
+++ b/services/ble/Gap.proto
@@ -476,8 +476,13 @@ message ResolvedPrivateAddress
 
 message Bond
 {
-    AddressWithType addressWithType = 1;        // Identity address
-    bytes deviceName = 2 [(bytes_size) = 32];   // Device Name from GAP (Generic Access) service. Not unique; truncated to 32 bytes.
+    // Identity address of the peer
+    AddressWithType addressWithType = 1;
+    
+    // Device Name from GAP (Generic Access) service.
+    // Not unique; truncated to 32 bytes.
+    // Can be empty if the device does not have a name or has not been read yet.
+    bytes deviceName = 2 [(bytes_size) = 32];
 }
 
 message BondList


### PR DESCRIPTION
Note that a device name returned through the `Gap*::GetBondList` command can be empty.