### PR TITLE
feat(mbedTLS): refactored, upgraded and removed deprecated mbedTLSv3 calls

### DIFF
--- a/infra/syntax/Asn1Formatter.cpp
+++ b/infra/syntax/Asn1Formatter.cpp
@@ -130,6 +130,11 @@ namespace infra
         stream << infra::text << 'Z';
     }
 
+    void Asn1Formatter::AddDer(infra::ConstByteRange der)
+    {
+        stream << der;
+    }
+
     Asn1ContainerFormatter Asn1Formatter::StartSequence()
     {
         stream << static_cast<uint8_t>(Tag::Constructed | Tag::Sequence);

--- a/infra/syntax/Asn1Formatter.cpp
+++ b/infra/syntax/Asn1Formatter.cpp
@@ -130,9 +130,10 @@ namespace infra
         stream << infra::text << 'Z';
     }
 
-    void Asn1Formatter::AddDer(infra::ConstByteRange der)
+    void Asn1Formatter::AddConstructed(infra::ConstByteRange constructed)
     {
-        stream << der;
+        really_assert(!constructed.empty() && (constructed.front() & Tag::Constructed) != 0);
+        stream << constructed;
     }
 
     Asn1ContainerFormatter Asn1Formatter::StartSequence()

--- a/infra/syntax/Asn1Formatter.cpp
+++ b/infra/syntax/Asn1Formatter.cpp
@@ -1,4 +1,5 @@
 #include "infra/syntax/Asn1Formatter.hpp"
+#include "infra/util/ReallyAssert.hpp"
 
 namespace
 {

--- a/infra/syntax/Asn1Formatter.hpp
+++ b/infra/syntax/Asn1Formatter.hpp
@@ -27,6 +27,7 @@ namespace infra
         void AddUtcTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
         void AddGeneralizedTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
         void AddTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
+        void AddDer(infra::ConstByteRange der);
 
         template<typename T>
         void AddOptional(std::optional<T> value);

--- a/infra/syntax/Asn1Formatter.hpp
+++ b/infra/syntax/Asn1Formatter.hpp
@@ -27,7 +27,7 @@ namespace infra
         void AddUtcTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
         void AddGeneralizedTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
         void AddTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
-        void AddDer(infra::ConstByteRange der);
+        void AddConstructed(infra::ConstByteRange constructed);
 
         template<typename T>
         void AddOptional(std::optional<T> value);

--- a/infra/syntax/test/TestAsn1Formatter.cpp
+++ b/infra/syntax/test/TestAsn1Formatter.cpp
@@ -225,6 +225,28 @@ TEST(Asn1ObjectFormatter, add_non_empty_optional)
     ASSERT_THAT(stream.Storage(), testing::ElementsAre(0x02, 0x01, 0xAB));
 }
 
+TEST(Asn1ObjectFormatter, add_constructed)
+{
+    infra::ByteOutputStream::WithStorage<10> stream;
+    infra::Asn1Formatter formatter(stream);
+
+    // Example DER array
+    auto constructed_der = std::array<uint8_t, 10>{ 0x20, 0x08, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02, 0x02, 0x01 };
+    formatter.AddConstructed(constructed_der);
+
+    EXPECT_EQ(constructed_der, stream.Storage());
+}
+
+TEST(Asn1ObjectFormatter, add_constructed_unintentional)
+{
+    infra::ByteOutputStream::WithStorage<2> stream;
+    infra::Asn1Formatter formatter(stream);
+
+    auto constructed_unintentional = std::array<uint8_t, 10>{ 0x00, 0x08, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02, 0x02, 0x01 };
+
+    EXPECT_DEATH(formatter.AddConstructed(constructed_unintentional), ".*");
+}
+
 TEST(Asn1ObjectFormatter, start_sequence)
 {
     infra::ByteOutputStream::WithStorage<8> stream;

--- a/infra/syntax/test/TestAsn1Formatter.cpp
+++ b/infra/syntax/test/TestAsn1Formatter.cpp
@@ -230,22 +230,23 @@ TEST(Asn1ObjectFormatter, add_constructed)
     infra::ByteOutputStream::WithStorage<10> stream;
     infra::Asn1Formatter formatter(stream);
 
-    // Example DER array
-    auto constructed_der = std::array<uint8_t, 10>{ 0x20, 0x08, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02, 0x02, 0x01 };
-    formatter.AddConstructed(constructed_der);
+    auto constructedDer = std::array<uint8_t, 10>{ 0x30, 0x08, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02, 0x05, 0x00 };
+    formatter.AddConstructed(constructedDer);
 
-    EXPECT_EQ(constructed_der, stream.Storage());
+    EXPECT_THAT(stream.Storage(), testing::ElementsAreArray(constructedDer));
 }
 
+#ifndef EMIL_MUTATION_TESTING
 TEST(Asn1ObjectFormatter, add_constructed_unintentional)
 {
-    infra::ByteOutputStream::WithStorage<2> stream;
+    infra::ByteOutputStream::WithStorage<3> stream;
     infra::Asn1Formatter formatter(stream);
 
-    auto constructed_unintentional = std::array<uint8_t, 10>{ 0x00, 0x08, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02, 0x02, 0x01 };
+    auto primitiveDer = std::array<uint8_t, 3>{ 0x02, 0x01, 0x01 };
 
-    EXPECT_DEATH(formatter.AddConstructed(constructed_unintentional), ".*");
+    EXPECT_DEATH(formatter.AddConstructed(primitiveDer), ".*");
 }
+#endif
 
 TEST(Asn1ObjectFormatter, start_sequence)
 {

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -2,8 +2,8 @@
 #include "infra/stream/ByteOutputStream.hpp"
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/ReallyAssert.hpp"
-#include "mbedtls/build_info.h"
 #include "mbedtls/pk.h"
+#include "mbedtls/version.h"
 #include "services/util/MbedTlsRandomDataGeneratorWrapper.hpp"
 
 #if MBEDTLS_VERSION_MAJOR < 3

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -2,8 +2,8 @@
 #include "infra/stream/ByteOutputStream.hpp"
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/ReallyAssert.hpp"
+#include "mbedtls/build_info.h"
 #include "mbedtls/pk.h"
-#include "mbedtls/version.h"
 #include "services/util/MbedTlsRandomDataGeneratorWrapper.hpp"
 
 #if MBEDTLS_VERSION_MAJOR < 3
@@ -121,6 +121,8 @@ namespace services
         stream << infra::AsBase64(infra::ConstByteRange(contents, contents + contentsSize));
         stream << "-----END RSA PRIVATE KEY-----\r\n";
         stream << '\0';
+
+        mbedtls_platform_zeroize(contents, sizeof(contents));
     }
 
     void CertificatesMbedTls::WriteOwnCertificate(infra::BoundedString& outputBuffer, hal::SynchronousRandomDataGenerator& randomDataGenerator)

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -3,6 +3,7 @@
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include "mbedtls/pk.h"
+#include "mbedtls/platform_util.h"
 #include "mbedtls/version.h"
 #include "services/util/MbedTlsRandomDataGeneratorWrapper.hpp"
 

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -105,11 +105,12 @@ namespace services
     {
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
         really_assert(mbedtls_pk_get_psa_attributes(&privateKey, PSA_KEY_USAGE_SIGN_HASH, &attributes) == 0);
+        really_assert(mbedtls_pk_get_type(&privateKey) == MBEDTLS_PK_RSA);
 
         mbedtls_svc_key_id_t keyId = MBEDTLS_SVC_KEY_ID_INIT;
         really_assert(mbedtls_pk_import_into_psa(&privateKey, &attributes, &keyId) == 0);
 
-        unsigned char contents[2048];
+        unsigned char contents[PSA_EXPORT_KEY_PAIR_MAX_SIZE];
         std::size_t contentsSize = 0;
         auto status = psa_export_key(keyId, contents, sizeof(contents), &contentsSize);
         psa_destroy_key(keyId);
@@ -178,7 +179,7 @@ namespace services
                         auto length = mbedtls_pk_write_pubkey_der(&privateKey, spki, sizeof(spki));
                         really_assert(length > 0);
 
-                        tbsSequence.AddDer(infra::ConstByteRange(spki + sizeof(spki) - length, spki + sizeof(spki)));
+                        tbsSequence.AddConstructed(infra::ConstByteRange(spki + sizeof(spki) - length, spki + sizeof(spki)));
                     }
 
                     //  v3 Extensions

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -112,9 +112,8 @@ namespace services
 
         unsigned char contents[PSA_EXPORT_KEY_PAIR_MAX_SIZE];
         std::size_t contentsSize = 0;
-        auto status = psa_export_key(keyId, contents, sizeof(contents), &contentsSize);
-        psa_destroy_key(keyId);
-        really_assert(status == PSA_SUCCESS);
+        really_assert(psa_export_key(keyId, contents, sizeof(contents), &contentsSize) == PSA_SUCCESS);
+        really_assert(psa_destroy_key(keyId) == PSA_SUCCESS);
 
         outputBuffer.clear();
         infra::StringOutputStream stream(outputBuffer);

--- a/services/network/CertificatesMbedTls.cpp
+++ b/services/network/CertificatesMbedTls.cpp
@@ -2,7 +2,6 @@
 #include "infra/stream/ByteOutputStream.hpp"
 #include "infra/stream/StringOutputStream.hpp"
 #include "infra/util/ReallyAssert.hpp"
-#include "mbedtls/oid.h"
 #include "mbedtls/pk.h"
 #include "mbedtls/version.h"
 #include "services/util/MbedTlsRandomDataGeneratorWrapper.hpp"
@@ -31,6 +30,8 @@ namespace services
         mbedtls_x509_crt_init(&caCertificates);
         mbedtls_x509_crt_init(&ownCertificate);
         mbedtls_pk_init(&privateKey);
+
+        really_assert(psa_crypto_init() == PSA_SUCCESS);
     }
 
     CertificatesMbedTls::~CertificatesMbedTls()
@@ -102,28 +103,22 @@ namespace services
 
     void CertificatesMbedTls::WritePrivateKey(infra::BoundedString& outputBuffer)
     {
-        infra::ByteOutputStream::WithStorage<2048> contentsStream;
-        infra::Asn1Formatter formatter(contentsStream);
-        {
-            auto sequence = formatter.StartSequence();
+        psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+        really_assert(mbedtls_pk_get_psa_attributes(&privateKey, PSA_KEY_USAGE_SIGN_HASH, &attributes) == 0);
 
-            mbedtls_rsa_context& rsaContext = *mbedtls_pk_rsa(privateKey);
+        mbedtls_svc_key_id_t keyId = MBEDTLS_SVC_KEY_ID_INIT;
+        really_assert(mbedtls_pk_import_into_psa(&privateKey, &attributes, &keyId) == 0);
 
-            sequence.Add(uint8_t(rsaContext.MBEDTLS_PRIVATE(ver)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(N)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(E)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(D)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(P)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(Q)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(DP)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(DQ)));
-            sequence.AddBigNumber(MakeByteRange(rsaContext.MBEDTLS_PRIVATE(QP)));
-        }
+        unsigned char contents[2048];
+        std::size_t contentsSize = 0;
+        auto status = psa_export_key(keyId, contents, sizeof(contents), &contentsSize);
+        psa_destroy_key(keyId);
+        really_assert(status == PSA_SUCCESS);
 
         outputBuffer.clear();
         infra::StringOutputStream stream(outputBuffer);
         stream << "-----BEGIN RSA PRIVATE KEY-----\r\n";
-        stream << infra::AsBase64(contentsStream.Writer().Processed());
+        stream << infra::AsBase64(infra::ConstByteRange(contents, contents + contentsSize));
         stream << "-----END RSA PRIVATE KEY-----\r\n";
         stream << '\0';
     }
@@ -176,24 +171,14 @@ namespace services
 
                     // PublicKeyInfo
                     {
-                        auto publicKeyInfoSequence = tbsSequence.StartSequence();
-                        mbedtls_x509_buf pk_oid;
+                        // AlgorithmIdentifier (SEQUENCE 2 + OID 11 + NULL 2 = 15) + BIT STRING header 4 + unused-bits byte 1 + outer SEQUENCE header 4.
+                        constexpr std::size_t subjectPublicKeyInfoOverhead = 24;
+                        unsigned char spki[PSA_EXPORT_PUBLIC_KEY_MAX_SIZE + subjectPublicKeyInfoOverhead];
 
-                        mbedtls_oid_get_oid_by_pk_alg(mbedtls_pk_get_type(&privateKey), const_cast<const char**>(reinterpret_cast<char**>(&pk_oid.p)), &pk_oid.len);
+                        auto length = mbedtls_pk_write_pubkey_der(&privateKey, spki, sizeof(spki));
+                        really_assert(length > 0);
 
-                        X509AddAlgorithm(publicKeyInfoSequence, pk_oid);
-
-                        {
-                            auto publicKeyBitString = publicKeyInfoSequence.StartBitString();
-                            {
-                                auto rsaPublicKeySequence = publicKeyBitString.StartSequence();
-                                mbedtls_rsa_context* rsaContext = mbedtls_pk_rsa(privateKey);
-                                really_assert(rsaContext != nullptr);
-
-                                rsaPublicKeySequence.AddBigNumber(MakeByteRange(rsaContext->MBEDTLS_PRIVATE(N)));
-                                rsaPublicKeySequence.AddBigNumber(MakeByteRange(rsaContext->MBEDTLS_PRIVATE(E)));
-                            }
-                        }
+                        tbsSequence.AddDer(infra::ConstByteRange(spki + sizeof(spki) - length, spki + sizeof(spki)));
                     }
 
                     //  v3 Extensions


### PR DESCRIPTION
This pull request updates the certificate handling code to use the PSA Crypto API for private and public key operations, improving security and maintainability. It also adds a utility method to the ASN.1 formatter for easier DER encoding insertion.

**Certificate key handling improvements:**

* Refactored `CertificatesMbedTls::WritePrivateKey` to use PSA Crypto API for exporting private keys instead of manual ASN.1 formatting, ensuring better integration with hardware-backed key storage and improved security.
* Updated public key encoding in certificate generation to use `mbedtls_pk_write_pubkey_der` and the new `AddDer` method, replacing manual ASN.1 construction for SubjectPublicKeyInfo.
* Ensured PSA Crypto is initialized during certificate object construction by calling `psa_crypto_init()`.

**Infrastructure and utility enhancements:**

* Added `AddConstruct` method to `infra::Asn1Formatter` to allow direct insertion of constructed data into ASN.1 streams. [[1]](diffhunk://#diff-fa7c93b0d7beb023c1a507aa472edc36d1682c13baf2012662f8175600017bd8R133-R137) [[2]](diffhunk://#diff-53fe8aa7b346843053980aec49f4ddff7fa49bf98cf0d3adea746f6a77b6e939R30)

**Code cleanup:**

* Removed unused `mbedtls/oid.h` include from `CertificatesMbedTls.cpp`.