### PR TITLE
fix(infra/util): reject an oversized swap in BoundedDeque and BoundedString

### DIFF
--- a/infra/util/BoundedDeque.hpp
+++ b/infra/util/BoundedDeque.hpp
@@ -676,6 +676,8 @@ namespace infra
     {
         using std::swap;
 
+        really_assert(size() <= other.max_size() && other.size() <= max_size());
+
         for (size_type i = 0; i < size() && i < other.size(); ++i)
             swap(*storage[index(i)], *other.storage[other.index(i)]);
 

--- a/infra/util/BoundedString.hpp
+++ b/infra/util/BoundedString.hpp
@@ -1130,6 +1130,8 @@ namespace infra
     {
         using std::swap;
 
+        really_assert(size() <= other.max_size() && other.size() <= max_size());
+
         for (size_type i = 0; i < size() && i < other.size(); ++i)
             swap(range[i], other.range[i]);
 

--- a/infra/util/test/TestBoundedDeque.cpp
+++ b/infra/util/test/TestBoundedDeque.cpp
@@ -656,6 +656,16 @@ TEST(BoundedDequeTest, TestSwapDifferentSizes)
     EXPECT_EQ(expectedDeque2, deque2);
 }
 
+TEST(BoundedDequeTest, TestSwapDoesNotExceedCapacity)
+{
+    int range1[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    infra::BoundedDeque<int>::WithMaxSize<8> big(range1, range1 + 8);
+    int range2[2] = { 8, 9 };
+    infra::BoundedDeque<int>::WithMaxSize<3> small(range2, range2 + 2);
+
+    ASSERT_DEATH(small.swap(big), "");
+}
+
 TEST(BoundedDequeTest, TestSwapDifferentSizesWrapped)
 {
     int range1[2] = { 0, 1 };

--- a/infra/util/test/TestBoundedString.cpp
+++ b/infra/util/test/TestBoundedString.cpp
@@ -618,6 +618,14 @@ TEST(BoundedStringTest, TestSwap)
     EXPECT_EQ("abc", string2);
 }
 
+TEST(BoundedStringTest, TestSwapDoesNotExceedCapacity)
+{
+    infra::BoundedString::WithStorage<8> big("abcdefgh");
+    infra::BoundedString::WithStorage<3> small("xy");
+
+    ASSERT_DEATH(small.swap(big), "");
+}
+
 TEST(BoundedStringTest, TestTrimLeft)
 {
     EXPECT_EQ("abc ", infra::TrimLeft(infra::BoundedConstString("abc ")));


### PR DESCRIPTION
Follow-on from #1332. While fixing the asymmetric capacity assertion in `BoundedVector::swap` I checked whether the sibling containers guard the same thing. Two of them do not.

`BoundedDeque::swap` and `BoundedStringBase::swap` copy element by element from the other container with no check that its contents fit. Swapping a larger container into a smaller one writes past the smaller one's capacity.

In a debug build this trips an assertion inside `MemoryRange::operator[]`. In a release build nothing stops it. Compiled with `-DNDEBUG`:

```
before: big.size=8 (max 8), small.size=2 (max 3)
after : small.size=8 max_size=469191256
```

The write ran over the storage range itself, so the deque afterwards reports a size beyond its capacity and a `max_size` read out of corrupted memory. `BoundedString` is the same shape, eight characters into a three-character buffer.

Where the other containers stand, all checked the same way:

| container | oversized swap, release build |
| --- | --- |
| `BoundedVector` | guarded, the assertion #1332 made symmetric |
| `BoundedList` | fails loudly, `really_assert` in `push_back` |
| `BoundedForwardList` | fails loudly, `really_assert` in `push_back` |
| `BoundedDeque` | silent corruption |
| `BoundedString` | silent overflow |

So this adds the missing guard to those two.

On `really_assert` rather than `assert`: `assert` compiles out under `NDEBUG`, which is the build where this actually bites. `push_back` in both of these files already uses `really_assert(!full())` for the same class of error, so this follows what the files do rather than what `BoundedVector::swap` happens to use.

### Verification

With the guard, both abort at the check instead of corrupting, in the same `-DNDEBUG` build as above:

```
ASSERT size() <= other.max_size() && other.size() <= max_size() @ BoundedDeque.hpp:679
ASSERT size() <= other.max_size() && other.size() <= max_size() @ BoundedString.hpp:1133
```

Legitimate swaps are unaffected. Built with ASan and UBSan, `-DNDEBUG`:

```
deque diff sizes : d1.size=2 d2.size=3 d1[0]=3 d2[0]=0
deque wrapped    : w1.size=1 w2.size=4 w2[3]=9
string           : s1='defg' s2='abc'
string both full : f1='xyz' f2='abc'
```

The wrapped case is there deliberately, since `BoundedDeque::index` wraps and I wanted the guard checked against a deque whose storage is not in order.

Tests added next to the existing swap tests in both files, using `ASSERT_DEATH` as `TestBoundedDeque.cpp` already does.

Refs #1332
