### PR TITLE
test(infra/syntax): add a fuzz target for ProtoParser

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -4,3 +4,4 @@ cmake --preset fuzzing
 cmake --build --preset fuzzing
 
 cp build/fuzzing/infra/syntax/fuzz/infra.syntax_json_fuzzer $OUT/infra-syntax_json_fuzzer
+cp build/fuzzing/infra/syntax/fuzz/infra.syntax_proto_parser_fuzzer $OUT/infra-syntax_proto_parser_fuzzer

--- a/infra/syntax/fuzz/CMakeLists.txt
+++ b/infra/syntax/fuzz/CMakeLists.txt
@@ -7,3 +7,13 @@ target_link_libraries(infra.syntax_json_fuzzer PUBLIC
 target_sources(infra.syntax_json_fuzzer PRIVATE
     FuzzJson.cpp
 )
+
+emil_add_fuzzing_executable(infra.syntax_proto_parser_fuzzer)
+
+target_link_libraries(infra.syntax_proto_parser_fuzzer PUBLIC
+    infra.syntax
+)
+
+target_sources(infra.syntax_proto_parser_fuzzer PRIVATE
+    FuzzProtoParser.cpp
+)

--- a/infra/syntax/fuzz/FuzzProtoParser.cpp
+++ b/infra/syntax/fuzz/FuzzProtoParser.cpp
@@ -1,0 +1,65 @@
+#include "infra/stream/ByteInputStream.hpp"
+#include "infra/syntax/ProtoParser.hpp"
+#include "infra/util/BoundedString.hpp"
+#include "infra/util/BoundedVector.hpp"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace
+{
+    // Bounds the work one input can ask for, so a fuzz case that is merely large does
+    // not read as a hang. Deep nesting is the interesting part, not deep recursion.
+    constexpr uint32_t maxFields = 64;
+    constexpr uint32_t maxDepth = 4;
+
+    void ParseFields(infra::ProtoParser& parser, uint32_t depth)
+    {
+        for (uint32_t field = 0; field != maxFields && !parser.Empty() && !parser.FormatFailed(); ++field)
+        {
+            auto [value, fieldNumber] = parser.GetField();
+
+            if (std::holds_alternative<infra::ProtoLengthDelimited>(value))
+            {
+                auto& delimited = std::get<infra::ProtoLengthDelimited>(value);
+
+                // Drive the accessors a generated message would use. Each one reads the
+                // same bytes through a different bound, which is where a length that
+                // outruns the stream would show up.
+                infra::BoundedString::WithStorage<16> string;
+                delimited.GetString(string);
+
+                infra::BoundedConstString stringReference;
+                delimited.GetStringReference(stringReference);
+
+                infra::BoundedVector<uint8_t>::WithMaxSize<16> bytes;
+                delimited.GetBytes(bytes);
+
+                infra::ConstByteRange bytesReference;
+                delimited.GetBytesReference(bytesReference);
+
+                if (depth != maxDepth)
+                {
+                    auto nested = delimited.Parser();
+                    ParseFields(nested, depth + 1);
+                }
+
+                delimited.SkipEverything();
+            }
+        }
+    }
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
+{
+    infra::ByteInputStream stream(infra::ConstByteRange(data, data + size), infra::softFail);
+    infra::ProtoParser parser(stream);
+
+    ParseFields(parser, 0);
+
+    // softFail requires the caller to read the result before the policy is destroyed.
+    static_cast<void>(parser.FormatFailed());
+    static_cast<void>(stream.ErrorPolicy().Failed());
+
+    return 0;
+}


### PR DESCRIPTION
The repository has ClusterFuzzLite wired up but only one fuzz target, covering `Json`. This adds a second, for `ProtoParser`.

`ProtoParser` is the natural next one. It reads a length-delimited binary format where the length comes from the input itself and is then used to bound a reader:

```cpp
case 2:
    return std::make_pair(PartialProtoLengthDelimited{ static_cast<uint32_t>(GetVarInt()) }, fieldNumber);
```

so a varint that does not match the bytes actually present is reachable from any input, and each accessor (`GetString`, `GetStringReference`, `GetBytes`, `GetBytesReference`, `GetStdString`) reads that region through a different bound.

The target drives all of those, then recurses into nested messages, so a length that outruns the stream is exercised through every bound rather than just the first. Field count and nesting depth are capped so a large input does not read as a hang.

## What I found

Nothing, and I want to be straight about how hard I looked.

I could not link libFuzzer locally: Apple's clang ships no fuzzer runtime, so `-fsanitize=fuzzer` fails at link with `libclang_rt.fuzzer_osx.a` not found. The target itself compiles clean under the `fuzzing` preset, only the link step fails, so this is a toolchain gap on my machine rather than a problem with the code.

To get some signal anyway I built the same `LLVMFuzzerTestOneInput` entry point into a standalone driver with ASan and UBSan, and fed it 1.8 million inputs across 12 seeds, biased toward protobuf shapes (a tag byte carrying a wire type, then length and payload) mixed with noise. All clean. `LimitedStreamReader` appears to be doing its job of keeping a bogus length from reaching past the buffer.

That driver is coverage-blind, which is exactly the weakness your CI does not have. Run under ClusterFuzzLite with coverage feedback it will explore far past anything random input reaches, which is the real reason to land the target rather than the negative result above.

## Note on the softFail contract

`StreamErrorPolicy` asserts in its destructor unless the result was read, so the target ends by reading `FormatFailed()` and `ErrorPolicy().Failed()`. Without that, every input trips the assertion and the fuzzer reports a crash on the first case. Worth knowing if anyone writes the next stream-based target.

## Checks

```
$ cmake --preset fuzzing
$ cmake --build build/fuzzing --target infra.syntax_proto_parser_fuzzer
[337/343] Building CXX object infra/syntax/fuzz/CMakeFiles/infra.syntax_proto_parser_fuzzer.dir/FuzzProtoParser.cpp.o
...
ld: library 'libclang_rt.fuzzer_osx.a' not found        <- the local toolchain gap described above
```

```
$ ./protofuzz 150000 <seed>    # standalone ASan/UBSan driver, seeds 1-12
seed 1: clean
...
seed 12: clean
```

`.clusterfuzzlite/build.sh` copies each target explicitly, so the new one is added there too. I have no way to run the ClusterFuzzLite container myself, so that one line is the part I would most like a second pair of eyes on.
