### PR TITLE
chore: make StateGuard destructor protected non-virtual

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,12 +5,10 @@ This repository is a set of C++ libraries and headers that provide heap-less, ST
 ## Build System Conventions
 
 **CMake Presets**: Use CMake presets extensively. Key presets:
-
 - `host` - Host tooling/tests (use for development)
 - `coverage` - Test coverage analysis
 
 **EmIL Patterns**: All CMake uses EmIL conventions:
-
 ```cmake
 emil_build_for(target BOOL EMIL_BUILD_TESTS)
 emil_generate_artifacts(TARGET target HEX MAP)
@@ -18,7 +16,6 @@ emil_exclude_from_clang_format(directory)
 ```
 
 **Target Conditionals**: Build logic heavily uses target conditionals:
-
 ```cmake
 if ("${TARGET_MCU}" STREQUAL stm32wb55)
 if (TARGET_MCU_VENDOR STREQUAL ti)
@@ -31,7 +28,6 @@ if (TARGET_MCU_VENDOR STREQUAL ti)
 **Code Style and Formatting**: MUST follow the `./documents/modules/ROOT/pages/CodingStandard.adoc`. Use `clang-format` for formatting; configured via `.clang-format`.
 
 **Build Commands**:
-
 ```bash
 # List available presets
 cmake --list-presets
@@ -48,11 +44,9 @@ ctest --preset host -R <test_name>
 ```
 
 **Pull Requests and Commits**:
-
 - Follow Conventional Commit style from `.github/CONTRIBUTING.md` when proposing pull request titles and when creating commit messages.
 
 **VS Code Integration**:
-
 - CMake extension manages presets via status bar
 - TestMate C++ for micro tests
 - Gcov Viewer for coverage analysis

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,7 +88,7 @@ ctest --preset host -R <test_name>
 - Prefer `infra` containers (e.g., `infra::Bounded*`, `infra::Intrusive*`) over standard library containers, except in host applications and tests.
 - When declaring a class with base classes, place the colon and inheritance list on a separate line with proper indentation.
 - Constructors with one parameter must be an explicit constructor.
-- Declare `protected: ~MyBase() = default;` on base classes instead of a public `virtual` destructor. A virtual destructor is only allowed when objects are actually deleted through a base pointer. As per C++ Core Guideline C.35.
+- Declare `protected: ~MyBase() = default;` on base classes instead of a public `virtual` destructor. A virtual destructor is only allowed when objects should be deletable through their base pointer. As per C++ Core Guideline C.35.
 - No exceptions shall be used in the codebase, except in Host applications and tests.
 - Avoid protected members in classes except test classes; prefer private members with public/protected accessors if needed.
 - Use SFINAE to restrict template parameters if the template is only valid for specific types.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,10 +5,12 @@ This repository is a set of C++ libraries and headers that provide heap-less, ST
 ## Build System Conventions
 
 **CMake Presets**: Use CMake presets extensively. Key presets:
+
 - `host` - Host tooling/tests (use for development)
 - `coverage` - Test coverage analysis
 
 **EmIL Patterns**: All CMake uses EmIL conventions:
+
 ```cmake
 emil_build_for(target BOOL EMIL_BUILD_TESTS)
 emil_generate_artifacts(TARGET target HEX MAP)
@@ -16,6 +18,7 @@ emil_exclude_from_clang_format(directory)
 ```
 
 **Target Conditionals**: Build logic heavily uses target conditionals:
+
 ```cmake
 if ("${TARGET_MCU}" STREQUAL stm32wb55)
 if (TARGET_MCU_VENDOR STREQUAL ti)
@@ -28,6 +31,7 @@ if (TARGET_MCU_VENDOR STREQUAL ti)
 **Code Style and Formatting**: MUST follow the `./documents/modules/ROOT/pages/CodingStandard.adoc`. Use `clang-format` for formatting; configured via `.clang-format`.
 
 **Build Commands**:
+
 ```bash
 # List available presets
 cmake --list-presets
@@ -44,9 +48,11 @@ ctest --preset host -R <test_name>
 ```
 
 **Pull Requests and Commits**:
+
 - Follow Conventional Commit style from `.github/CONTRIBUTING.md` when proposing pull request titles and when creating commit messages.
 
 **VS Code Integration**:
+
 - CMake extension manages presets via status bar
 - TestMate C++ for micro tests
 - Gcov Viewer for coverage analysis
@@ -82,7 +88,7 @@ ctest --preset host -R <test_name>
 - Prefer `infra` containers (e.g., `infra::Bounded*`, `infra::Intrusive*`) over standard library containers, except in host applications and tests.
 - When declaring a class with base classes, place the colon and inheritance list on a separate line with proper indentation.
 - Constructors with one parameter must be an explicit constructor.
-- Declare `protected: ~MyBase() = default;` on base classes instead of a public `virtual` destructor. A virtual destructor is only allowed when objects are actually deleted through a base pointer.
+- Declare `protected: ~MyBase() = default;` on base classes instead of a public `virtual` destructor. A virtual destructor is only allowed when objects are actually deleted through a base pointer. As per C++ Core Guideline C.35.
 - No exceptions shall be used in the codebase, except in Host applications and tests.
 - Avoid protected members in classes except test classes; prefer private members with public/protected accessors if needed.
 - Use SFINAE to restrict template parameters if the template is only valid for specific types.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,6 +82,7 @@ ctest --preset host -R <test_name>
 - Prefer `infra` containers (e.g., `infra::Bounded*`, `infra::Intrusive*`) over standard library containers, except in host applications and tests.
 - When declaring a class with base classes, place the colon and inheritance list on a separate line with proper indentation.
 - Constructors with one parameter must be an explicit constructor.
+- Declare `protected: ~MyBase() = default;` on base classes instead of a public `virtual` destructor. A virtual destructor is only allowed when objects are actually deleted through a base pointer.
 - No exceptions shall be used in the codebase, except in Host applications and tests.
 - Avoid protected members in classes except test classes; prefer private members with public/protected accessors if needed.
 - Use SFINAE to restrict template parameters if the template is only valid for specific types.

--- a/services/ble/StateGuard.hpp
+++ b/services/ble/StateGuard.hpp
@@ -13,10 +13,8 @@ namespace services
     class StateGuard
     {
     public:
-        StateGuard() = default;
         StateGuard(const StateGuard& other) = delete;
         StateGuard& operator=(const StateGuard& other) = delete;
-        virtual ~StateGuard() = default;
 
         bool StateIs(std::initializer_list<GapState> states) const
         {
@@ -48,6 +46,9 @@ namespace services
         }
 
     protected:
+        StateGuard() = default;
+        ~StateGuard() = default;
+
         virtual GapState DetermineCurrentState() const = 0;
     };
 } // namespace services


### PR DESCRIPTION
The public `virtual ~StateGuard() = default;` increased binary size on targets using it (~2 kB on some targets).

`StateGuard` is inherited as a `protected` base and nothing ever deletes through a `StateGuard*`, so the destructor never needs to dispatch virtually. Declaring it virtual anyway adds vtable slots and forces the compiler to emit destructor bodies (plus thunks under multiple inheritance) that are vtable-anchored and therefore cannot be stripped by `--gc-sections`, even though these objects are statically allocated and never destroyed.[ C++ Core Guidelines C.35](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-dtor-virtual) covers this: a base class destructor should be either public and virtual, or protected and non-virtual — the latter applies here, and it makes `delete` through the base a compile error instead of undefined behaviour.