### PR TITLE
ci: use proper tags for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
     directory: .clusterfuzzlite
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "build(deps)"
+
   - package-ecosystem: docker
     directory: .devcontainer
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "ci(deps)"
+
   - package-ecosystem: docker
     directory: .clusterfuzzlite
     schedule:
@@ -21,3 +24,5 @@ updates:
     directory: .devcontainer
     schedule:
       interval: daily
+    commit-message:
+      prefix: "build(deps)"


### PR DESCRIPTION
Updated commit message prefixes for GitHub Actions and Docker dependencies.