### PR TITLE
ci: skip the secret-dependent jobs on fork pull requests

### DIFF
--- a/.github/workflows/dependency-scanner.yml
+++ b/.github/workflows/dependency-scanner.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   dependency-submission:
+    # the dependency graph needs contents:write, which a fork PR's token does not carry
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/fuzzing-pr.yml
+++ b/.github/workflows/fuzzing-pr.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   fuzz_pr:
-    # skip fuzzing for dependabot PRs since dependabot does not have access to secrets
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # skip fuzzing for dependabot and fork PRs since neither has access to secrets
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}-${{ matrix.sanitizer }}-${{ github.workflow }}


### PR DESCRIPTION
Following on from the conversation in #1332.

`fuzzing-pr.yml` already skips dependabot, with the comment "dependabot does not have access to secrets". Fork pull requests are in exactly that position, so this extends the same condition to them, and applies it to `dependency-submission` too.

That turns three of the four checks that always fail on a fork into skips:

- `fuzz_pr (address)` and `fuzz_pr (undefined)`, which cannot clone the metrics repo without `METRICS_TOKEN`
- `dependency-submission`, which needs `contents: write` that a fork's token does not carry

`dependency-review` has `needs: [dependency-submission]`, so it skips with it rather than failing on the missing snapshot.

`merge_group` and `workflow_dispatch` runs are unaffected. `github.event.pull_request` is null for both, so `!github.event.pull_request.head.repo.fork` stays true and the jobs run as they do now. `actionlint` is clean on both files.

This does not solve #116, it just stops the noise. On the two that would actually solve it:

**SonarCloud** is the hard one, because the coverage build genuinely compiles and runs the contributor's code. The usual route is a GitHub Environment with required reviewers on that job, so `SONAR_TOKEN` is released only after a maintainer has read the diff. That is a repository settings change rather than something I can put in a PR, so I have left it alone.

**dependency-submission** looked splittable into an unprivileged `pull_request` job that produces the snapshot and a `workflow_run` job that submits it, which would keep untrusted code out of the privileged half. `philips-forks/cmake-dependency-submission` calculates and submits in one step though, with no snapshot-only output, so doing it properly needs a change there first. Worth noting that in the default `glob` scanMode it parses CMake files rather than configuring them, so it is not executing the contributor's build, which may make it a better first candidate than Sonar if you do want to pursue it.

Happy to take either further if useful.

Refs #116
