### PR TITLE
fix(infra/syntax): include what the headers use

### DIFF
--- a/infra/syntax/Asn1.hpp
+++ b/infra/syntax/Asn1.hpp
@@ -2,6 +2,7 @@
 #define INFRA_ASN1_HPP
 
 #include "infra/util/ByteRange.hpp"
+#include <cstdint>
 #include <utility>
 
 namespace infra

--- a/infra/syntax/Asn1Formatter.hpp
+++ b/infra/syntax/Asn1Formatter.hpp
@@ -4,6 +4,8 @@
 #include "infra/stream/OutputStream.hpp"
 #include "infra/stream/SavedMarkerStream.hpp"
 #include "infra/util/WithStorage.hpp"
+#include <cstdint>
+#include <optional>
 
 namespace infra
 {

--- a/infra/syntax/CppFormatter.hpp
+++ b/infra/syntax/CppFormatter.hpp
@@ -2,7 +2,9 @@
 #define INFRA_CPP_FORMATTER_HPP
 
 #include "google/protobuf/io/printer.h"
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace application

--- a/infra/syntax/JsonFileReader.hpp
+++ b/infra/syntax/JsonFileReader.hpp
@@ -3,6 +3,8 @@
 
 #include "infra/syntax/Json.hpp"
 #include "infra/syntax/JsonObjectNavigator.hpp"
+#include <string>
+#include <vector>
 
 namespace infra
 {

--- a/infra/syntax/JsonFormatter.hpp
+++ b/infra/syntax/JsonFormatter.hpp
@@ -5,6 +5,7 @@
 #include "infra/syntax/Json.hpp"
 #include "infra/util/BoundedString.hpp"
 #include "infra/util/WithStorage.hpp"
+#include <cstdint>
 #include <optional>
 #include <type_traits>
 

--- a/infra/syntax/JsonInputStream.hpp
+++ b/infra/syntax/JsonInputStream.hpp
@@ -3,6 +3,7 @@
 
 #include "infra/stream/InputStream.hpp"
 #include "infra/syntax/Json.hpp"
+#include <cstdint>
 
 namespace infra
 {

--- a/infra/syntax/JsonObjectNavigator.hpp
+++ b/infra/syntax/JsonObjectNavigator.hpp
@@ -2,8 +2,10 @@
 #define JSON_OBJECT_NAVIGATOR_HPP
 
 #include "infra/syntax/Json.hpp"
+#include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 
 namespace infra
 {

--- a/infra/syntax/JsonStreamingParser.hpp
+++ b/infra/syntax/JsonStreamingParser.hpp
@@ -5,6 +5,7 @@
 #include "infra/util/BoundedVector.hpp"
 #include "infra/util/PolymorphicVariant.hpp"
 #include "infra/util/WithStorage.hpp"
+#include <cstdint>
 
 namespace infra
 {

--- a/infra/syntax/ProtoFormatter.hpp
+++ b/infra/syntax/ProtoFormatter.hpp
@@ -3,6 +3,7 @@
 
 #include "infra/stream/OutputStream.hpp"
 #include "infra/util/BoundedVector.hpp"
+#include <cstdint>
 
 namespace infra
 {

--- a/infra/syntax/ProtoParser.hpp
+++ b/infra/syntax/ProtoParser.hpp
@@ -4,8 +4,11 @@
 #include "infra/stream/InputStream.hpp"
 #include "infra/stream/LimitedInputStream.hpp"
 #include "infra/util/BoundedVector.hpp"
+#include <cstdint>
+#include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace infra
 {

--- a/infra/syntax/XmlNavigator.hpp
+++ b/infra/syntax/XmlNavigator.hpp
@@ -2,9 +2,12 @@
 #define INFRA_XML_OBJECT_NAVIGATOR_HPP
 
 #include "pugixml.hpp"
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace infra
 {


### PR DESCRIPTION
Eleven of the fourteen headers in `infra/syntax` use a type without including the header that defines it. `XmlNavigator.hpp` from the issue is one of them: it uses `int32_t`, `std::string` and `std::vector`, while including only pugixml, `<functional>`, `<optional>` and `<stdexcept>`.

| header | added |
| --- | --- |
| Asn1.hpp | `<cstdint>` |
| Asn1Formatter.hpp | `<cstdint>`, `<optional>` |
| CppFormatter.hpp | `<cstdint>`, `<string>` |
| JsonFileReader.hpp | `<string>`, `<vector>` |
| JsonFormatter.hpp | `<cstdint>` |
| JsonInputStream.hpp | `<cstdint>` |
| JsonObjectNavigator.hpp | `<cstdint>`, `<string>` |
| JsonStreamingParser.hpp | `<cstdint>` |
| ProtoFormatter.hpp | `<cstdint>` |
| ProtoParser.hpp | `<cstdint>`, `<string>`, `<vector>` |
| XmlNavigator.hpp | `<cstdint>`, `<string>`, `<vector>` |

19 lines added, nothing else touched. Each one is placed alphabetically among the existing angle-bracket includes, below the quoted ones, matching what the files already do.

On verification, and the part worth being straight about: I could not reproduce the original failure. All fourteen headers compile standalone both before and after this change, under Apple clang with libc++ and under gcc 13 with libstdc++ in a container. Both of those pull the missing headers in transitively, which is exactly why the break only showed up in the MinGW build in the issue. So this is not "a failing build now passes", it is the headers no longer depending on a transitive include that a given standard library may or may not give them.

What I did check is the property itself: a scan for types used directly without the defining header included directly reports 11 of 14 headers before, 0 of 14 after, and no header regressed on either toolchain.

Scope is deliberately one directory. The same pattern exists elsewhere in the repo, and `include-what-you-use` as the issue suggests would be the durable answer. Happy to continue directory by directory, or to leave it here if you would rather wire up the tool.

Fixes #1121
