### PR TITLE
test: helper for echo tests with deferred requests

### DIFF
--- a/protobuf/echo/test_doubles/CMakeLists.txt
+++ b/protobuf/echo/test_doubles/CMakeLists.txt
@@ -7,6 +7,8 @@ target_link_libraries(protobuf.test_doubles PUBLIC
 )
 
 target_sources(protobuf.test_doubles PRIVATE
+    DeferredSendEchoPolicy.cpp
+    DeferredSendEchoPolicy.hpp
     EchoSingleLoopback.cpp
     EchoSingleLoopback.hpp
     EchoMock.hpp

--- a/protobuf/echo/test_doubles/DeferredSendEchoPolicy.cpp
+++ b/protobuf/echo/test_doubles/DeferredSendEchoPolicy.cpp
@@ -1,0 +1,33 @@
+#include "protobuf/echo/test_doubles/DeferredSendEchoPolicy.hpp"
+
+namespace services
+{
+    void DeferredSendEchoPolicy::RequestSend(ServiceProxy& proxy, const infra::Function<void(ServiceProxy& proxy)>& onRequest)
+    {
+        if (deferring)
+            deferredRequests.emplace_back(&proxy, onRequest);
+        else
+            onRequest(proxy);
+    }
+
+    void DeferredSendEchoPolicy::StartDeferring()
+    {
+        deferring = true;
+    }
+
+    void DeferredSendEchoPolicy::GrantDeferredRequests()
+    {
+        deferring = false;
+
+        auto requests = std::move(deferredRequests);
+        deferredRequests.clear();
+
+        for (auto& [proxy, onRequest] : requests)
+            onRequest(*proxy);
+    }
+
+    const std::vector<DeferredSendEchoPolicy::DeferredRequest>& DeferredSendEchoPolicy::DeferredRequests() const
+    {
+        return deferredRequests;
+    }
+}

--- a/protobuf/echo/test_doubles/DeferredSendEchoPolicy.cpp
+++ b/protobuf/echo/test_doubles/DeferredSendEchoPolicy.cpp
@@ -22,7 +22,7 @@ namespace services
         auto requests = std::move(deferredRequests);
         deferredRequests.clear();
 
-        for (auto& [proxy, onRequest] : requests)
+        for (const auto& [proxy, onRequest] : requests)
             onRequest(*proxy);
     }
 

--- a/protobuf/echo/test_doubles/DeferredSendEchoPolicy.hpp
+++ b/protobuf/echo/test_doubles/DeferredSendEchoPolicy.hpp
@@ -1,0 +1,28 @@
+#ifndef PROTOBUF_TEST_DEFERRED_SEND_ECHO_POLICY_HPP
+#define PROTOBUF_TEST_DEFERRED_SEND_ECHO_POLICY_HPP
+
+#include "protobuf/echo/Echo.hpp"
+#include <utility>
+#include <vector>
+
+namespace services
+{
+    class DeferredSendEchoPolicy
+        : public EchoPolicy
+    {
+    public:
+        using DeferredRequest = std::pair<ServiceProxy*, infra::Function<void(ServiceProxy& proxy)>>;
+
+        void RequestSend(ServiceProxy& proxy, const infra::Function<void(ServiceProxy& proxy)>& onRequest) override;
+
+        void StartDeferring();
+        void GrantDeferredRequests();
+        const std::vector<DeferredRequest>& DeferredRequests() const;
+
+    private:
+        bool deferring = false;
+        std::vector<DeferredRequest> deferredRequests;
+    };
+}
+
+#endif


### PR DESCRIPTION
An `EchoPolicy` that can withhold send grants on demand:

- `StartDeferring()` — capture `RequestSend` calls instead of forwarding them
- `DeferredRequests()` — the captured `(ServiceProxy*, onRequest)` pairs, in request order
- `GrantDeferredRequests()` — stop deferring and forward everything that was captured

Before `StartDeferring()` it behaves like the default policy.

## Why

`EchoSingleLoopback` grants every send synchronously, so a test can never observe two sends pending at the same time. That scenario matters: a service that replies to an inbound method while also emitting an asynchronous notification must use two distinct `ServiceProxy` instances, otherwise the second `ServiceProxy::RequestSend` hits `really_assert(!onGranted)`.

That used to be tested with `EchoMock`, which never grants — but `EchoMock` also cannot deliver an inbound method, so the service method had to be called directly on the controller, bypassing `Service::StartMethod`. This policy allows driving a real inbound method over Echo *while* keeping the resulting sends pending.

## Usage

```cpp
MyTest()
{
    echo.SetPolicy(policy);
}

application::EchoSingleLoopback echo{ serializerFactory };
services::DeferredSendEchoPolicy policy;
```

```cpp
EXPECT_CALL(observer, SomethingHappened()).WillOnce([this]()
    {
        policy.StartDeferring();
        controller.NotifyAsynchronously();
    });

requestProxy.RequestSend([this]()
    {
        requestProxy.SomeMethod();
    });

ASSERT_THAT(policy.DeferredRequests(), testing::SizeIs(2));
EXPECT_THAT(policy.DeferredRequests().front().first, testing::Ne(policy.DeferredRequests().back().first));

policy.GrantDeferredRequests();
```

Deferred requests must be granted before teardown, otherwise `~ServiceProxy` cancels a send that `EchoOnStreams` never registered.