### PR TITLE
feat: optimized JsonString::ToStdString

### DIFF
--- a/infra/syntax/Json.cpp
+++ b/infra/syntax/Json.cpp
@@ -272,12 +272,7 @@ namespace infra
 #ifdef EMIL_HOST_BUILD
     std::string JsonString::ToStdString() const
     {
-        std::string result;
-
-        for (auto c : *this)
-            result.push_back(c);
-
-        return result;
+        return { begin(), end() };
     }
 #endif
 


### PR DESCRIPTION
Changed from byte-to-byte appending to a zero-initialized string to just costructing the string from the begin/end iterators.