### PR TITLE
fix(infra/util): allow BoundedVector::swap with a full vector

### DIFF
--- a/infra/util/BoundedVector.hpp
+++ b/infra/util/BoundedVector.hpp
@@ -550,7 +550,7 @@ namespace infra
     {
         using std::swap;
 
-        assert(size() <= other.max_size() && other.size() < max_size());
+        assert(size() <= other.max_size() && other.size() <= max_size());
 
         for (size_type i = 0; i < size() && i < other.size(); ++i)
         {

--- a/infra/util/test/TestBoundedVector.cpp
+++ b/infra/util/test/TestBoundedVector.cpp
@@ -408,6 +408,36 @@ TEST(BoundedVectorTest, TestSwapSmallerWithLarger)
     EXPECT_EQ(expectedVector2, vector2);
 }
 
+TEST(BoundedVectorTest, TestSwapTwoFullVectors)
+{
+    int range1[3] = { 0, 1, 2 };
+    infra::BoundedVector<int>::WithMaxSize<3> vector1(range1, range1 + 3);
+    int range2[3] = { 3, 4, 5 };
+    infra::BoundedVector<int>::WithMaxSize<3> vector2(range2, range2 + 3);
+
+    infra::swap(vector1, vector2);
+
+    infra::BoundedVector<int>::WithMaxSize<3> expectedVector1(range2, range2 + 3);
+    infra::BoundedVector<int>::WithMaxSize<3> expectedVector2(range1, range1 + 3);
+    EXPECT_EQ(expectedVector1, vector1);
+    EXPECT_EQ(expectedVector2, vector2);
+}
+
+TEST(BoundedVectorTest, TestSwapWithFullVector)
+{
+    int range1[1] = { 0 };
+    infra::BoundedVector<int>::WithMaxSize<3> vector1(range1, range1 + 1);
+    int range2[3] = { 1, 2, 3 };
+    infra::BoundedVector<int>::WithMaxSize<3> vector2(range2, range2 + 3);
+
+    infra::swap(vector1, vector2);
+
+    infra::BoundedVector<int>::WithMaxSize<3> expectedVector1(range2, range2 + 3);
+    infra::BoundedVector<int>::WithMaxSize<3> expectedVector2(range1, range1 + 1);
+    EXPECT_EQ(expectedVector1, vector1);
+    EXPECT_EQ(expectedVector2, vector2);
+}
+
 TEST(BoundedVectorTest, TestClear)
 {
     infra::BoundedVector<int>::WithMaxSize<5> vector(std::size_t(2), 4);


### PR DESCRIPTION
Fixes #1314

`BoundedVector::swap()` guards capacity with

```cpp
assert(size() <= other.max_size() && other.size() < max_size());
```

The second condition uses `<` where the first uses `<=`. Swapping is therefore rejected whenever the right-hand vector is exactly full, even though both vectors have enough room for the other's contents.

Two consequences:

- two full vectors of equal capacity can never be swapped
- the check is asymmetric — `full.swap(smaller)` passes while `smaller.swap(full)` aborts, so whether a valid swap succeeds depends on which vector is the left-hand side

The reproduction from the issue aborts on `main`:

```cpp
infra::BoundedVector<int>::WithMaxSize<2> a, b;
a.push_back(1); a.push_back(2);
b.push_back(3); b.push_back(4);
a.swap(b);   // Assertion failed: other.size() < max_size()  ->  2 < 2
```

The body below the assertion already handles this case correctly — the three loops copy the shared prefix and move the tail either way — so only the guard needed changing.

## Change

Use `<=` in both halves of the assertion. Each vector is still required to have capacity for the other's contents; only the off-by-one is removed.

## Tests

Two tests added alongside the existing swap tests:

- `TestSwapTwoFullVectors` — the reported case, both vectors full at equal capacity
- `TestSwapWithFullVector` — a smaller vector swapped with a full one, the direction the asymmetry rejected

`TestBoundedVector.cpp` passes 48/48 with this change. With the assertion reverted, the suite aborts at `TestSwapTwoFullVectors`, so the tests pin the guard rather than the surrounding logic.

I ran that file directly against GoogleTest rather than through the CMake presets — `cmake --preset host` stalls while fetching dependencies on my machine, so I could not run the full `host` build locally. Everything here is header-only container code, so CI should be a clean signal.
